### PR TITLE
EventHub metrics #2: Add config-driven experiment metrics to the EventHub

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/AppPrivacyConfiguration.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/AppPrivacyConfiguration.swift
@@ -336,7 +336,7 @@ public struct AppPrivacyConfiguration: PrivacyConfiguration {
         return subfeatureData.settings
     }
 
-    public func subfeatureSettings(for feature: PrivacyFeature) -> [SubfeatureID: PrivacyConfigurationData.PrivacyFeature.SubfeatureSettings] {
+    public func allSubfeatureSettings(for feature: PrivacyFeature) -> [SubfeatureID: PrivacyConfigurationData.PrivacyFeature.SubfeatureSettings] {
         subfeatures(for: feature).compactMapValues(\.settings)
     }
 

--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/AppPrivacyConfiguration.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/AppPrivacyConfiguration.swift
@@ -336,6 +336,10 @@ public struct AppPrivacyConfiguration: PrivacyConfiguration {
         return subfeatureData.settings
     }
 
+    public func subfeatureSettings(for feature: PrivacyFeature) -> [SubfeatureID: PrivacyConfigurationData.PrivacyFeature.SubfeatureSettings] {
+        subfeatures(for: feature).compactMapValues(\.settings)
+    }
+
     public func userEnabledProtection(forDomain domain: String) {
         let domainToRemove = locallyUnprotected.unprotectedDomains.first { unprotectedDomain in
             unprotectedDomain.punycodeEncodedHostname.lowercased() == domain

--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/PrivacyConfiguration.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/PrivacyConfiguration.swift
@@ -109,6 +109,13 @@ public protocol PrivacyConfiguration {
     /// Returns settings for a specified subfeature.
     func settings(for subfeature: any PrivacySubfeature) -> PrivacyConfigurationData.PrivacyFeature.SubfeatureSettings?
 
+    /// Returns the raw `settings` JSON of every subfeature of `feature`, keyed by subfeature ID.
+    ///
+    /// Unlike `settings(for: any PrivacySubfeature)` this needs no compile-time subfeature enum, so it
+    /// reaches subfeatures whose IDs only exist in remote config — experiment subfeatures such as
+    /// `contentScopeExperiment1` or `tdsNextExperiment007`. Subfeatures with no `settings` are omitted.
+    func subfeatureSettings(for feature: PrivacyFeature) -> [SubfeatureID: PrivacyConfigurationData.PrivacyFeature.SubfeatureSettings]
+
     /// Removes given domain from locally unprotected list.
     func userEnabledProtection(forDomain: String)
     /// Adds given domain to locally unprotected list.
@@ -142,5 +149,10 @@ public extension PrivacyConfiguration {
     func stateFor(subfeatureID: SubfeatureID, parentFeatureID: ParentFeatureID, randomizer: (Range<Double>) -> Double = Double.random(in:)) -> PrivacyConfigurationFeatureState {
         return stateFor(subfeatureID: subfeatureID, parentFeatureID: parentFeatureID, versionProvider: AppVersionProvider(), randomizer: randomizer)
     }
+
+    /// Defaulted so the many test doubles conforming to this protocol need not each implement it. It is
+    /// still a protocol requirement, so `AppPrivacyConfiguration`'s real implementation is reached
+    /// through the witness table rather than shadowed by this.
+    func subfeatureSettings(for feature: PrivacyFeature) -> [SubfeatureID: PrivacyConfigurationData.PrivacyFeature.SubfeatureSettings] { [:] }
 
 }

--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/PrivacyConfiguration.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/PrivacyConfiguration.swift
@@ -114,7 +114,7 @@ public protocol PrivacyConfiguration {
     /// Unlike `settings(for: any PrivacySubfeature)` this needs no compile-time subfeature enum, so it
     /// reaches subfeatures whose IDs only exist in remote config — experiment subfeatures such as
     /// `contentScopeExperiment1` or `tdsNextExperiment007`. Subfeatures with no `settings` are omitted.
-    func subfeatureSettings(for feature: PrivacyFeature) -> [SubfeatureID: PrivacyConfigurationData.PrivacyFeature.SubfeatureSettings]
+    func allSubfeatureSettings(for feature: PrivacyFeature) -> [SubfeatureID: PrivacyConfigurationData.PrivacyFeature.SubfeatureSettings]
 
     /// Removes given domain from locally unprotected list.
     func userEnabledProtection(forDomain: String)
@@ -149,10 +149,5 @@ public extension PrivacyConfiguration {
     func stateFor(subfeatureID: SubfeatureID, parentFeatureID: ParentFeatureID, randomizer: (Range<Double>) -> Double = Double.random(in:)) -> PrivacyConfigurationFeatureState {
         return stateFor(subfeatureID: subfeatureID, parentFeatureID: parentFeatureID, versionProvider: AppVersionProvider(), randomizer: randomizer)
     }
-
-    /// Defaulted so the many test doubles conforming to this protocol need not each implement it. It is
-    /// still a protocol requirement, so `AppPrivacyConfiguration`'s real implementation is reached
-    /// through the witness table rather than shadowed by this.
-    func subfeatureSettings(for feature: PrivacyFeature) -> [SubfeatureID: PrivacyConfigurationData.PrivacyFeature.SubfeatureSettings] { [:] }
 
 }

--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfigTestsUtils/MockPrivacyConfiguration.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfigTestsUtils/MockPrivacyConfiguration.swift
@@ -62,6 +62,10 @@ public class MockPrivacyConfiguration: PrivacyConfiguration {
         subfeatureSettings
     }
 
+    public func allSubfeatureSettings(for feature: PrivacyFeature) -> [SubfeatureID: PrivacyConfigurationData.PrivacyFeature.SubfeatureSettings] {
+        [:]
+    }
+
     public var exceptionsListClosure: (PrivacyFeature) -> [String] = { _ in [] }
     public var featureSettings: PrivacyConfigurationData.PrivacyFeature.FeatureSettings = [:]
     public var subfeatureSettings: PrivacyConfigurationData.PrivacyFeature.SubfeatureSettings?

--- a/SharedPackages/BrowserServicesKit/Tests/BrokenSitePromptTests/PrivacyConfigurationManagerMock.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/BrokenSitePromptTests/PrivacyConfigurationManagerMock.swift
@@ -89,6 +89,10 @@ class PrivacyConfigurationMock: PrivacyConfiguration {
         return nil
     }
 
+    func allSubfeatureSettings(for feature: PrivacyFeature) -> [SubfeatureID: PrivacyConfigurationData.PrivacyFeature.SubfeatureSettings] {
+        [:]
+    }
+
     var userUnprotected = Set<String>()
     func userEnabledProtection(forDomain domain: String) {
         userUnprotected.remove(domain)

--- a/SharedPackages/BrowserServicesKit/Tests/BrowserServicesKitTests/ContentBlocker/UserContentControllerTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/BrowserServicesKitTests/ContentBlocker/UserContentControllerTests.swift
@@ -344,6 +344,10 @@ class PrivacyConfigurationMock: PrivacyConfiguration {
         return nil
     }
 
+    func allSubfeatureSettings(for feature: PrivacyFeature) -> [SubfeatureID: PrivacyConfigurationData.PrivacyFeature.SubfeatureSettings] {
+        [:]
+    }
+
     var identifier: String = "abcd"
     var version: String? = "123456789"
     var userUnprotectedDomains: [String] = []

--- a/SharedPackages/BrowserServicesKit/Tests/ConfigurationTests/TrackerDataURLOverriderTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/ConfigurationTests/TrackerDataURLOverriderTests.swift
@@ -234,6 +234,10 @@ class MockPrivacyConfiguration: PrivacyConfiguration {
         return subfeatureSettings ?? mockSubfeatureSettings[subfeature.rawValue]
     }
 
+    func allSubfeatureSettings(for feature: PrivacyFeature) -> [SubfeatureID: PrivacyConfigurationData.PrivacyFeature.SubfeatureSettings] {
+        [:]
+    }
+
     func exceptionsList(forFeature featureKey: PrivacyFeature) -> [String] { exceptionsList(featureKey) }
     var isFeatureKeyEnabled: ((PrivacyFeature, AppVersionProvider) -> Bool)?
     func isEnabled(featureKey: PrivacyFeature, versionProvider: AppVersionProvider, defaultValue: Bool) -> Bool {

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/Mocks/Mocks.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/Mocks/Mocks.swift
@@ -215,6 +215,10 @@ class MockPrivacyConfiguration: PrivacyConfiguration {
         return nil
     }
 
+    func allSubfeatureSettings(for feature: PrivacyFeature) -> [SubfeatureID: PrivacyConfigurationData.PrivacyFeature.SubfeatureSettings] {
+        [:]
+    }
+
     var identifier: String = "abcd"
     var version: String? = "123456789"
     var userUnprotectedDomains: [String] = []

--- a/SharedPackages/BrowserServicesKit/Tests/MaliciousSiteProtectionTests/Mocks/PrivacyConfigurationManagerMock.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/MaliciousSiteProtectionTests/Mocks/PrivacyConfigurationManagerMock.swift
@@ -89,6 +89,10 @@ class PrivacyConfigurationMock: PrivacyConfiguration {
         return nil
     }
 
+    func allSubfeatureSettings(for feature: PrivacyFeature) -> [SubfeatureID: PrivacyConfigurationData.PrivacyFeature.SubfeatureSettings] {
+        [:]
+    }
+
     var userUnprotected = Set<String>()
     func userEnabledProtection(forDomain domain: String) {
         userUnprotected.remove(domain)

--- a/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCoreTestsUtils/Mocks.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCoreTestsUtils/Mocks.swift
@@ -261,6 +261,10 @@ public final class PrivacyConfigurationMock: PrivacyConfiguration {
         return nil
     }
 
+    public func allSubfeatureSettings(for feature: PrivacyFeature) -> [SubfeatureID: PrivacyConfigurationData.PrivacyFeature.SubfeatureSettings] {
+        [:]
+    }
+
     public func userEnabledProtection(forDomain: String) {
 
     }

--- a/SharedPackages/EventHub/Package.swift
+++ b/SharedPackages/EventHub/Package.swift
@@ -49,6 +49,9 @@ let package = Package(
             ]),
         .testTarget(
             name: "EventHubTests",
-            dependencies: ["EventHub"]),
+            dependencies: [
+                "EventHub",
+                .product(name: "PrivacyConfigTestsUtils", package: "BrowserServicesKit"),
+            ]),
     ]
 )

--- a/SharedPackages/EventHub/Package.swift
+++ b/SharedPackages/EventHub/Package.swift
@@ -45,6 +45,7 @@ let package = Package(
                 .product(name: "Common", package: "Common"),
                 .product(name: "Persistence", package: "Persistence"),
                 .product(name: "UserScript", package: "BrowserServicesKit"),
+                .product(name: "PrivacyConfig", package: "BrowserServicesKit"),
             ]),
         .testTarget(
             name: "EventHubTests",

--- a/SharedPackages/EventHub/Sources/EventHub/Config/EventHubConfig.swift
+++ b/SharedPackages/EventHub/Sources/EventHub/Config/EventHubConfig.swift
@@ -90,6 +90,35 @@ public struct TelemetryPixelConfig: Equatable, Sendable {
     public var isEnabled: Bool { state == "enabled" }
 }
 
+/// One experiment-metric conversion request — the whole of what the metrics handler hands to the
+/// Native Apps experiment framework, and the unit the cross-platform specification asserts against.
+///
+/// Flattened at parse time. Config groups a metric's conversions as `windows × thresholds`, but that
+/// product is an authoring convenience with no meaning once an event arrives (M-FAN-P1), so the parser
+/// multiplies it out once and the event-time job is left as a filter over a flat list.
+public struct MetricRequest: Equatable, Sendable {
+    /// The experiment (subfeature) ID whose `settings.metrics` declared this metric. Declaration is
+    /// attachment: a request always belongs to the declaring experiment and is never fanned out by
+    /// metric name alone, so two experiments declaring the same name stay independent (M-SEL-P1/P2).
+    public let experiment: String
+    /// The event type that triggers this metric.
+    public let event: String
+    public let metric: String
+    /// Inclusive day bounds after enrollment. Whether the user is inside the window is the experiment
+    /// framework's decision, not the hub's — the hub only reports.
+    public let windowDays: ClosedRange<Int>
+    /// Occurrence count at which the framework converts.
+    public let threshold: Int
+
+    public init(experiment: String, event: String, metric: String, windowDays: ClosedRange<Int>, threshold: Int) {
+        self.experiment = experiment
+        self.event = event
+        self.metric = metric
+        self.windowDays = windowDays
+        self.threshold = threshold
+    }
+}
+
 /// Runtime state for a single parameter within a pixel's active period.
 public struct ParamState: Codable, Equatable, Sendable {
     public var value: Int

--- a/SharedPackages/EventHub/Sources/EventHub/Config/EventHubConfigParser.swift
+++ b/SharedPackages/EventHub/Sources/EventHub/Config/EventHubConfigParser.swift
@@ -55,6 +55,60 @@ public final class EventHubConfigParser {
         }
     }
 
+    /// Parses the `metrics` map out of one experiment subfeature's raw `settings` JSON, returning the
+    /// flattened conversion requests it declares. Malformed or invalid input yields an empty list and
+    /// never throws, as with `parseTelemetry`.
+    ///
+    /// Metrics live in the settings of CSS and TDS experiment subfeatures rather than in the `eventHub`
+    /// feature, so — unlike `parseTelemetry`, which is handed the dictionary remote config already
+    /// holds — this takes the raw JSON string, which is how `PrivacyConfigurationData` carries
+    /// subfeature settings.
+    ///
+    /// One bad metric is isolated rather than fatal: its siblings in the same experiment still parse.
+    public func parseMetrics(experiment: String, settingsJSON: String) -> [MetricRequest] {
+        guard let data = settingsJSON.data(using: .utf8) else { return [] }
+        let settings: SubfeatureSettingsDTO
+        do {
+            settings = try JSONDecoder().decode(SubfeatureSettingsDTO.self, from: data)
+        } catch {
+            Logger.eventHub.error("config: experiment \(experiment, privacy: .public) settings could not be decoded, no metrics configured: \(error.localizedDescription, privacy: .public)")
+            return []
+        }
+        // An absent `metrics` key is the normal case — the key is optional and most experiments declare
+        // none — so it must stay distinguishable from the decode failure above.
+        guard let metrics = settings.metrics else { return [] }
+        return metrics.flatMap { name, dto in
+            Self.toRequests(experiment: experiment, metric: name, dto)
+        }
+    }
+
+    private static func toRequests(experiment: String, metric: String, _ dto: MetricDTO) -> [MetricRequest] {
+        guard let event = dto.event, !event.isEmpty else {
+            Logger.eventHub.error("config: metric \(experiment, privacy: .public)/\(metric, privacy: .public) skipped, missing event")
+            return []
+        }
+        var requests: [MetricRequest] = []
+        for conversion in dto.conversions ?? [] {
+            for window in conversion.windows ?? [] {
+                // The one guard that has to exist: `ClosedRange` traps on an inverted range. Negative
+                // day bounds are meaningless, and a threshold below 1 would have the framework convert
+                // on every occurrence — a config typo would become pixel spam. Config validation
+                // rejects all three upstream (remote-config repo tests, so out of specification
+                // scope); this is defence, and it drops only the offending window or threshold.
+                guard window.count == 2, let low = window.first, let high = window.last,
+                      low >= 0, low <= high else {
+                    Logger.eventHub.error("config: metric \(experiment, privacy: .public)/\(metric, privacy: .public) dropped a conversion window that was not an ordered, non-negative pair")
+                    continue
+                }
+                for threshold in conversion.thresholds ?? [] where threshold >= 1 {
+                    requests.append(MetricRequest(experiment: experiment, event: event, metric: metric,
+                                                  windowDays: low...high, threshold: threshold))
+                }
+            }
+        }
+        return requests
+    }
+
     /// Parses a single serialised pixel config (as produced by `serializePixelConfig`), returning `nil`
     /// if it is malformed or invalid.
     public func parseSinglePixelConfig(name: String, json: String) -> TelemetryPixelConfig? {
@@ -165,6 +219,25 @@ public final class EventHubConfigParser {
         let state: String?
         let trigger: TriggerDTO?
         let parameters: [String: ParameterDTO]?
+    }
+
+    /// An experiment subfeature's `settings`, of which only the optional `metrics` map concerns us —
+    /// TDS experiments also carry `controlUrl`/`treatmentUrl` there, which decode away harmlessly.
+    private struct SubfeatureSettingsDTO: Codable {
+        let metrics: [String: MetricDTO]?
+    }
+
+    /// Every field optional so one malformed metric is skipped with its siblings intact; a
+    /// non-optional field would fail the whole `settings` decode instead.
+    private struct MetricDTO: Codable {
+        let event: String?
+        let conversions: [ConversionDTO]?
+    }
+
+    private struct ConversionDTO: Codable {
+        /// `[[low, high], …]` — inclusive day bounds, which may freely overlap.
+        let windows: [[Int]]?
+        let thresholds: [Int]?
     }
 
     private struct TriggerDTO: Codable {

--- a/SharedPackages/EventHub/Sources/EventHub/Core/EventHub.swift
+++ b/SharedPackages/EventHub/Sources/EventHub/Core/EventHub.swift
@@ -31,15 +31,13 @@ public protocol EventHubManaging: AnyObject {
     /// repeat reaches no handler, a first occurrence reaches every handler. See `DedupStore`.
     func handleWebEvent(_ webEventData: [String: Any], tabID: EventHubTabID)
 
-    /// Fires any enabled immediate-trigger telemetry whose `trigger.source` equals `type`. For
-    /// browser-native events (not content-scope-scripts): there is no tab context, so no page to
-    /// de-duplicate against, and every call is a genuine occurrence.
-    func handleImmediateEvent(_ type: String, data: Encodable?)
-
-    /// Counts a browser-native event toward any enabled period/aggregated telemetry whose parameter
-    /// `source` equals `type`. Like `handleImmediateEvent`, and unlike web events, this never passes
-    /// through de-duplication: each call is a genuine occurrence.
-    func handleAggregatedEvent(_ type: String, data: Encodable?)
+    /// Processes a browser-native event (not content-scope-scripts): fires matching immediate
+    /// telemetry, counts it toward matching period telemetry, and reports any experiment metrics bound
+    /// to it — the same fan-out a web event gets.
+    ///
+    /// There is no tab context, so no page to de-duplicate against, and every call is a genuine
+    /// occurrence delivered to every handler. See `DedupStore`.
+    func handleNativeEvent(_ type: String, data: Encodable?)
 
     /// Signals that the given tab has navigated to `url` (clears per-tab dedup on URL change).
     func onNavigationStarted(tabID: EventHubTabID, url: String)
@@ -58,8 +56,7 @@ public protocol EventHubManaging: AnyObject {
 }
 
 public extension EventHubManaging {
-    func handleImmediateEvent(_ type: String) { handleImmediateEvent(type, data: nil) }
-    func handleAggregatedEvent(_ type: String) { handleAggregatedEvent(type, data: nil) }
+    func handleNativeEvent(_ type: String) { handleNativeEvent(type, data: nil) }
 }
 
 /// Real `EventHubManaging` implementation. All mutable state is confined to one serial `DispatchQueue`
@@ -71,8 +68,8 @@ public extension EventHubManaging {
 /// back into EventHub merely enqueues instead of deadlocking.
 ///
 /// Because the body runs later, anything that must be sampled at the moment of the *call* is captured
-/// before dispatching — see `nowMillis` in `handleWebEvent`/`handleAggregatedEvent`, and the payload
-/// encoding in `handleImmediateEvent`.
+/// before dispatching — see `nowMillis` in `handleWebEvent`/`handleNativeEvent`, and the payload
+/// encoding in `handleNativeEvent`.
 ///
 /// The four remaining uses of `queue.sync` are deliberate. None can deadlock: none is reachable from
 /// inside the queue, and a serial queue is FIFO, so a `sync` enqueued after the caller's own `async`
@@ -90,6 +87,7 @@ public final class EventHub: EventHubManaging {
     private let parser: EventHubConfigParser
     private let scheduler: EventHubScheduler
     private let pixelFiring: EventHubPixelFiring
+    private let conversionReporting: EventHubConversionReporting?
     private let queue: DispatchQueue
 
     private var telemetries: [String: Telemetry] = [:]
@@ -99,6 +97,10 @@ public final class EventHub: EventHubManaging {
     /// and hub-lifetime, so it outlives the `Telemetry` objects a period rollover replaces — dedup is
     /// page-scoped, not period-scoped. See `DedupStore`.
     private let dedupStore = DedupStore()
+    /// Every conversion request every experiment currently declares, flat and already multiplied out.
+    /// Rebuilt wholesale from config, like `latestConfigs`, and deliberately never persisted: it is a
+    /// derived view of remote config, so storing it would only duplicate what config already holds.
+    private var metricRequests: [MetricRequest] = []
     private var latestConfigs: [TelemetryPixelConfig] = []
     private var latestEnabled = false
     private var isForeground = false
@@ -131,12 +133,15 @@ public final class EventHub: EventHubManaging {
         settings: EventHubSettingsProviding,
         scheduler: EventHubScheduler,
         pixelFiring: EventHubPixelFiring,
+        conversionReporting: EventHubConversionReporting? = nil,
+        experimentSettings: AnyPublisher<[String: String], Never> = Just([:]).eraseToAnyPublisher(),
         queue: DispatchQueue = DispatchQueue(label: "com.duckduckgo.eventhub")
     ) {
         self.store = store
         self.parser = parser
         self.scheduler = scheduler
         self.pixelFiring = pixelFiring
+        self.conversionReporting = conversionReporting
         self.queue = queue
 
         // Both subscriptions re-apply the config themselves, so any change in enablement *or* in the
@@ -160,6 +165,26 @@ public final class EventHub: EventHubManaging {
                     self.latestConfigs = settings.map { self.parser.parseTelemetry($0) } ?? []
                     Logger.eventHub.info("parsed \(self.latestConfigs.count, privacy: .public) telemetry config(s) from settings")
                     if self.hasConsumedInitialSettings { self.applyConfigLocked() }
+                }
+            }
+            .store(in: &subscriptions)
+        // Deliberately its own parameter rather than a third member of `EventHubSettingsProviding`:
+        // that protocol means "feature enablement plus the telemetry settings, consent-stripped", and
+        // metrics are neither. They live in the settings of the CSS and TDS experiment subfeatures, and
+        // a conversion request carries no event payload — only experiment, metric, window and
+        // threshold — so there is nothing in one for a consent gate to strip.
+        //
+        // Unlike the two above this needs no `hasConsumedInitialSettings` gate: the registry is
+        // in-memory and derived, so a transient empty value during launch costs nothing and cannot wipe
+        // persisted state the way a transient `enabled == false` could.
+        experimentSettings
+            .sink { [weak self] settingsByExperiment in
+                guard let self else { return }
+                queue.async {
+                    self.metricRequests = settingsByExperiment.flatMap { experiment, json in
+                        self.parser.parseMetrics(experiment: experiment, settingsJSON: json)
+                    }
+                    Logger.eventHub.info("parsed \(self.metricRequests.count, privacy: .public) metric conversion request(s) from \(settingsByExperiment.count, privacy: .public) experiment(s)")
                 }
             }
             .store(in: &subscriptions)
@@ -195,39 +220,38 @@ public final class EventHub: EventHubManaging {
                 Logger.eventHub.debug("[EventHub] \(type, privacy: .private) dropped, already seen on this tab's current page")
                 return
             }
-            fireImmediateLocked(source: type, data: data)
-            countPeriodLocked(source: type, data: data, nowMillis: nowMillis)
+            deliverLocked(type: type, data: data, nowMillis: nowMillis)
         }
     }
 
-    public func handleImmediateEvent(_ type: String, data: Encodable?) {
+    /// The single delivery point: one event reaches every handler, exactly once. Web events get here
+    /// only after the de-duplication gate in `handleWebEvent`; native events, having no page to
+    /// de-duplicate against, get here directly. That gate is the *only* difference between the two
+    /// paths, which is precisely what the specification says it is — so the handler list lives here
+    /// once rather than being repeated per entry point.
+    private func deliverLocked(type: String, data: [String: Any]?, nowMillis: Int64) {
+        fireImmediateLocked(source: type, data: data)
+        countPeriodLocked(source: type, data: data, nowMillis: nowMillis)
+        reportMetricsLocked(source: type)
+    }
+
+    public func handleNativeEvent(_ type: String, data: Encodable?) {
         guard !type.isEmpty else { return }
+        Logger.eventHub.debug("[EventHub] native event received: \(type, privacy: .public)")
         // Encoded here, not in the block: `data` is a caller-owned `Encodable` that may be a reference
         // type, and the caller is free to mutate it the moment this returns. The cost is encoding a
-        // payload that a disabled feature then discards — native immediate events are rare enough that
-        // this is cheaper than the alternatives for reading `latestEnabled` off-queue.
-        Logger.eventHub.debug("[EventHub] native immediate event received: \(type, privacy: .public)")
+        // payload that a disabled feature then discards — native events are rare enough that this is
+        // cheaper than the alternatives for reading `latestEnabled` off-queue.
         let encoded = Self.encode(data)
-        queue.async { [self] in
-            guard latestEnabled else {
-                Logger.eventHub.debug("[EventHub] \(type, privacy: .public) dropped, the eventHub feature is disabled")
-                return
-            }
-            fireImmediateLocked(source: type, data: encoded)
-        }
-    }
-
-    public func handleAggregatedEvent(_ type: String, data: Encodable?) {
-        guard !type.isEmpty else { return }
-        Logger.eventHub.debug("[EventHub] native aggregated event received: \(type, privacy: .public)")
-        let encoded = Self.encode(data)
+        // Sampled here for the same reason as in `handleWebEvent`: `now` decides whether the event
+        // still belongs to the running period, so it has to be the arrival time.
         let nowMillis = scheduler.nowMillis()
         queue.async { [self] in
             guard latestEnabled else {
                 Logger.eventHub.debug("[EventHub] \(type, privacy: .public) dropped, the eventHub feature is disabled")
                 return
             }
-            countPeriodLocked(source: type, data: encoded, nowMillis: nowMillis)
+            deliverLocked(type: type, data: encoded, nowMillis: nowMillis)
         }
     }
 
@@ -291,6 +315,33 @@ public final class EventHub: EventHubManaging {
             : outcomes.joined(separator: "; ")
         Logger.eventHub.debug("[EventHub] period routing for \(source, privacy: .private) → \(summary, privacy: .public)")
         rearmSchedulerLocked()
+    }
+
+    /// Reports one conversion request per (experiment, metric, window, threshold) that names this event
+    /// type. Stateless by design: no counting, no window arithmetic, no enrollment check, nothing
+    /// persisted — the experiment framework owns all of that, and no-ops a request for an experiment
+    /// the user is not enrolled in.
+    ///
+    /// A linear scan because `metricRequests` is already flat and tiny (the whole cross-platform
+    /// reference fixture, ten experiments, is fifteen requests). If that ever stops holding, grouping
+    /// it by event type is a one-line change.
+    private func reportMetricsLocked(source: String) {
+        guard let conversionReporting else { return }
+        var reported: [String] = []
+        for request in metricRequests where request.event == source {
+            conversionReporting.reportConversion(experiment: request.experiment,
+                                                 metric: request.metric,
+                                                 windowDays: request.windowDays,
+                                                 threshold: request.threshold)
+            reported.append("\(request.experiment)/\(request.metric) \(request.windowDays.lowerBound)-\(request.windowDays.upperBound)×\(request.threshold)")
+        }
+        // One line per event, as with the period routing above, so "the metric never converted" can be
+        // answered from a single entry: whether anything was declared for this event, and what was
+        // handed to the framework if so.
+        let summary = reported.isEmpty
+            ? "no metric is declared for it (\(metricRequests.count) request(s) loaded)"
+            : reported.joined(separator: "; ")
+        Logger.eventHub.debug("[EventHub] metric routing for \(source, privacy: .private) → \(summary, privacy: .public)")
     }
 
     public func onConfigChanged() {

--- a/SharedPackages/EventHub/Sources/EventHub/Core/Parameter.swift
+++ b/SharedPackages/EventHub/Sources/EventHub/Core/Parameter.swift
@@ -78,15 +78,13 @@ final class CounterParameter: Parameter {
     func queryValue() -> String? { BucketCounter.bucketCount(value, buckets: buckets) }
 }
 
-/// Carries a value forwarded from an event payload, as compact JSON.
+/// Carries a value forwarded from an event payload, as compact JSON (`overlay` → `"overlay"`,
+/// `{"a": true}` → `{"a":true}`).
 ///
-/// The value is **not** percent-encoded here: it leaves as compact JSON (`overlay` → `"overlay"`,
-/// `{"a": true}` → `{"a":true}`) and the pixel transport applies the single encoding the wire needs.
-/// This parameter used to encode as well, which double-encoded every value — `%` is absent from
-/// `CharacterSet.urlQueryParameterAllowed`, so both transports re-escaped the escapes and `"overlay"`
-/// arrived as `%2522overlay%2522`, which one decode does not recover. Encoding is the transport's job
-/// on both platforms: `URL.appendingParameters` → `URLQueryItem(percentEncodingName:)` on macOS,
-/// `APIRequestV2`'s `URLComponents.queryItems` on iOS.
+/// Percent-encoding belongs to the pixel transport, not here — `URL.appendingParameters` →
+/// `URLQueryItem(percentEncodingName:)` on macOS, `APIRequestV2`'s `URLComponents.queryItems` on iOS.
+/// Both encode with an allowed set that excludes `%`, so any escaping applied to the value here would
+/// be escaped again and the endpoint would need two decodes to reach the payload.
 final class DataParameter: Parameter {
     private let dataKey: String?
     private var lastValue: String?

--- a/SharedPackages/EventHub/Sources/EventHub/Core/Parameter.swift
+++ b/SharedPackages/EventHub/Sources/EventHub/Core/Parameter.swift
@@ -78,15 +78,16 @@ final class CounterParameter: Parameter {
     func queryValue() -> String? { BucketCounter.bucketCount(value, buckets: buckets) }
 }
 
+/// Carries a value forwarded from an event payload, as compact JSON.
+///
+/// The value is **not** percent-encoded here: it leaves as compact JSON (`overlay` → `"overlay"`,
+/// `{"a": true}` → `{"a":true}`) and the pixel transport applies the single encoding the wire needs.
+/// This parameter used to encode as well, which double-encoded every value — `%` is absent from
+/// `CharacterSet.urlQueryParameterAllowed`, so both transports re-escaped the escapes and `"overlay"`
+/// arrived as `%2522overlay%2522`, which one decode does not recover. Encoding is the transport's job
+/// on both platforms: `URL.appendingParameters` → `URLQueryItem(percentEncodingName:)` on macOS,
+/// `APIRequestV2`'s `URLComponents.queryItems` on iOS.
 final class DataParameter: Parameter {
-    /// RFC 3986 "unreserved" characters (alphanumerics plus `-._~`) are left unescaped; everything
-    /// else — including `"`, `{`, `}`, `:`, and space — is percent-encoded. This matches the
-    /// compact-JSON-then-percent-encode format the ported `EventHubDataParameterTests` expect once
-    /// `DataParameter` is wired into `EventHub` (e.g. `"logged-in"` → `%22logged-in%22`,
-    /// `{"a": true}` → `%7B%22a%22%3Atrue%7D`). `CharacterSet.alphanumerics` alone is not enough: it
-    /// excludes `-`, which would wrongly turn `logged-in` into `logged%2Din`.
-    private static let unreservedCharacters = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-._~"))
-
     private let dataKey: String?
     private var lastValue: String?
 
@@ -107,9 +108,8 @@ final class DataParameter: Parameter {
             Logger.eventHub.error("data parameter for key \(dataKey, privacy: .public) is not JSON-serialisable, value dropped")
             return clear()
         }
-        let encodedValue = compact.addingPercentEncoding(withAllowedCharacters: Self.unreservedCharacters)
-        guard lastValue != encodedValue else { return false }
-        lastValue = encodedValue
+        guard lastValue != compact else { return false }
+        lastValue = compact
         return true
     }
 

--- a/SharedPackages/EventHub/Sources/EventHub/Wiring/EventHubConversionReporting.swift
+++ b/SharedPackages/EventHub/Sources/EventHub/Wiring/EventHubConversionReporting.swift
@@ -1,0 +1,31 @@
+//
+//  EventHubConversionReporting.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+/// The seam through which EventHub hands experiment-metric conversion requests to the Native Apps
+/// experiment framework, mirroring `EventHubPixelFiring` for telemetry.
+///
+/// Everything past this call belongs to the framework: it resolves enrollment and cohort, decides
+/// window containment, accumulates occurrences against the threshold, suppresses repeats and fires the
+/// pixel. The hub's metrics handler is deliberately stateless — no counting, no window arithmetic, no
+/// enrollment check, nothing persisted — so a request for an experiment the user is not enrolled in is
+/// a no-op rather than something the hub has to filter.
+public protocol EventHubConversionReporting {
+    func reportConversion(experiment: String, metric: String, windowDays: ClosedRange<Int>, threshold: Int)
+}

--- a/SharedPackages/EventHub/Sources/EventHub/Wiring/EventHubExperimentSettings.swift
+++ b/SharedPackages/EventHub/Sources/EventHub/Wiring/EventHubExperimentSettings.swift
@@ -1,0 +1,46 @@
+//
+//  EventHubExperimentSettings.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import PrivacyConfig
+
+/// Reads the experiment subfeature settings that `EventHub`'s metrics registry is built from.
+///
+/// Shared by both platform integrations rather than duplicated in each: which parent features are read
+/// is a correctness-relevant list, and iOS and macOS silently disagreeing about it would mean metrics
+/// attaching under one parent and not the other.
+public enum EventHubExperimentSettings {
+
+    /// The parent features whose subfeatures may declare `settings.metrics`: Content Scope Scripts
+    /// experiments and — on Apple and the extension, where TDS experiments live under content
+    /// blocking rather than Android's `blockList` — TDS experiments. Both are read, so a metric
+    /// attaches under either parent (M-SEL-8).
+    public static let parentFeatures: [PrivacyFeature] = [.contentScopeExperiments, .contentBlocking]
+
+    /// The raw `settings` JSON of every experiment subfeature that may declare metrics, keyed by
+    /// subfeature ID — the shape `EventHub`'s `experimentSettings` publisher expects.
+    ///
+    /// Subfeature IDs are unique across the two parents in practice; on a collision the first parent
+    /// listed wins, which is arbitrary but harmless — nothing depends on which parent a metric came
+    /// from once it is parsed, since a conversion request names only the subfeature.
+    public static func current(_ config: PrivacyConfiguration) -> [String: String] {
+        parentFeatures.reduce(into: [:]) { result, feature in
+            result.merge(config.subfeatureSettings(for: feature)) { existing, _ in existing }
+        }
+    }
+}

--- a/SharedPackages/EventHub/Sources/EventHub/Wiring/EventHubExperimentSettings.swift
+++ b/SharedPackages/EventHub/Sources/EventHub/Wiring/EventHubExperimentSettings.swift
@@ -40,7 +40,7 @@ public enum EventHubExperimentSettings {
     /// from once it is parsed, since a conversion request names only the subfeature.
     public static func current(_ config: PrivacyConfiguration) -> [String: String] {
         parentFeatures.reduce(into: [:]) { result, feature in
-            result.merge(config.subfeatureSettings(for: feature)) { existing, _ in existing }
+            result.merge(config.allSubfeatureSettings(for: feature)) { existing, _ in existing }
         }
     }
 }

--- a/SharedPackages/EventHub/Sources/EventHubTests/Spec/DeduplicationSpecTests.swift
+++ b/SharedPackages/EventHub/Sources/EventHubTests/Spec/DeduplicationSpecTests.swift
@@ -24,6 +24,13 @@ import Foundation
 /// (`docs/event-hub/tests/deduplication.md` in `duckduckgo/ddg-workflow`). Each case ID from that
 /// document leads the test name so coverage is greppable and a failure names the spec case.
 ///
+/// **Complete case roster.** Every ID the document defines appears below, so this file can be diffed
+/// against the document in one place:
+///
+/// - One decision before fan-out — D-DEL-1, D-DEL-2, D-DEL-3, D-DEL-4, D-DEL-5, D-DEL-6
+/// - Navigation resets the page — D-NAV-1, D-NAV-2, D-NAV-3, D-NAV-4
+/// - Native events are exempt — D-NAT-1
+///
 /// The properties the cases evidence:
 /// - **D-DEL-P1** — for every web event the hub makes exactly one de-duplication decision at
 ///   ingestion, keyed `(event type, event data, tab)` against the tab's current page, before any

--- a/SharedPackages/EventHub/Sources/EventHubTests/Spec/MetricsSpecTests.swift
+++ b/SharedPackages/EventHub/Sources/EventHubTests/Spec/MetricsSpecTests.swift
@@ -1,0 +1,391 @@
+//
+//  MetricsSpecTests.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+import Testing
+import Foundation
+@testable import EventHub
+
+/// Apple's coverage of the cross-platform experiment-metrics specification
+/// (`docs/event-hub/tests/metrics.md` in `duckduckgo/ddg-workflow`).
+///
+/// **Complete case roster.** Every ID the document defines appears below, so this file can be diffed
+/// against the document in one place:
+///
+/// - Binding — M-SEL-1, M-SEL-2, M-SEL-3, M-SEL-4, M-SEL-5, M-SEL-6, M-SEL-7, M-SEL-8, M-SEL-9,
+///   M-SEL-10
+/// - Fan-out — M-FAN-1
+/// - Web-event de-duplication — M-DED-1
+/// - Configuration lifecycle — M-LIF-1, M-LIF-2, M-LIF-3, M-LIF-4, M-LIF-5, M-LIF-6
+///
+/// The properties they evidence:
+/// - **M-SEL-P1/P2** — declaration is attachment. Requests are produced per (experiment, metric), so
+///   two experiments declaring the same metric name stay independent and neither borrows the other's
+///   event.
+/// - **M-FAN-P1** — within a conversion group `windows × thresholds` form a product; a metric's request
+///   set is the union of its groups' products. Apple's framework API takes one window and one threshold
+///   per call, so the fan-out is asserted here directly rather than at an absorbing seam.
+/// - **M-DED-P1** — metrics consume the hub's de-duplicated stream, the decision being taken once
+///   before fan-out.
+/// - **M-LIF-P1** — declarations are read live, per event, from current config.
+/// - **M-LIF-P2** — events reach metrics only through the hub, so disabling `eventHub` stops them.
+///
+/// The assertion boundary is the conversion request — `(experiment, metric, conversionWindowDays,
+/// threshold)` — observed just past the experiment framework's enrollment gate. See
+/// `SpyConversionReporting` for why that is the honest seam on Apple.
+@Suite("Spec: experiment metrics")
+struct MetricsSpecTests {
+
+    // MARK: The specification's fixture
+
+    /// `contentScopeExperiment1`, the experiment most cases use: four metrics, one of them on a native
+    /// event, and `searchLike` carrying two conversion groups so the fan-out is observable.
+    static let experiment1 = """
+    { "metrics": {
+        "captchaSeen": { "event": "captchaDetected", "conversions": [
+            { "windows": [[0, 7]], "thresholds": [1, 3] } ] },
+        "searchLike": { "event": "searchPerformed", "conversions": [
+            { "windows": [[0, 0], [1, 1]], "thresholds": [1] },
+            { "windows": [[0, 7]], "thresholds": [2, 3] } ] },
+        "pageLoad": { "event": "pageLoaded", "conversions": [
+            { "windows": [[0, 5]], "thresholds": [1] } ] },
+        "appLaunched": { "event": "appLaunch", "conversions": [
+            { "windows": [[0, 7]], "thresholds": [1, 2] } ] }
+    } }
+    """
+
+    /// Two windows in one group, both at threshold 1.
+    static let experiment3 = """
+    { "metrics": { "reloadLoop": { "event": "reloadLoopDetected", "conversions": [
+        { "windows": [[0, 0], [0, 7]], "thresholds": [1] } ] } } }
+    """
+
+    /// Declares `captchaSeen` on the same event as experiment 1, at a different threshold set.
+    static let experiment10 = """
+    { "metrics": { "captchaSeen": { "event": "captchaDetected", "conversions": [
+        { "windows": [[0, 7]], "thresholds": [1] } ] } } }
+    """
+
+    /// An enrolled experiment declaring no metrics at all.
+    static let experiment19 = "{}"
+
+    /// Declares `captchaSeen` — the same *name* as experiments 1 and 10 — bound to a different event.
+    static let experiment21 = """
+    { "metrics": { "captchaSeen": { "event": "reloadLoopDetected", "conversions": [
+        { "windows": [[0, 7]], "thresholds": [1] } ] } } }
+    """
+
+    /// A TDS experiment, under the other parent feature. Its `settings` also carry the control and
+    /// treatment URLs a real TDS experiment has, which must decode away without disturbing `metrics`.
+    static let tdsExperiment007 = """
+    { "controlUrl": "v5/experiments/control.json",
+      "treatmentUrl": "v5/experiments/treatment.json",
+      "metrics": {
+        "blocklistFailure": { "event": "tdsDownloadFailed", "conversions": [
+            { "windows": [[0, 7]], "thresholds": [1] } ] },
+        "pageLoad": { "event": "pageLoaded", "conversions": [
+            { "windows": [[0, 5]], "thresholds": [1] } ] }
+    } }
+    """
+
+    static let reference: [String: String] = [
+        "contentScopeExperiment1": experiment1,
+        "contentScopeExperiment3": experiment3,
+        "contentScopeExperiment10": experiment10,
+        "contentScopeExperiment19": experiment19,
+        "contentScopeExperiment21": experiment21,
+        "tdsNextExperiment007": tdsExperiment007,
+    ]
+
+    /// The fixture with a given experiment's settings replaced — how the lifecycle cases apply a config
+    /// that has dropped a metric.
+    static func reference(_ experiment: String, replacedWith settings: String) -> [String: String] {
+        var config = reference
+        config[experiment] = settings
+        return config
+    }
+
+    /// Experiment 1 with `captchaSeen` removed and its other three metrics untouched (M-LIF-2).
+    static let experiment1WithoutCaptchaSeen = """
+    { "metrics": {
+        "searchLike": { "event": "searchPerformed", "conversions": [
+            { "windows": [[0, 0], [1, 1]], "thresholds": [1] },
+            { "windows": [[0, 7]], "thresholds": [2, 3] } ] },
+        "pageLoad": { "event": "pageLoaded", "conversions": [
+            { "windows": [[0, 5]], "thresholds": [1] } ] },
+        "appLaunched": { "event": "appLaunch", "conversions": [
+            { "windows": [[0, 7]], "thresholds": [1, 2] } ] }
+    } }
+    """
+
+    /// The metrics suite configures no telemetry: it asserts conversion requests, not pixels.
+    private static func fixture(enrolled: Set<String>, experiments: [String: String] = reference) -> SpecFixture {
+        SpecFixture("{}", experiments: experiments, enrolled: enrolled)
+    }
+
+    // MARK: Binding — metrics attach to the experiment that declares them
+
+    @Test("M-SEL-1: each experiment declaring a metric requests it")
+    func eachExperimentDeclaringAMetricRequestsIt() {
+        // Experiments 1 and 10 bind `captchaSeen` to the same event, at different threshold sets.
+        let f = Self.fixture(enrolled: ["contentScopeExperiment1", "contentScopeExperiment10"])
+        f.send("captchaDetected", reason: "any", on: f.openPage())
+
+        #expect(f.requested == [
+            "contentScopeExperiment1/captchaSeen/0-7/1",
+            "contentScopeExperiment1/captchaSeen/0-7/3",
+            "contentScopeExperiment10/captchaSeen/0-7/1",
+        ])
+    }
+
+    @Test("M-SEL-2: only the declaring experiment requests")
+    func onlyTheDeclaringExperimentRequests() {
+        let f = Self.fixture(enrolled: ["contentScopeExperiment1", "contentScopeExperiment3"])
+        f.send("reloadLoopDetected", reason: "any", on: f.openPage())
+
+        #expect(f.requested == [
+            "contentScopeExperiment3/reloadLoop/0-7/1",
+            "contentScopeExperiment3/reloadLoop/0/1",
+        ])
+    }
+
+    @Test("M-SEL-3: a shared metric name bound to different events requests per experiment")
+    func aSharedMetricNameBoundToDifferentEventsRequestsPerExperiment() {
+        // `captchaSeen` is bound to `captchaDetected` in experiment 1 but to `reloadLoopDetected` in
+        // experiment 21, so this event reaches 21's copy of the name and not 1's.
+        let f = Self.fixture(enrolled: ["contentScopeExperiment1", "contentScopeExperiment3", "contentScopeExperiment21"])
+        f.send("reloadLoopDetected", reason: "any", on: f.openPage())
+
+        #expect(f.requested == [
+            "contentScopeExperiment21/captchaSeen/0-7/1",
+            "contentScopeExperiment3/reloadLoop/0-7/1",
+            "contentScopeExperiment3/reloadLoop/0/1",
+        ])
+    }
+
+    @Test("M-SEL-4: the event named by another experiment's identically-named metric requests nothing here")
+    func theEventNamedByAnotherExperimentsIdenticallyNamedMetricRequestsNothingHere() {
+        // The mirror of M-SEL-3: experiment 21's `captchaSeen` does not answer to `captchaDetected`.
+        let f = Self.fixture(enrolled: ["contentScopeExperiment1", "contentScopeExperiment21"])
+        f.send("captchaDetected", reason: "any", on: f.openPage())
+
+        #expect(f.requested == [
+            "contentScopeExperiment1/captchaSeen/0-7/1",
+            "contentScopeExperiment1/captchaSeen/0-7/3",
+        ])
+    }
+
+    @Test("M-SEL-5: an enrolled experiment declaring no metrics requests nothing")
+    func anEnrolledExperimentDeclaringNoMetricsRequestsNothing() {
+        let f = Self.fixture(enrolled: ["contentScopeExperiment19"])
+        let page = f.openPage()
+        f.send("reloadLoopDetected", reason: "any", on: page)
+        f.send("captchaDetected", reason: "any", on: page)
+
+        #expect(f.requested.isEmpty)
+    }
+
+    @Test("M-SEL-6: a declared metric whose experiment is not enrolled requests nothing")
+    func aDeclaredMetricWhoseExperimentIsNotEnrolledRequestsNothing() {
+        // `tdsDownloadFailed` is declared only by tdsNextExperiment007, which the user is not in.
+        let f = Self.fixture(enrolled: ["contentScopeExperiment1"])
+        f.send("tdsDownloadFailed", reason: "any", on: f.openPage())
+
+        #expect(f.requested.isEmpty)
+    }
+
+    @Test("M-SEL-7: a user enrolled in no experiments requests nothing")
+    func aUserEnrolledInNoExperimentsRequestsNothing() {
+        let f = Self.fixture(enrolled: [])
+        let page = f.openPage()
+        f.send("captchaDetected", reason: "any", on: page)
+        f.send("reloadLoopDetected", reason: "any", on: page)
+        f.send("searchPerformed", reason: "any", on: page)
+        f.sendNative("appLaunch", payload: ["launchType": "cold"])
+
+        #expect(f.requested.isEmpty)
+    }
+
+    @Test("M-SEL-8: metrics attach under both experiment parent features")
+    func metricsAttachUnderBothExperimentParentFeatures() {
+        // contentScopeExperiment1 sits under `contentScopeExperiments`, tdsNextExperiment007 under
+        // `contentBlocking`. Both parents are read, so both experiments' `pageLoad` is requested.
+        let f = Self.fixture(enrolled: ["contentScopeExperiment1", "tdsNextExperiment007"])
+        f.send("pageLoaded", reason: "any", on: f.openPage())
+
+        #expect(f.requested == [
+            "contentScopeExperiment1/pageLoad/0-5/1",
+            "tdsNextExperiment007/pageLoad/0-5/1",
+        ])
+    }
+
+    @Test("M-SEL-9: an event matching no declared metric is ignored")
+    func anEventMatchingNoDeclaredMetricIsIgnored() {
+        let f = Self.fixture(enrolled: ["contentScopeExperiment1"])
+        f.send("somethingUnrelated", reason: "any", on: f.openPage())
+
+        #expect(f.requested.isEmpty)
+    }
+
+    @Test("M-SEL-10: a native event with no tab context produces requests")
+    func aNativeEventWithNoTabContextProducesRequests() {
+        let f = Self.fixture(enrolled: ["contentScopeExperiment1"])
+        f.sendNative("appLaunch", payload: ["launchType": "cold"])
+
+        #expect(f.requested == [
+            "contentScopeExperiment1/appLaunched/0-7/1",
+            "contentScopeExperiment1/appLaunched/0-7/2",
+        ])
+    }
+
+    // MARK: Fan-out — a declaration is a set of requests
+
+    @Test("M-FAN-1: windows and thresholds multiply out within a group; groups do not combine")
+    func windowsAndThresholdsMultiplyOutWithinAGroupAndGroupsDoNotCombine() {
+        // `searchLike` group 1 is [0,0] and [1,1] at threshold 1; group 2 is [0,7] at thresholds 2 and
+        // 3. Four requests, not the six a cross-group product would give.
+        let f = Self.fixture(enrolled: ["contentScopeExperiment1"])
+        f.send("searchPerformed", reason: "any", on: f.openPage())
+
+        #expect(f.requested == [
+            "contentScopeExperiment1/searchLike/0-7/2",
+            "contentScopeExperiment1/searchLike/0-7/3",
+            "contentScopeExperiment1/searchLike/0/1",
+            "contentScopeExperiment1/searchLike/1/1",
+        ])
+    }
+
+    // MARK: Web-event de-duplication
+
+    @Test("M-DED-1: repeated occurrences on one page request once")
+    func repeatedOccurrencesOnOnePageRequestOnce() {
+        // The metrics leg of D-DEL-4: the hub takes one decision before fan-out, so the second and
+        // third occurrences reach no handler at all.
+        let f = Self.fixture(enrolled: ["contentScopeExperiment1"])
+        let page = f.openPage()
+        f.send("captchaDetected", reason: "overlay", on: page)
+        f.send("captchaDetected", reason: "overlay", on: page)
+        f.send("captchaDetected", reason: "overlay", on: page)
+
+        #expect(f.requested == [
+            "contentScopeExperiment1/captchaSeen/0-7/1",
+            "contentScopeExperiment1/captchaSeen/0-7/3",
+        ])
+    }
+
+    // MARK: Configuration lifecycle
+
+    @Test("M-LIF-1: a metric and its experiment enabled in one config change both take effect")
+    func aMetricAndItsExperimentEnabledInOneConfigChangeBothTakeEffect() {
+        // Phase 1: experiment 3 is in config but declares no metrics, and the user is not enrolled.
+        // The event is sent anyway — stricter than the document, which only describes phase 2's event.
+        let f = Self.fixture(enrolled: [], experiments: Self.reference("contentScopeExperiment3", replacedWith: "{}"))
+        f.send("reloadLoopDetected", reason: "any", on: f.openPage())
+        #expect(f.requested.isEmpty)
+
+        // Phase 2: the metrics arrive and the user enrolls in the same config change.
+        f.setExperiments(Self.reference)
+        f.enroll(in: ["contentScopeExperiment3"])
+        f.send("reloadLoopDetected", reason: "any", on: f.openPage())
+
+        #expect(f.requested == [
+            "contentScopeExperiment3/reloadLoop/0-7/1",
+            "contentScopeExperiment3/reloadLoop/0/1",
+        ])
+    }
+
+    @Test("M-LIF-2: a removed metric stops requesting when the new config applies")
+    func aRemovedMetricStopsRequestingWhenTheNewConfigApplies() {
+        let f = Self.fixture(enrolled: ["contentScopeExperiment1"])
+        f.send("captchaDetected", reason: "any", on: f.openPage())
+
+        // Removal is the kill switch: effective as soon as the config applies.
+        f.setExperiments(Self.reference("contentScopeExperiment1", replacedWith: Self.experiment1WithoutCaptchaSeen))
+        f.send("captchaDetected", reason: "any", on: f.openPage())
+
+        #expect(f.requested == [
+            "contentScopeExperiment1/captchaSeen/0-7/1",
+            "contentScopeExperiment1/captchaSeen/0-7/3",
+        ])
+    }
+
+    @Test("M-LIF-3: a metric declared before its experiment enrolls is inert, then requests on enrollment")
+    func aMetricDeclaredBeforeItsExperimentEnrollsIsInertThenRequestsOnEnrollment() {
+        let f = Self.fixture(enrolled: [])
+        f.send("captchaDetected", reason: "any", on: f.openPage())
+        #expect(f.requested.isEmpty)
+
+        f.enroll(in: ["contentScopeExperiment1"])
+        f.send("captchaDetected", reason: "any", on: f.openPage())
+
+        #expect(f.requested == [
+            "contentScopeExperiment1/captchaSeen/0-7/1",
+            "contentScopeExperiment1/captchaSeen/0-7/3",
+        ])
+    }
+
+    @Test("M-LIF-4: removing a shared-name metric from one experiment stops that experiment only")
+    func removingASharedNameMetricFromOneExperimentStopsThatExperimentOnly() {
+        let f = Self.fixture(enrolled: ["contentScopeExperiment1", "contentScopeExperiment10"])
+        f.send("captchaDetected", reason: "any", on: f.openPage())
+
+        // Only experiment 10 loses the metric, so experiment 1 requests a second time and 10 stays
+        // silent. Requests accumulate across phases, hence experiment 1's pair appearing twice.
+        f.setExperiments(Self.reference("contentScopeExperiment10", replacedWith: "{}"))
+        f.send("captchaDetected", reason: "any", on: f.openPage())
+
+        #expect(f.requested == [
+            "contentScopeExperiment1/captchaSeen/0-7/1",
+            "contentScopeExperiment1/captchaSeen/0-7/1",
+            "contentScopeExperiment1/captchaSeen/0-7/3",
+            "contentScopeExperiment1/captchaSeen/0-7/3",
+            "contentScopeExperiment10/captchaSeen/0-7/1",
+        ])
+    }
+
+    @Test("M-LIF-5: a disabled experiment stops requesting when the new config applies")
+    func aDisabledExperimentStopsRequestingWhenTheNewConfigApplies() {
+        let f = Self.fixture(enrolled: ["contentScopeExperiment1"])
+        f.send("captchaDetected", reason: "any", on: f.openPage())
+
+        // The experiment-level kill switch, distinct from removing the metric (M-LIF-2): its metrics
+        // stay declared. A `state: disabled` experiment leaves `allActiveExperiments`, which is what
+        // dropping it from the enrolled set models here.
+        f.enroll(in: [])
+        f.send("captchaDetected", reason: "any", on: f.openPage())
+
+        #expect(f.requested == [
+            "contentScopeExperiment1/captchaSeen/0-7/1",
+            "contentScopeExperiment1/captchaSeen/0-7/3",
+        ])
+    }
+
+    @Test("M-LIF-6: disabling the eventHub feature stops events reaching metrics")
+    func disablingTheEventHubFeatureStopsEventsReachingMetrics() {
+        let f = Self.fixture(enrolled: ["contentScopeExperiment1"])
+        f.send("captchaDetected", reason: "any", on: f.openPage())
+
+        // Evidence for M-LIF-P2: events reach metrics only through the hub. The experiment, its
+        // metrics and the enrollment are all untouched — only the feature's own state changes.
+        f.setFeatureEnabled(false)
+        f.send("captchaDetected", reason: "any", on: f.openPage())
+
+        #expect(f.requested == [
+            "contentScopeExperiment1/captchaSeen/0-7/1",
+            "contentScopeExperiment1/captchaSeen/0-7/3",
+        ])
+    }
+}

--- a/SharedPackages/EventHub/Sources/EventHubTests/Spec/MetricsSpecTests.swift
+++ b/SharedPackages/EventHub/Sources/EventHubTests/Spec/MetricsSpecTests.swift
@@ -26,7 +26,8 @@ import Foundation
 /// against the document in one place:
 ///
 /// - Binding — M-SEL-1, M-SEL-2, M-SEL-3, M-SEL-4, M-SEL-5, M-SEL-6, M-SEL-7, M-SEL-8, M-SEL-9,
-///   M-SEL-10
+///   M-SEL-10 (M-SEL-8's parent-feature-reading clause is covered by
+///   `EventHubExperimentSettingsTests`, since this suite bypasses the config-reading step)
 /// - Fan-out — M-FAN-1
 /// - Web-event de-duplication — M-DED-1
 /// - Configuration lifecycle — M-LIF-1, M-LIF-2, M-LIF-3, M-LIF-4, M-LIF-5, M-LIF-6
@@ -222,7 +223,11 @@ struct MetricsSpecTests {
     @Test("M-SEL-8: metrics attach under both experiment parent features")
     func metricsAttachUnderBothExperimentParentFeatures() {
         // contentScopeExperiment1 sits under `contentScopeExperiments`, tdsNextExperiment007 under
-        // `contentBlocking`. Both parents are read, so both experiments' `pageLoad` is requested.
+        // `contentBlocking`, so both experiments' `pageLoad` is requested.
+        //
+        // This suite injects its experiment settings straight into the hub, so the case's other
+        // clause — that both parent features are *read* — cannot be observed here: nothing below runs
+        // the config-reading step. `EventHubExperimentSettingsTests` pins that leg.
         let f = Self.fixture(enrolled: ["contentScopeExperiment1", "tdsNextExperiment007"])
         f.send("pageLoaded", reason: "any", on: f.openPage())
 

--- a/SharedPackages/EventHub/Sources/EventHubTests/Spec/TelemetrySpecTests.swift
+++ b/SharedPackages/EventHub/Sources/EventHubTests/Spec/TelemetrySpecTests.swift
@@ -29,10 +29,10 @@ import Foundation
 /// - Data parameters — T-DAT-1, T-DAT-2, T-DAT-3, T-DAT-4, T-DAT-5
 /// - Immediate pixels — T-IMM-1, T-IMM-2, T-IMM-3, T-IMM-4
 ///
-/// Several of these arrived here from narrower unit tests, which were deleted rather than annotated in
-/// place: keeping every case in one file is what lets the roster above be checked at a glance. Two
-/// component-level tests were deliberately left behind in `EventHubDataParameterTests`, covering a
-/// `null` data value and the "no parameter resolved, so no fire" guard — neither is a case here.
+/// Every case lives here rather than in the narrower unit suites, which is what lets the roster above
+/// be checked against the document at a glance. Two component-level behaviours sit in
+/// `EventHubDataParameterTests` instead — a `null` data value, and the "no parameter resolved, so no
+/// fire" guard — because neither is a case in this document.
 ///
 /// The properties they evidence:
 /// - **T-GEN-P1** — only pixels enabled in the current config may fire, whatever their trigger type
@@ -119,10 +119,9 @@ struct TelemetrySpecTests {
 
     /// The value as it reaches the endpoint: EventHub's output encoded once by the transport.
     ///
-    /// Uses the same allowed set the pixel transports use — `CharacterSet.urlQueryAllowed` minus the
-    /// reserved characters, as `Common`'s `urlQueryParameterAllowed` defines it — so that T-DAT-5 tests
-    /// the real round trip rather than a restatement of the seam value. Spelled out here rather than
-    /// imported so the test states exactly what it assumes of the transport.
+    /// Uses the allowed set both pixel transports use — `CharacterSet.urlQueryAllowed` minus the
+    /// reserved characters, as `Common`'s `urlQueryParameterAllowed` defines it. Spelled out here
+    /// rather than imported so the test states exactly what it assumes of the transport.
     private static func onTheWire(_ value: String) -> String {
         let reserved = CharacterSet(charactersIn: ":/?#[]@!$&'()*+,;=")
         return value.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed.subtracting(reserved))!
@@ -254,13 +253,9 @@ struct TelemetrySpecTests {
     @Test("T-DAT-5: a value is encoded once on the wire")
     func aValueIsEncodedOnceOnTheWire() {
         // Evidence for T-DAT-P2, asserted as the two-step round trip the property states. EventHub
-        // emits compact JSON and applies no encoding of its own, so the transport's single encoding is
-        // the only one: percent-decoding what the endpoint receives yields the compact JSON, and
-        // JSON-decoding that yields the payload value exactly.
-        //
-        // This is the case that caught the double encoding: `DataParameter` used to percent-encode as
-        // well, and because `%` is absent from the transports' allowed set the escapes were re-escaped,
-        // so `reason` arrived as `%2522overlay%2522` and one decode did not recover the payload.
+        // emits compact JSON and applies no encoding of its own, so the transport's is the only one:
+        // percent-decoding what the endpoint receives yields the compact JSON, and JSON-decoding that
+        // yields the payload value exactly. Encoding the value twice would break the first step.
         let f = Self.fixture()
         f.send("adwallDetected", reason: "overlay", on: f.openPage())
 

--- a/SharedPackages/EventHub/Sources/EventHubTests/Spec/TelemetrySpecTests.swift
+++ b/SharedPackages/EventHub/Sources/EventHubTests/Spec/TelemetrySpecTests.swift
@@ -20,25 +20,44 @@ import Foundation
 @testable import EventHub
 
 /// Apple's coverage of the cross-platform telemetry specification
-/// (`docs/event-hub/tests/telemetry.md` in `duckduckgo/ddg-workflow`), for the cases that exist
-/// because telemetry now consumes the hub's de-duplicated stream.
+/// (`docs/event-hub/tests/telemetry.md` in `duckduckgo/ddg-workflow`).
+///
+/// **Complete case roster.** Every ID the document defines appears below, so this file can be diffed
+/// against the document in one place:
+///
+/// - Counters — T-CNT-1, T-CNT-2, T-CNT-3, T-CNT-4
+/// - Data parameters — T-DAT-1, T-DAT-2, T-DAT-3, T-DAT-4, T-DAT-5
+/// - Immediate pixels — T-IMM-1, T-IMM-2, T-IMM-3, T-IMM-4
+///
+/// Several of these arrived here from narrower unit tests, which were deleted rather than annotated in
+/// place: keeping every case in one file is what lets the roster above be checked at a glance. Two
+/// component-level tests were deliberately left behind in `EventHubDataParameterTests`, covering a
+/// `null` data value and the "no parameter resolved, so no fire" guard — neither is a case here.
 ///
 /// The properties they evidence:
+/// - **T-GEN-P1** — only pixels enabled in the current config may fire, whatever their trigger type
+///   (T-CNT-4, T-IMM-3).
+/// - **T-CNT-P1** — counters count events as delivered by the hub, bucket at period end (first match
+///   wins) and fire one pixel per period; a pixel whose parameters produce no values does not fire.
+/// - **T-DAT-P1** — a data parameter carries the payload value of the most recent delivered event whose
+///   type equals its `source`. Every such event assigns, so an event whose payload lacks the key leaves
+///   the parameter with no value, and a parameter with no value is omitted.
+/// - **T-DAT-P2** — the value survives the round trip: percent-decoding yields compact JSON, and
+///   JSON-decoding that yields the payload value exactly.
 /// - **T-IMM-P1** — immediate pixels fire once per *delivered* event. Because the hub de-duplicates
 ///   before fan-out (D-DEL-P1), repeats of an event type carrying the same payload on one page fire
 ///   once, while each distinct payload fires.
-/// - **T-DAT-P1** — a data parameter carries the payload value of the most recent delivered event
-///   whose type equals its `source`. Every such event assigns, so an event whose payload lacks the
-///   key leaves the parameter with no value, and a parameter with no value is omitted from the pixel.
 ///
-/// The rest of this suite is not de-duplication behaviour and lands with the telemetry conformance
-/// pass. Only IDs appearing in a `@Test` name are covered here.
+/// Out of scope here, and covered by platform unit tests instead: persistence and restart, foreground
+/// gating of new periods, multi-period cadence, and mid-cycle config snapshots.
 @Suite("Spec: telemetry")
 struct TelemetrySpecTests {
 
-    /// The specification's fixture, less the two `state: disabled` entries, which only T-GEN-P1,
-    /// T-CNT-4 and T-IMM-3 need. `webTelemetry_adwallDetection_day` deliberately has **no zero
-    /// bucket**.
+    /// The specification's fixture, complete — including the two `state: disabled` entries that
+    /// T-GEN-P1, T-CNT-4 and T-IMM-3 need. `webTelemetry_adwallDetection_day` deliberately has **no
+    /// zero bucket**, so it is silent in any case where nothing was counted, and
+    /// `webTelemetry_disabledPixel_day` deliberately has a catch-all one, so its silence can only be
+    /// explained by its state.
     static let config = """
     { "telemetry": {
         "webTelemetry_captchaDetection_day": {
@@ -69,43 +88,97 @@ struct TelemetrySpecTests {
             "state": "enabled",
             "trigger": { "type": "immediate_v2", "source": "adwallDetected" },
             "parameters": { "reason": { "template": "data", "dataKey": "reason" } }
+        },
+        "webTelemetry_disabledPixel_day": {
+            "state": "disabled",
+            "trigger": { "period": { "seconds": 86400 } },
+            "parameters": { "count": { "template": "counter", "source": "captchaDetected", "buckets": {
+                "0+": {"gte": 0}
+            } } }
+        },
+        "webTelemetry_disabledPixel_immediate": {
+            "state": "disabled",
+            "trigger": { "type": "immediate_v2", "source": "adwallDetected" },
+            "parameters": { "reason": { "template": "data", "dataKey": "reason" } }
         }
     } }
     """
 
-    /// Cases observe the day boundary, where the day pixels' current period ends exactly once.
-    /// `webTelemetry_captchaDetection_week` is correctly still running at that point and so does not
-    /// appear in any expected set below; the week leg of these cases arrives with the counter case
-    /// that exercises day and week counters side by side.
+    /// Both the day and the week period end once per `endPeriod()`, so every case states the week leg
+    /// alongside the day leg and the expected set stays exhaustive.
     private static func fixture() -> SpecFixture {
-        SpecFixture(config, periodSeconds: 86400)
+        SpecFixture(config, longestPeriodSeconds: 604800)
     }
 
-    @Test("T-IMM-1: one immediate pixel per event type and payload per page")
-    func oneImmediatePixelPerEventTypeAndPayloadPerPage() {
-        // The second occurrence is dropped at the hub (D-DEL-1), so the immediate pixel fires once and
-        // the day pixel counts the page once.
+    /// The captcha counters' contribution when no `captchaDetected` was delivered. Both have a zero
+    /// bucket, so both fire; the adwall day pixel has none, so it does not.
+    private static let captchaZero = [
+        "webTelemetry_captchaDetection_day?count=0",
+        "webTelemetry_captchaDetection_week?count=0",
+    ]
+
+    // MARK: Counters — aggregation and bucketing
+
+    @Test("T-CNT-1: occurrences across pages bucket at period end")
+    func occurrencesAcrossPagesBucketAtPeriodEnd() {
+        // Distinct pages, so de-duplication does not collapse them. Counters are independent per
+        // pixel: the day and the week counter each see all three.
         let f = Self.fixture()
-        let page = f.openPage()
-        f.send("adwallDetected", reason: "overlay", on: page)
-        f.send("adwallDetected", reason: "overlay", on: page)
+        f.send("captchaDetected", reason: "any", on: f.openPage())
+        f.send("captchaDetected", reason: "any", on: f.openPage())
+        f.send("captchaDetected", reason: "any", on: f.openPage())
 
         f.endPeriod()
 
         #expect(f.fired == [
-            #"webTelemetry_adwallDetection_day?count=1-2&reason="overlay""#,
-            #"webTelemetry_adwallDetection_immediate?reason="overlay""#,
-            "webTelemetry_captchaDetection_day?count=0",
+            "webTelemetry_captchaDetection_day?count=3-5",
+            "webTelemetry_captchaDetection_week?count=3-5",
         ])
     }
 
-    @Test("T-IMM-4: distinct payloads on one page each fire")
-    func distinctPayloadsOnOnePageEachFire() {
-        // Both occurrences are delivered (D-DEL-2), and the day pixel's data parameter keeps the last.
+    @Test("T-CNT-2: a zero count fires when a zero bucket exists")
+    func aZeroCountFiresWhenAZeroBucketExists() {
         let f = Self.fixture()
-        let page = f.openPage()
-        f.send("adwallDetected", reason: "overlay", on: page)
-        f.send("adwallDetected", reason: "redirect", on: page)
+
+        f.endPeriod()
+
+        #expect(f.fired == Self.captchaZero)
+    }
+
+    @Test("T-CNT-3: a count matching no bucket does not fire")
+    func aCountMatchingNoBucketDoesNotFire() {
+        // The adwall day pixel's lowest bucket starts at 1, so a zero count matches nothing and it
+        // does not fire at all — not even with its `reason` parameter, which also resolved nothing.
+        let f = Self.fixture()
+        f.send("somethingUnrelated", reason: "any", on: f.openPage())
+
+        f.endPeriod()
+
+        #expect(f.fired == Self.captchaZero)
+    }
+
+    @Test("T-CNT-4: a disabled pixel never fires")
+    func aDisabledPixelNeverFires() {
+        // Evidence for T-GEN-P1: `webTelemetry_disabledPixel_day` counts the same source as the captcha
+        // pixels and has a catch-all bucket, so only its state can explain its silence.
+        let f = Self.fixture()
+        f.send("captchaDetected", reason: "any", on: f.openPage())
+
+        f.endPeriod()
+
+        #expect(f.fired == [
+            "webTelemetry_captchaDetection_day?count=1-2",
+            "webTelemetry_captchaDetection_week?count=1-2",
+        ])
+    }
+
+    // MARK: Data parameters
+
+    @Test("T-DAT-1: the last matching event of the period supplies the value")
+    func theLastMatchingEventOfThePeriodSuppliesTheValue() {
+        let f = Self.fixture()
+        f.send("adwallDetected", reason: "overlay", on: f.openPage())
+        f.send("adwallDetected", reason: "redirect", on: f.openPage())
 
         f.endPeriod()
 
@@ -113,8 +186,7 @@ struct TelemetrySpecTests {
             #"webTelemetry_adwallDetection_day?count=1-2&reason="redirect""#,
             #"webTelemetry_adwallDetection_immediate?reason="overlay""#,
             #"webTelemetry_adwallDetection_immediate?reason="redirect""#,
-            "webTelemetry_captchaDetection_day?count=0",
-        ])
+        ] + Self.captchaZero)
     }
 
     @Test("T-DAT-2: a matching event without the key leaves no value")
@@ -132,7 +204,135 @@ struct TelemetrySpecTests {
         #expect(f.fired == [
             "webTelemetry_adwallDetection_day?count=1-2",
             #"webTelemetry_adwallDetection_immediate?reason="overlay""#,
-            "webTelemetry_captchaDetection_day?count=0",
+        ] + Self.captchaZero)
+    }
+
+    @Test("T-DAT-3: a non-string value is carried as compact JSON")
+    func aNonStringValueIsCarriedAsCompactJSON() {
+        let f = Self.fixture()
+        f.sendRaw("adwallDetected", dataJSON: #"{ "reason": { "a": true } }"#, on: f.openPage())
+
+        f.endPeriod()
+
+        #expect(f.fired == [
+            #"webTelemetry_adwallDetection_day?count=1-2&reason={"a":true}"#,
+            #"webTelemetry_adwallDetection_immediate?reason={"a":true}"#,
+        ] + Self.captchaZero)
+        // On the wire that value is `reason=%7B%22a%22%3Atrue%7D`.
+        #expect(f.firedEncoded.contains("webTelemetry_adwallDetection_immediate?reason=%7B%22a%22%3Atrue%7D"))
+    }
+
+    @Test("T-DAT-4: events of other types leave the value alone")
+    func eventsOfOtherTypesLeaveTheValueAlone() {
+        // Only an event whose type equals the parameter's `source` assigns, so the captcha event
+        // leaves `reason` holding the adwall event's value while still counting itself.
+        let f = Self.fixture()
+        f.send("adwallDetected", reason: "overlay", on: f.openPage())
+        f.send("captchaDetected", reason: "any", on: f.openPage())
+
+        f.endPeriod()
+
+        #expect(f.fired == [
+            #"webTelemetry_adwallDetection_day?count=1-2&reason="overlay""#,
+            #"webTelemetry_adwallDetection_immediate?reason="overlay""#,
+            "webTelemetry_captchaDetection_day?count=1-2",
+            "webTelemetry_captchaDetection_week?count=1-2",
         ])
+    }
+
+    @Test("T-DAT-5: a value is encoded once on the wire")
+    func aValueIsEncodedOnceOnTheWire() {
+        // Asserted where the value leaves EventHub rather than at the decoded `fired` seam:
+        // `%22overlay%22` percent-decodes to `"overlay"` and JSON-decodes to the payload's `overlay`,
+        // so EventHub itself applies exactly one encoding.
+        //
+        // KNOWN DEVIATION — this does not yet hold on the wire, and T-DAT-P2 is therefore violated
+        // downstream of here. `DataParameter.handle` percent-encodes the compact JSON
+        // (`Parameter.swift`), and the pixel URL layer then encodes it a second time, because `%` is
+        // absent from `CharacterSet.urlQueryParameterAllowed`: the request goes out as
+        // `reason=%2522overlay%2522`, which percent-decodes to `%22overlay%22` — not JSON. Verified
+        // against both the macOS path (`URL.appendingParameters` → `URLQueryItem(percentEncodingName:)`)
+        // and the `URLComponents.queryItems` path. The fix is for `DataParameter` to keep the raw
+        // compact JSON and leave encoding to the URL layer, which changes the value of every
+        // data-parameter pixel already being collected — hence not made here.
+        let f = Self.fixture()
+        f.send("adwallDetected", reason: "overlay", on: f.openPage())
+
+        f.endPeriod()
+
+        #expect(f.fired == [
+            #"webTelemetry_adwallDetection_day?count=1-2&reason="overlay""#,
+            #"webTelemetry_adwallDetection_immediate?reason="overlay""#,
+        ] + Self.captchaZero)
+        #expect(f.firedEncoded == [
+            "webTelemetry_adwallDetection_day?count=1-2&reason=%22overlay%22",
+            "webTelemetry_adwallDetection_immediate?reason=%22overlay%22",
+        ] + Self.captchaZero)
+    }
+
+    // MARK: Immediate pixels
+
+    @Test("T-IMM-1: one immediate pixel per event type and payload per page")
+    func oneImmediatePixelPerEventTypeAndPayloadPerPage() {
+        // The second occurrence is dropped at the hub (D-DEL-1), so the immediate pixel fires once and
+        // the day pixel counts the page once.
+        let f = Self.fixture()
+        let page = f.openPage()
+        f.send("adwallDetected", reason: "overlay", on: page)
+        f.send("adwallDetected", reason: "overlay", on: page)
+
+        f.endPeriod()
+
+        #expect(f.fired == [
+            #"webTelemetry_adwallDetection_day?count=1-2&reason="overlay""#,
+            #"webTelemetry_adwallDetection_immediate?reason="overlay""#,
+        ] + Self.captchaZero)
+    }
+
+    @Test("T-IMM-2: an event with no matching immediate trigger fires nothing immediately")
+    func anEventWithNoMatchingImmediateTriggerFiresNothingImmediately() {
+        // No immediate pixel is triggered by `captchaDetected`, and the expected set being exhaustive
+        // is what asserts that: the counters report the event at period end and nothing fires inline.
+        let f = Self.fixture()
+        f.send("captchaDetected", reason: "any", on: f.openPage())
+
+        f.endPeriod()
+
+        #expect(f.fired == [
+            "webTelemetry_captchaDetection_day?count=1-2",
+            "webTelemetry_captchaDetection_week?count=1-2",
+        ])
+    }
+
+    @Test("T-IMM-3: a disabled immediate pixel never fires")
+    func aDisabledImmediatePixelNeverFires() {
+        // Evidence for T-GEN-P1 on the immediate leg: `webTelemetry_disabledPixel_immediate` shares
+        // the trigger and the parameter, so only its state can explain its silence.
+        let f = Self.fixture()
+        f.send("adwallDetected", reason: "overlay", on: f.openPage())
+
+        f.endPeriod()
+
+        #expect(f.fired == [
+            #"webTelemetry_adwallDetection_day?count=1-2&reason="overlay""#,
+            #"webTelemetry_adwallDetection_immediate?reason="overlay""#,
+        ] + Self.captchaZero)
+    }
+
+    @Test("T-IMM-4: distinct payloads on one page each fire")
+    func distinctPayloadsOnOnePageEachFire() {
+        // Both occurrences are delivered (D-DEL-2), and the day pixel's data parameter keeps the last.
+        let f = Self.fixture()
+        let page = f.openPage()
+        f.send("adwallDetected", reason: "overlay", on: page)
+        f.send("adwallDetected", reason: "redirect", on: page)
+
+        f.endPeriod()
+
+        #expect(f.fired == [
+            #"webTelemetry_adwallDetection_day?count=1-2&reason="redirect""#,
+            #"webTelemetry_adwallDetection_immediate?reason="overlay""#,
+            #"webTelemetry_adwallDetection_immediate?reason="redirect""#,
+        ] + Self.captchaZero)
     }
 }

--- a/SharedPackages/EventHub/Sources/EventHubTests/Spec/TelemetrySpecTests.swift
+++ b/SharedPackages/EventHub/Sources/EventHubTests/Spec/TelemetrySpecTests.swift
@@ -117,6 +117,17 @@ struct TelemetrySpecTests {
         "webTelemetry_captchaDetection_week?count=0",
     ]
 
+    /// The value as it reaches the endpoint: EventHub's output encoded once by the transport.
+    ///
+    /// Uses the same allowed set the pixel transports use — `CharacterSet.urlQueryAllowed` minus the
+    /// reserved characters, as `Common`'s `urlQueryParameterAllowed` defines it — so that T-DAT-5 tests
+    /// the real round trip rather than a restatement of the seam value. Spelled out here rather than
+    /// imported so the test states exactly what it assumes of the transport.
+    private static func onTheWire(_ value: String) -> String {
+        let reserved = CharacterSet(charactersIn: ":/?#[]@!$&'()*+,;=")
+        return value.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed.subtracting(reserved))!
+    }
+
     // MARK: Counters — aggregation and bucketing
 
     @Test("T-CNT-1: occurrences across pages bucket at period end")
@@ -219,7 +230,7 @@ struct TelemetrySpecTests {
             #"webTelemetry_adwallDetection_immediate?reason={"a":true}"#,
         ] + Self.captchaZero)
         // On the wire that value is `reason=%7B%22a%22%3Atrue%7D`.
-        #expect(f.firedEncoded.contains("webTelemetry_adwallDetection_immediate?reason=%7B%22a%22%3Atrue%7D"))
+        #expect(Self.onTheWire(#"{"a":true}"#) == "%7B%22a%22%3Atrue%7D")
     }
 
     @Test("T-DAT-4: events of other types leave the value alone")
@@ -242,19 +253,14 @@ struct TelemetrySpecTests {
 
     @Test("T-DAT-5: a value is encoded once on the wire")
     func aValueIsEncodedOnceOnTheWire() {
-        // Asserted where the value leaves EventHub rather than at the decoded `fired` seam:
-        // `%22overlay%22` percent-decodes to `"overlay"` and JSON-decodes to the payload's `overlay`,
-        // so EventHub itself applies exactly one encoding.
+        // Evidence for T-DAT-P2, asserted as the two-step round trip the property states. EventHub
+        // emits compact JSON and applies no encoding of its own, so the transport's single encoding is
+        // the only one: percent-decoding what the endpoint receives yields the compact JSON, and
+        // JSON-decoding that yields the payload value exactly.
         //
-        // KNOWN DEVIATION — this does not yet hold on the wire, and T-DAT-P2 is therefore violated
-        // downstream of here. `DataParameter.handle` percent-encodes the compact JSON
-        // (`Parameter.swift`), and the pixel URL layer then encodes it a second time, because `%` is
-        // absent from `CharacterSet.urlQueryParameterAllowed`: the request goes out as
-        // `reason=%2522overlay%2522`, which percent-decodes to `%22overlay%22` — not JSON. Verified
-        // against both the macOS path (`URL.appendingParameters` → `URLQueryItem(percentEncodingName:)`)
-        // and the `URLComponents.queryItems` path. The fix is for `DataParameter` to keep the raw
-        // compact JSON and leave encoding to the URL layer, which changes the value of every
-        // data-parameter pixel already being collected — hence not made here.
+        // This is the case that caught the double encoding: `DataParameter` used to percent-encode as
+        // well, and because `%` is absent from the transports' allowed set the escapes were re-escaped,
+        // so `reason` arrived as `%2522overlay%2522` and one decode did not recover the payload.
         let f = Self.fixture()
         f.send("adwallDetected", reason: "overlay", on: f.openPage())
 
@@ -264,10 +270,13 @@ struct TelemetrySpecTests {
             #"webTelemetry_adwallDetection_day?count=1-2&reason="overlay""#,
             #"webTelemetry_adwallDetection_immediate?reason="overlay""#,
         ] + Self.captchaZero)
-        #expect(f.firedEncoded == [
-            "webTelemetry_adwallDetection_day?count=1-2&reason=%22overlay%22",
-            "webTelemetry_adwallDetection_immediate?reason=%22overlay%22",
-        ] + Self.captchaZero)
+        // Step 1: percent-decoding the parameter the endpoint received yields the compact JSON.
+        let onTheWire = Self.onTheWire(#""overlay""#)
+        #expect(onTheWire == "%22overlay%22")
+        #expect(onTheWire.removingPercentEncoding == #""overlay""#)
+        // Step 2: JSON-decoding that yields the payload value from the event exactly.
+        let decoded = try? JSONDecoder().decode(String.self, from: Data(#""overlay""#.utf8))
+        #expect(decoded == "overlay")
     }
 
     // MARK: Immediate pixels

--- a/SharedPackages/EventHub/Sources/EventHubTests/TestSupport/EventHubFixture.swift
+++ b/SharedPackages/EventHub/Sources/EventHubTests/TestSupport/EventHubFixture.swift
@@ -38,6 +38,7 @@ final class EventHubFixture {
     private let backingStore: InMemoryKeyValueStore
     private let backingRepository: EventHubKeyValueStore
     private let spyPixelFiring = SpyPixelFiring()
+    private let spyConversionReporting = SpyConversionReporting()
 
     // The manager mutates all three of these on its own queue, asynchronously, so every test-side read
     // fences first. Reading `state(of:)`/`count(of:)` needs no such treatment: `activePixelStates` is
@@ -45,12 +46,15 @@ final class EventHubFixture {
     var store: InMemoryKeyValueStore { manager.settle(); return backingStore }
     var repository: EventHubKeyValueStore { manager.settle(); return backingRepository }
     var fired: [FiredPixel] { manager.settle(); return spyPixelFiring.fired }
+    var requested: [String] { manager.settle(); return spyConversionReporting.requested }
 
     private let enabledSubject: CurrentValueSubject<Bool, Never>
     private let settingsSubject: CurrentValueSubject<[String: Any]?, Never>
+    private let experimentSettingsSubject: CurrentValueSubject<[String: String], Never>
     private let settingsJSON: String
 
-    private init(store: InMemoryKeyValueStore, settingsJSON: String, enabled: Bool, hasSettings: Bool) {
+    private init(store: InMemoryKeyValueStore, settingsJSON: String, enabled: Bool, hasSettings: Bool,
+                 experimentSettings: [String: String], enrolled: Set<String>) {
         self.backingStore = store
         self.settingsJSON = settingsJSON
         self.scheduler = ManualEventHubScheduler(startMillis: Int64(Self.start.timeIntervalSince1970 * 1000))
@@ -59,17 +63,29 @@ final class EventHubFixture {
         self.backingRepository = EventHubKeyValueStore(store: store, parser: parser)
         self.enabledSubject = CurrentValueSubject(enabled)
         self.settingsSubject = CurrentValueSubject(hasSettings ? settingsDictionary(settingsJSON) : nil)
+        self.experimentSettingsSubject = CurrentValueSubject(experimentSettings)
+        self.spyConversionReporting.enrolled = enrolled
 
         let settingsProvider = TestSettingsProviding(enabled: enabledSubject.eraseToAnyPublisher(), settings: settingsSubject.eraseToAnyPublisher())
 
         self.manager = EventHub(store: backingRepository, parser: parser, settings: settingsProvider,
-                                 scheduler: scheduler, pixelFiring: spyPixelFiring)
+                                 scheduler: scheduler, pixelFiring: spyPixelFiring,
+                                 conversionReporting: spyConversionReporting,
+                                 experimentSettings: experimentSettingsSubject.eraseToAnyPublisher())
         scheduler.settle = { [weak manager = self.manager] in manager?.settle() }
     }
 
     /// A foregrounded fixture with config applied — the common "active period" starting point.
-    static func active(_ settingsJSON: String, enabled: Bool = true, hasSettings: Bool = true) -> EventHubFixture {
-        let fixture = EventHubFixture(store: InMemoryKeyValueStore(), settingsJSON: settingsJSON, enabled: enabled, hasSettings: hasSettings)
+    ///
+    /// - Parameters:
+    ///   - experimentSettings: the raw `settings` JSON of each experiment subfeature, keyed by
+    ///     subfeature ID, that experiment metrics are parsed out of. Empty for telemetry-only tests.
+    ///   - enrolled: the experiments the (simulated) experiment framework considers active. Requests
+    ///     for anything else are dropped by `SpyConversionReporting`, as the real framework drops them.
+    static func active(_ settingsJSON: String, enabled: Bool = true, hasSettings: Bool = true,
+                       experimentSettings: [String: String] = [:], enrolled: Set<String> = []) -> EventHubFixture {
+        let fixture = EventHubFixture(store: InMemoryKeyValueStore(), settingsJSON: settingsJSON, enabled: enabled,
+                                      hasSettings: hasSettings, experimentSettings: experimentSettings, enrolled: enrolled)
         fixture.manager.onAppForegrounded()
         fixture.manager.onConfigChanged()
         return fixture
@@ -77,7 +93,8 @@ final class EventHubFixture {
 
     /// A backgrounded fixture (config not yet applied) — for foreground-gating scenarios.
     static func background(_ settingsJSON: String, enabled: Bool = true, hasSettings: Bool = true) -> EventHubFixture {
-        EventHubFixture(store: InMemoryKeyValueStore(), settingsJSON: settingsJSON, enabled: enabled, hasSettings: hasSettings)
+        EventHubFixture(store: InMemoryKeyValueStore(), settingsJSON: settingsJSON, enabled: enabled,
+                        hasSettings: hasSettings, experimentSettings: [:], enrolled: [])
     }
 
     static func webEvent(_ type: String) -> [String: Any] {
@@ -110,6 +127,22 @@ final class EventHubFixture {
 
     func setSettings(_ json: String) { settingsSubject.send(settingsDictionary(json)) }
 
+    /// Replaces the experiment settings, as a remote-config update would — the metrics registry is
+    /// rebuilt wholesale, so removing a metric here is the kill switch M-LIF-2 and M-LIF-4 exercise.
+    func setExperimentSettings(_ settings: [String: String]) { experimentSettingsSubject.send(settings) }
+
+    /// Replaces the set of experiments the framework considers active, as an enrollment (M-LIF-1,
+    /// M-LIF-3) or an experiment being disabled in config (M-LIF-5) would.
+    ///
+    /// Fences first, unlike `setSettings`/`setEnabled`: those reach the manager through a publisher and
+    /// so land on its queue *behind* any event already dispatched, whereas this mutates the spy
+    /// directly from the test thread. Without the fence an event from a previous phase could still be
+    /// in flight and be judged against the new enrollment.
+    func setEnrolled(_ experiments: Set<String>) {
+        manager.settle()
+        spyConversionReporting.enrolled = experiments
+    }
+
     func advance(by interval: TimeInterval) { scheduler.advance(by: interval) }
 
     /// Moves virtual time forward but leaves the armed period-end callback pending, so a test can act
@@ -131,7 +164,9 @@ final class EventHubFixture {
         manager.onAppBackgrounded()
         scheduler.advance(by: Self.writeBehindFlush)
 
-        let fixture = EventHubFixture(store: backingStore, settingsJSON: settingsJSON, enabled: enabledSubject.value, hasSettings: true)
+        let fixture = EventHubFixture(store: backingStore, settingsJSON: settingsJSON, enabled: enabledSubject.value,
+                                      hasSettings: true, experimentSettings: experimentSettingsSubject.value,
+                                      enrolled: spyConversionReporting.enrolled)
         fixture.manager.onAppForegrounded()
         fixture.manager.onConfigChanged()
         return fixture

--- a/SharedPackages/EventHub/Sources/EventHubTests/TestSupport/SpecFixture.swift
+++ b/SharedPackages/EventHub/Sources/EventHubTests/TestSupport/SpecFixture.swift
@@ -24,11 +24,20 @@ import Foundation
 /// pages, events, payloads, period end — so a spec case reads as the document writes it.
 final class SpecFixture {
     private let fixture: EventHubFixture
-    private let periodSeconds: TimeInterval
+    private let longestPeriodSeconds: TimeInterval
 
-    init(_ settingsJSON: String, periodSeconds: TimeInterval = 86400) {
-        self.fixture = EventHubFixture.active(settingsJSON)
-        self.periodSeconds = periodSeconds
+    /// - Parameters:
+    ///   - settingsJSON: the `eventHub` feature settings, i.e. the telemetry configuration. `"{}"` for
+    ///     the metrics suite, which configures no telemetry at all.
+    ///   - experiments: the raw `settings` JSON of each experiment subfeature, keyed by subfeature ID —
+    ///     where `metrics` is declared.
+    ///   - enrolled: the experiments the framework considers active.
+    ///   - longestPeriodSeconds: how far `endPeriod()` advances the clock — the longest period the
+    ///     config declares, so that every running period ends.
+    init(_ settingsJSON: String, longestPeriodSeconds: TimeInterval = 86400,
+         experiments: [String: String] = [:], enrolled: Set<String> = []) {
+        self.fixture = EventHubFixture.active(settingsJSON, experimentSettings: experiments, enrolled: enrolled)
+        self.longestPeriodSeconds = longestPeriodSeconds
     }
 
     var manager: EventHub { fixture.manager }
@@ -71,15 +80,37 @@ final class SpecFixture {
 
     /// A browser-native event: no tab, no URL, and so never de-duplicated.
     func sendNative(_ type: String, payload: [String: String]) {
-        fixture.manager.handleImmediateEvent(type, data: payload)
+        fixture.manager.handleNativeEvent(type, data: payload)
+    }
+
+    // MARK: Configuration lifecycle
+
+    /// Enrols the user in `experiments`, replacing any previous enrollment.
+    func enroll(in experiments: Set<String>) {
+        fixture.setEnrolled(experiments)
+    }
+
+    /// Applies a new remote config for the experiment subfeatures, replacing the previous one.
+    func setExperiments(_ experiments: [String: String]) {
+        fixture.setExperimentSettings(experiments)
+    }
+
+    /// Turns the `eventHub` feature itself on or off, as its remote `state` would (M-LIF-6, T-GEN-P1).
+    func setFeatureEnabled(_ enabled: Bool) {
+        fixture.setEnabled(enabled)
     }
 
     // MARK: Observation
 
-    /// Ends each running period once, per the suites' model: events are delivered, then the current
-    /// period ends.
+    /// Ends each running period exactly once, per the suites' model: events are delivered, then each
+    /// period pixel's current period ends.
+    ///
+    /// One clock jump suffices however many period lengths are configured, and however far apart they
+    /// are. A rollover starts the replacement period at `now` rather than at the boundary just passed,
+    /// so a pixel whose period elapsed during the jump fires once and its new period is then still
+    /// running — a 1-day and a 7-day pixel both end once here, and neither ends twice.
     func endPeriod() {
-        fixture.advance(by: periodSeconds)
+        fixture.advance(by: longestPeriodSeconds)
     }
 
     /// Every pixel fired, written as the specifications write them — `name?param=value`, sorted so a
@@ -89,15 +120,27 @@ final class SpecFixture {
     /// rather than `reason=%22overlay%22`); the encoding itself is pinned separately, by
     /// `EventHubDataParameterTests`. The time-derived `attributionPeriod` is excluded, as the suites
     /// specify.
-    var fired: [String] {
+    var fired: [String] { describe(decodingValues: true) }
+
+    /// As `fired`, but with parameter values left exactly as they leave EventHub — still
+    /// percent-encoded. For the cases that pin the wire form rather than the value (T-DAT-3, T-DAT-5),
+    /// which `fired` cannot express because it decodes.
+    var firedEncoded: [String] { describe(decodingValues: false) }
+
+    private func describe(decodingValues: Bool) -> [String] {
         fixture.fired.map { pixel in
             let parameters = pixel.parameters
                 .filter { $0.key != "attributionPeriod" }
                 .sorted { $0.key < $1.key }
-                .map { "\($0.key)=\($0.value.removingPercentEncoding ?? $0.value)" }
+                .map { "\($0.key)=\(decodingValues ? ($0.value.removingPercentEncoding ?? $0.value) : $0.value)" }
                 .joined(separator: "&")
             return parameters.isEmpty ? pixel.name : "\(pixel.name)?\(parameters)"
         }
         .sorted()
     }
+
+    /// Every conversion request handed to the experiment framework and accepted by it, written as
+    /// `experiment/metric/window/threshold` and sorted — the shape of the metrics specification's
+    /// derived-request table, so a case can state its complete expected set.
+    var requested: [String] { fixture.requested }
 }

--- a/SharedPackages/EventHub/Sources/EventHubTests/TestSupport/SpecFixture.swift
+++ b/SharedPackages/EventHub/Sources/EventHubTests/TestSupport/SpecFixture.swift
@@ -117,10 +117,9 @@ final class SpecFixture {
     /// case can state its complete expected set and an over-fire fails as loudly as a missing pixel.
     ///
     /// Values appear exactly as EventHub emits them, which for a data parameter is the compact JSON the
-    /// cases quote (`reason="overlay"`). Deliberately no percent-decoding: EventHub no longer encodes —
-    /// the transport applies the wire's single encoding — and decoding here would corrupt a payload
-    /// value that legitimately contains a `%`. The time-derived `attributionPeriod` is excluded, as the
-    /// suites specify.
+    /// cases quote (`reason="overlay"`). Deliberately no percent-decoding: nothing here is encoded, and
+    /// decoding would corrupt a payload value that legitimately contains a `%`. The time-derived
+    /// `attributionPeriod` is excluded, as the suites specify.
     var fired: [String] {
         fixture.fired.map { pixel in
             let parameters = pixel.parameters

--- a/SharedPackages/EventHub/Sources/EventHubTests/TestSupport/SpecFixture.swift
+++ b/SharedPackages/EventHub/Sources/EventHubTests/TestSupport/SpecFixture.swift
@@ -116,23 +116,17 @@ final class SpecFixture {
     /// Every pixel fired, written as the specifications write them — `name?param=value`, sorted so a
     /// case can state its complete expected set and an over-fire fails as loudly as a missing pixel.
     ///
-    /// Data values are percent-decoded back to the compact JSON the cases quote (`reason="overlay"`
-    /// rather than `reason=%22overlay%22`); the encoding itself is pinned separately, by
-    /// `EventHubDataParameterTests`. The time-derived `attributionPeriod` is excluded, as the suites
-    /// specify.
-    var fired: [String] { describe(decodingValues: true) }
-
-    /// As `fired`, but with parameter values left exactly as they leave EventHub — still
-    /// percent-encoded. For the cases that pin the wire form rather than the value (T-DAT-3, T-DAT-5),
-    /// which `fired` cannot express because it decodes.
-    var firedEncoded: [String] { describe(decodingValues: false) }
-
-    private func describe(decodingValues: Bool) -> [String] {
+    /// Values appear exactly as EventHub emits them, which for a data parameter is the compact JSON the
+    /// cases quote (`reason="overlay"`). Deliberately no percent-decoding: EventHub no longer encodes —
+    /// the transport applies the wire's single encoding — and decoding here would corrupt a payload
+    /// value that legitimately contains a `%`. The time-derived `attributionPeriod` is excluded, as the
+    /// suites specify.
+    var fired: [String] {
         fixture.fired.map { pixel in
             let parameters = pixel.parameters
                 .filter { $0.key != "attributionPeriod" }
                 .sorted { $0.key < $1.key }
-                .map { "\($0.key)=\(decodingValues ? ($0.value.removingPercentEncoding ?? $0.value) : $0.value)" }
+                .map { "\($0.key)=\($0.value)" }
                 .joined(separator: "&")
             return parameters.isEmpty ? pixel.name : "\(pixel.name)?\(parameters)"
         }

--- a/SharedPackages/EventHub/Sources/EventHubTests/TestSupport/SpyConversionReporting.swift
+++ b/SharedPackages/EventHub/Sources/EventHubTests/TestSupport/SpyConversionReporting.swift
@@ -1,0 +1,77 @@
+//
+//  SpyConversionReporting.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+@testable import EventHub
+
+/// Test double for `EventHubConversionReporting`: records every conversion request the hub hands to the
+/// Native Apps experiment framework. `EventHubFixture` exposes the recording as `.requested`.
+///
+/// It replicates exactly one line of the real framework — the enrollment gate that opens
+/// `PixelKit.fireExperimentPixelIfThresholdReached`:
+///
+///     guard let experimentData = featureFlagger.allActiveExperiments[subfeatureID] else { return }
+///
+/// That gate belongs to the framework, not the hub: per the Tech Design the metrics handler is
+/// stateless, with no enrollment check of its own. Observing requests just *after* it is what makes
+/// M-SEL-6 and M-SEL-7 ("an unenrolled experiment requests nothing") assertable without dragging
+/// PixelKit's window arithmetic, enrollment dates and event store into a specification test.
+///
+/// `allActiveExperiments` already excludes an experiment whose config `state` is `disabled`, keeping
+/// only `.enabled` and `.disabled(.targetDoesNotMatch)`, so removing an ID from `enrolled` models both
+/// un-enrolling and disabling in config (M-LIF-5).
+final class SpyConversionReporting: EventHubConversionReporting {
+    /// The experiments the user is currently enrolled in and which are currently enabled. Settable
+    /// mid-test, so a case can enroll between phases (M-LIF-1, M-LIF-3).
+    var enrolled: Set<String> = []
+
+    /// One recorded request. A local type rather than `MetricRequest`, whose `event` field the
+    /// reporting seam deliberately does not carry: by the time a request is made the event has already
+    /// done its job of selecting it.
+    struct Recorded: Equatable {
+        let experiment: String
+        let metric: String
+        let windowDays: ClosedRange<Int>
+        let threshold: Int
+    }
+
+    private(set) var requests: [Recorded] = []
+
+    func reportConversion(experiment: String, metric: String, windowDays: ClosedRange<Int>, threshold: Int) {
+        guard enrolled.contains(experiment) else { return }
+        requests.append(Recorded(experiment: experiment, metric: metric,
+                                 windowDays: windowDays, threshold: threshold))
+    }
+
+    /// Every request accepted, written as `experiment/metric/window/threshold` and sorted, so a case can
+    /// state its complete expected set and an over-request fails as loudly as a missing one.
+    ///
+    /// The window is rendered the way the specification's derived-request table writes it — and the way
+    /// PixelKit's own `conversionWindowDays` pixel parameter does — `"N"` for a single-day window and
+    /// `"low-high"` otherwise.
+    var requested: [String] {
+        requests
+            .map { request in
+                let window = request.windowDays.lowerBound == request.windowDays.upperBound
+                    ? "\(request.windowDays.lowerBound)"
+                    : "\(request.windowDays.lowerBound)-\(request.windowDays.upperBound)"
+                return "\(request.experiment)/\(request.metric)/\(window)/\(request.threshold)"
+            }
+            .sorted()
+    }
+}

--- a/SharedPackages/EventHub/Sources/EventHubTests/Unit/Config/EventHubConfigParserTests.swift
+++ b/SharedPackages/EventHub/Sources/EventHubTests/Unit/Config/EventHubConfigParserTests.swift
@@ -308,4 +308,95 @@ struct EventHubConfigParserTests {
 
         #expect(parser.serializePixelConfig(config) != nil)
     }
+
+    // MARK: parseMetrics
+
+    /// A flattened request rendered as `metric/event/window/threshold`, so expectations read compactly.
+    private func requests(_ json: String, experiment: String = "exp1") -> [String] {
+        parser.parseMetrics(experiment: experiment, settingsJSON: json)
+            .map { "\($0.metric)/\($0.event)/\($0.windowDays.lowerBound)-\($0.windowDays.upperBound)/\($0.threshold)" }
+            .sorted()
+    }
+
+    @Test("parseMetrics multiplies windows by thresholds within a group and unions groups")
+    func parseMetricsMultipliesWindowsByThresholds() {
+        let json = """
+        { "metrics": { "searchLike": { "event": "searchPerformed", "conversions": [
+            { "windows": [[0, 0], [1, 1]], "thresholds": [1] },
+            { "windows": [[0, 7]], "thresholds": [2, 3] } ] } } }
+        """
+        #expect(requests(json) == [
+            "searchLike/searchPerformed/0-0/1",
+            "searchLike/searchPerformed/0-7/2",
+            "searchLike/searchPerformed/0-7/3",
+            "searchLike/searchPerformed/1-1/1",
+        ])
+    }
+
+    @Test("parseMetrics carries the declaring experiment on every request")
+    func parseMetricsCarriesDeclaringExperiment() {
+        let json = """
+        { "metrics": { "m": { "event": "e", "conversions": [ { "windows": [[0, 7]], "thresholds": [1] } ] } } }
+        """
+        let parsed = parser.parseMetrics(experiment: "contentScopeExperiment1", settingsJSON: json)
+        #expect(parsed == [MetricRequest(experiment: "contentScopeExperiment1", event: "e", metric: "m",
+                                         windowDays: 0...7, threshold: 1)])
+    }
+
+    @Test("parseMetrics returns nothing when the settings declare no metrics")
+    func parseMetricsReturnsNothingWithoutMetricsKey() {
+        // The normal case: `metrics` is optional and most experiments declare none.
+        #expect(requests("{}").isEmpty)
+        #expect(requests(#"{ "controlUrl": "a.json", "treatmentUrl": "b.json" }"#).isEmpty)
+    }
+
+    @Test("parseMetrics ignores the other settings a TDS experiment carries")
+    func parseMetricsIgnoresOtherSettings() {
+        let json = """
+        { "controlUrl": "a.json", "treatmentUrl": "b.json",
+          "metrics": { "m": { "event": "e", "conversions": [ { "windows": [[0, 7]], "thresholds": [1] } ] } } }
+        """
+        #expect(requests(json) == ["m/e/0-7/1"])
+    }
+
+    @Test("parseMetrics returns nothing for settings that are not JSON")
+    func parseMetricsReturnsNothingForMalformedJSON() {
+        #expect(requests("not json at all").isEmpty)
+    }
+
+    @Test("parseMetrics skips a metric with no event and keeps its siblings")
+    func parseMetricsSkipsMetricWithNoEvent() {
+        let json = """
+        { "metrics": {
+            "broken": { "conversions": [ { "windows": [[0, 7]], "thresholds": [1] } ] },
+            "fine": { "event": "e", "conversions": [ { "windows": [[0, 7]], "thresholds": [1] } ] }
+        } }
+        """
+        #expect(requests(json) == ["fine/e/0-7/1"])
+    }
+
+    @Test("parseMetrics drops an unusable window and keeps the rest", arguments: [
+        "[7, 0]",       // inverted: `ClosedRange` would trap
+        "[-1, 7]",      // negative day bound
+        "[0]",          // not a pair
+        "[0, 1, 2]",    // not a pair
+    ])
+    func parseMetricsDropsUnusableWindow(window: String) {
+        let json = """
+        { "metrics": { "m": { "event": "e", "conversions": [
+            { "windows": [\(window), [0, 7]], "thresholds": [1] } ] } } }
+        """
+        #expect(requests(json) == ["m/e/0-7/1"])
+    }
+
+    @Test("parseMetrics drops a threshold below one", arguments: [0, -1])
+    func parseMetricsDropsThresholdBelowOne(threshold: Int) {
+        // A threshold below 1 would have the framework convert on every occurrence, so a config typo
+        // would become pixel spam.
+        let json = """
+        { "metrics": { "m": { "event": "e", "conversions": [
+            { "windows": [[0, 7]], "thresholds": [\(threshold), 2] } ] } } }
+        """
+        #expect(requests(json) == ["m/e/0-7/2"])
+    }
 }

--- a/SharedPackages/EventHub/Sources/EventHubTests/Unit/Core/EventHubDataParameterTests.swift
+++ b/SharedPackages/EventHub/Sources/EventHubTests/Unit/Core/EventHubDataParameterTests.swift
@@ -19,6 +19,9 @@
 import Testing
 @testable import EventHub
 
+/// What is left of this suite after the telemetry specification cases moved to `TelemetrySpecTests`:
+/// the two behaviours no case covers. Value encoding (T-DAT-3, T-DAT-5), last-value-wins (T-DAT-1) and
+/// the absent-key rule (T-DAT-2) all live there now, asserted against the specification's own fixture.
 @Suite("EventHub data parameters")
 struct EventHubDataParameterTests {
     static let immediateDataConfig = """
@@ -28,29 +31,6 @@ struct EventHubDataParameterTests {
         "parameters": { "loginState": { "template": "data", "dataKey": "loginState" } }
     } } }
     """
-
-    @Test("immediate data param encodes a string value")
-    func immediateDataParamEncodesStringValue() {
-        let f = EventHubFixture.active(Self.immediateDataConfig)
-        f.manager.handleWebEvent(EventHubFixture.eventWithData("login", dataJSON: #"{ "loginState": "logged-in" }"#), tabID: .new())
-        #expect(f.fired.count == 1)
-        #expect(f.fired.first?.parameters["loginState"] == "%22logged-in%22")
-    }
-
-    @Test("immediate data param encodes an object value")
-    func immediateDataParamEncodesObjectValue() {
-        let config = """
-        { "telemetry": { "webEvent_login": {
-            "state": "enabled",
-            "trigger": { "type": "immediate_v2", "source": "login" },
-            "parameters": { "payload": { "template": "data", "dataKey": "payload" } }
-        } } }
-        """
-        let f = EventHubFixture.active(config)
-        f.manager.handleWebEvent(EventHubFixture.eventWithData("login", dataJSON: #"{ "payload": { "a": true } }"#), tabID: .new())
-        #expect(f.fired.count == 1)
-        #expect(f.fired.first?.parameters["payload"] == "%7B%22a%22%3Atrue%7D")
-    }
 
     @Test("immediate data param encodes a null value")
     func immediateDataParamEncodesNullValue() {
@@ -70,24 +50,4 @@ struct EventHubDataParameterTests {
         #expect(f.fired.isEmpty)
     }
 
-    @Test("aggregate data param uses the last value from a matching source")
-    func aggregateDataParamUsesLastValueFromMatchingSource() {
-        let config = """
-        { "telemetry": { "yt": {
-            "state": "enabled",
-            "trigger": { "period": { "seconds": 60 } },
-            "parameters": {
-                "count": { "template": "counter", "source": "yt", "buckets": {"0-9": {"gte": 0, "lt": 10}, "10+": {"gte": 10}} },
-                "loginState": { "template": "data", "source": "yt", "dataKey": "loginState" }
-            }
-        } } }
-        """
-        let f = EventHubFixture.active(config)
-        f.manager.handleWebEvent(EventHubFixture.eventWithData("yt", dataJSON: #"{ "loginState": "a" }"#), tabID: .new())
-        f.manager.handleWebEvent(EventHubFixture.eventWithData("yt", dataJSON: #"{ "loginState": "b" }"#), tabID: .new())
-        f.advance(by: 60)
-
-        #expect(f.fired.count == 1)
-        #expect(f.fired.first?.parameters["loginState"] == "%22b%22")
-    }
 }

--- a/SharedPackages/EventHub/Sources/EventHubTests/Unit/Core/EventHubDataParameterTests.swift
+++ b/SharedPackages/EventHub/Sources/EventHubTests/Unit/Core/EventHubDataParameterTests.swift
@@ -19,9 +19,9 @@
 import Testing
 @testable import EventHub
 
-/// What is left of this suite after the telemetry specification cases moved to `TelemetrySpecTests`:
-/// the two behaviours no case covers. Value encoding (T-DAT-3, T-DAT-5), last-value-wins (T-DAT-1) and
-/// the absent-key rule (T-DAT-2) all live there now, asserted against the specification's own fixture.
+/// Component-level data-parameter behaviour that the telemetry specification does not state as a case:
+/// a `null` value, and the guard that stops a pixel firing when none of its data parameters resolve.
+/// The specification's own data-parameter cases, T-DAT-1 to T-DAT-5, live in `TelemetrySpecTests`.
 @Suite("EventHub data parameters")
 struct EventHubDataParameterTests {
     static let immediateDataConfig = """

--- a/SharedPackages/EventHub/Sources/EventHubTests/Unit/Core/EventHubNativeIngressTests.swift
+++ b/SharedPackages/EventHub/Sources/EventHubTests/Unit/Core/EventHubNativeIngressTests.swift
@@ -100,7 +100,8 @@ struct EventHubNativeIngressTests {
         let f = EventHubFixture.active(Self.immediateDataConfig)
         f.manager.handleNativeEvent("login", data: LoginPayload(loginState: "logged-in"))
         #expect(f.fired.count == 1)
-        #expect(f.fired.first?.parameters["loginState"] == "%22logged-in%22")
+        // Compact JSON, unencoded: the transport applies the wire's single encoding, not EventHub.
+        #expect(f.fired.first?.parameters["loginState"] == #""logged-in""#)
     }
 
     @Test("handleNativeEvent reaches every handler")
@@ -151,7 +152,7 @@ struct EventHubNativeIngressTests {
         f.manager.handleNativeEvent("yt", data: LoginPayload(loginState: "b"))
         f.advance(by: 60)
         #expect(f.fired.count == 1)
-        #expect(f.fired.first?.parameters["loginState"] == "%22b%22")
+        #expect(f.fired.first?.parameters["loginState"] == #""b""#)
     }
 
     @Test("handleNativeEvent does nothing when the feature is disabled")

--- a/SharedPackages/EventHub/Sources/EventHubTests/Unit/Core/EventHubNativeIngressTests.swift
+++ b/SharedPackages/EventHub/Sources/EventHubTests/Unit/Core/EventHubNativeIngressTests.swift
@@ -56,8 +56,8 @@ struct EventHubNativeIngressTests {
     } } }
     """
 
-    // One immediate pixel and one period counter sharing the same source ("test"), so each native
-    // method can be shown to drive only its own trigger type.
+    // One immediate pixel and one period counter sharing the same source ("test"), so a single native
+    // event can be shown to reach both trigger types.
     static let bothConfig = """
     { "telemetry": {
         "imm": { "state": "enabled", "trigger": { "type": "immediate_v2", "source": "test" }, "parameters": {} },
@@ -77,6 +77,9 @@ struct EventHubNativeIngressTests {
     } } }
     """
 
+    /// A native event payload, for the cases that check one reaches `data`-template parameters.
+    private struct LoginPayload: Encodable { let loginState: String }
+
     /// A payload whose encoding throws, to exercise the serialisation fail-safe.
     private struct ThrowingData: Encodable {
         func encode(to encoder: Encoder) throws {
@@ -84,118 +87,93 @@ struct EventHubNativeIngressTests {
         }
     }
 
-    // MARK: handleImmediateEvent
-
-    @Test("handleImmediateEvent fires the matching immediate pixel")
-    func handleImmediateEventFiresMatchingImmediatePixel() {
+    @Test("handleNativeEvent fires the matching immediate pixel")
+    func handleNativeEventFiresMatchingImmediatePixel() {
         let f = EventHubFixture.active(Self.immediateConfig)
-        f.manager.handleImmediateEvent("impression")
+        f.manager.handleNativeEvent("impression")
         #expect(f.fired.count == 1)
         #expect(f.fired.first?.name == "webEvent_impression")
     }
 
-    @Test("handleImmediateEvent forwards the data object to data-template params")
-    func handleImmediateEventForwardsDataObject() {
-        struct LoginPayload: Encodable { let loginState: String }
+    @Test("handleNativeEvent forwards the data object to data-template params")
+    func handleNativeEventForwardsDataObject() {
         let f = EventHubFixture.active(Self.immediateDataConfig)
-        f.manager.handleImmediateEvent("login", data: LoginPayload(loginState: "logged-in"))
+        f.manager.handleNativeEvent("login", data: LoginPayload(loginState: "logged-in"))
         #expect(f.fired.count == 1)
         #expect(f.fired.first?.parameters["loginState"] == "%22logged-in%22")
     }
 
-    @Test("handleImmediateEvent does not count toward a period counter of the same source")
-    func handleImmediateEventDoesNotCountPeriodCounter() {
+    @Test("handleNativeEvent reaches every handler")
+    func handleNativeEventReachesEveryHandler() {
+        // The positive statement of D-NAT-P1: a native occurrence is delivered to *every* handler, so
+        // one call both fires the immediate pixel and counts the period counter. This replaces the pair
+        // of tests that used to pin the opposite — that `handleImmediateEvent` skipped counters and
+        // `handleAggregatedEvent` skipped immediate pixels — a split no caller ever used.
         let f = EventHubFixture.active(Self.bothConfig)
-        f.manager.handleImmediateEvent("test")
+        f.manager.handleNativeEvent("test")
         #expect(f.fired.count == 1)
         #expect(f.fired.first?.name == "imm")
-        #expect(f.count(of: "per") == 0)
+        #expect(f.count(of: "per") == 1)
     }
 
-    @Test("handleImmediateEvent fires nothing when the feature is disabled")
-    func handleImmediateEventFiresNothingWhenDisabled() {
-        let f = EventHubFixture.active(Self.immediateConfig, enabled: false)
-        f.manager.handleImmediateEvent("impression")
-        #expect(f.fired.isEmpty)
-    }
-
-    @Test("handleImmediateEvent fires nothing for an unknown or empty type", arguments: ["unknown", ""])
-    func handleImmediateEventFiresNothingForUnknownOrEmptyType(type: String) {
-        let f = EventHubFixture.active(Self.immediateConfig)
-        f.manager.handleImmediateEvent(type)
-        #expect(f.fired.isEmpty)
-    }
-
-    @Test("handleImmediateEvent ignores unserialisable data and still fires")
-    func handleImmediateEventIgnoresUnserialisableDataAndStillFires() {
-        let f = EventHubFixture.active(Self.immediateConfig)
-        // The payload's encode(to:) throws; the fail-safe path drops the data and a parameter-less
-        // immediate pixel still fires rather than the whole call aborting.
-        f.manager.handleImmediateEvent("impression", data: ThrowingData())
-        #expect(f.fired.count == 1)
-    }
-
-    // MARK: handleAggregatedEvent
-
-    @Test("handleAggregatedEvent increments the matching counter")
-    func handleAggregatedEventIncrementsMatchingCounter() {
+    @Test("handleNativeEvent increments the matching counter")
+    func handleNativeEventIncrementsMatchingCounter() {
         let f = EventHubFixture.active(Self.periodConfig)
-        f.manager.handleAggregatedEvent("test")
+        f.manager.handleNativeEvent("test")
         #expect(f.count(of: Self.pixel1) == 1)
     }
 
-    @Test("handleAggregatedEvent counts every call with no per-tab dedup")
-    func handleAggregatedEventCountsEveryCallNoDedup() {
+    @Test("handleNativeEvent counts every call with no per-tab dedup")
+    func handleNativeEventCountsEveryCallNoDedup() {
+        // No tab context means no page to de-duplicate against, so every occurrence counts (D-NAT-P1).
         let f = EventHubFixture.active(Self.periodConfig)
-        // The differentiator from the web path: three identical native events (no tab) count three
-        // times, whereas three same-tab web events on one page would dedup to one.
-        f.manager.handleAggregatedEvent("test")
-        f.manager.handleAggregatedEvent("test")
-        f.manager.handleAggregatedEvent("test")
+        f.manager.handleNativeEvent("test")
+        f.manager.handleNativeEvent("test")
+        f.manager.handleNativeEvent("test")
         #expect(f.count(of: Self.pixel1) == 3)
     }
 
-    @Test("handleAggregatedEvent stops at the open-ended bucket")
-    func handleAggregatedEventStopsAtOpenEndedBucket() throws {
+    @Test("handleNativeEvent stops at the open-ended bucket")
+    func handleNativeEventStopsAtOpenEndedBucket() throws {
         let f = EventHubFixture.active(Self.periodConfig)
-        for _ in 0..<41 {
-            f.manager.handleAggregatedEvent("test")
+        for _ in 0..<45 {
+            f.manager.handleNativeEvent("test")
         }
         let state = try #require(f.state(of: Self.pixel1))
-        #expect(state.params["count"]?.stopCounting == true)
         #expect(state.params["count"]?.value == 40)
+        #expect(state.params["count"]?.stopCounting == true)
     }
 
-    @Test("handleAggregatedEvent records the last data value from a matching source")
-    func handleAggregatedEventRecordsLastDataValue() {
-        struct LoginPayload: Encodable { let loginState: String }
+    @Test("handleNativeEvent records the last data value from a matching source")
+    func handleNativeEventRecordsLastDataValue() {
         let f = EventHubFixture.active(Self.periodDataConfig)
-        f.manager.handleAggregatedEvent("yt", data: LoginPayload(loginState: "a"))
-        f.manager.handleAggregatedEvent("yt", data: LoginPayload(loginState: "b"))
+        f.manager.handleNativeEvent("yt", data: LoginPayload(loginState: "a"))
+        f.manager.handleNativeEvent("yt", data: LoginPayload(loginState: "b"))
         f.advance(by: 60)
         #expect(f.fired.count == 1)
         #expect(f.fired.first?.parameters["loginState"] == "%22b%22")
     }
 
-    @Test("handleAggregatedEvent does not fire an immediate pixel of the same source")
-    func handleAggregatedEventDoesNotFireImmediatePixel() {
-        let f = EventHubFixture.active(Self.bothConfig)
-        f.manager.handleAggregatedEvent("test")
+    @Test("handleNativeEvent does nothing when the feature is disabled")
+    func handleNativeEventDoesNothingWhenDisabled() {
+        let f = EventHubFixture.active(Self.bothConfig, enabled: false)
+        f.manager.handleNativeEvent("test")
         #expect(f.fired.isEmpty)
-        #expect(f.count(of: "per") == 1)
+        #expect(f.state(of: "per") == nil)
     }
 
-    @Test("handleAggregatedEvent counts nothing when the feature is disabled")
-    func handleAggregatedEventCountsNothingWhenDisabled() {
-        let f = EventHubFixture.active(Self.periodConfig, enabled: false)
-        f.manager.handleAggregatedEvent("test")
-        #expect(f.state(of: Self.pixel1) == nil)
+    @Test("handleNativeEvent does nothing for an unknown or empty type", arguments: ["unknown", ""])
+    func handleNativeEventDoesNothingForUnknownOrEmptyType(type: String) {
+        let f = EventHubFixture.active(Self.bothConfig)
+        f.manager.handleNativeEvent(type)
+        #expect(f.fired.isEmpty)
+        #expect(f.count(of: "per") == 0)
     }
 
-    @Test("handleAggregatedEvent counts nothing for an unknown or empty type", arguments: ["unknown", ""])
-    func handleAggregatedEventCountsNothingForUnknownOrEmptyType(type: String) {
-        let f = EventHubFixture.active(Self.periodConfig)
-        f.manager.handleAggregatedEvent(type)
-        #expect(f.count(of: Self.pixel1) == 0)
+    @Test("handleNativeEvent ignores unserialisable data and still fires")
+    func handleNativeEventIgnoresUnserialisableDataAndStillFires() {
+        let f = EventHubFixture.active(Self.immediateConfig)
+        f.manager.handleNativeEvent("impression", data: ThrowingData())
+        #expect(f.fired.count == 1)
     }
 }

--- a/SharedPackages/EventHub/Sources/EventHubTests/Unit/Core/EventHubNativeIngressTests.swift
+++ b/SharedPackages/EventHub/Sources/EventHubTests/Unit/Core/EventHubNativeIngressTests.swift
@@ -107,9 +107,7 @@ struct EventHubNativeIngressTests {
     @Test("handleNativeEvent reaches every handler")
     func handleNativeEventReachesEveryHandler() {
         // The positive statement of D-NAT-P1: a native occurrence is delivered to *every* handler, so
-        // one call both fires the immediate pixel and counts the period counter. This replaces the pair
-        // of tests that used to pin the opposite — that `handleImmediateEvent` skipped counters and
-        // `handleAggregatedEvent` skipped immediate pixels — a split no caller ever used.
+        // one call both fires the immediate pixel and counts the period counter.
         let f = EventHubFixture.active(Self.bothConfig)
         f.manager.handleNativeEvent("test")
         #expect(f.fired.count == 1)

--- a/SharedPackages/EventHub/Sources/EventHubTests/Unit/Core/EventHubTests.swift
+++ b/SharedPackages/EventHub/Sources/EventHubTests/Unit/Core/EventHubTests.swift
@@ -198,20 +198,9 @@ struct EventHubTests {
         #expect(f.fired.isEmpty)
     }
 
-    @Test("skips firing when no bucket matches")
-    func skipsFiringWhenNoBucketMatches() {
-        // Buckets start at 5, so a zero count matches nothing and no pixel is fired.
-        let config = """
-        { "telemetry": { "p": {
-            "state": "enabled",
-            "trigger": { "period": { "seconds": 60 } },
-            "parameters": { "count": { "template": "counter", "source": "test", "buckets": {"5-9": {"gte": 5, "lt": 10}} } }
-        } } }
-        """
-        let f = EventHubFixture.active(config)
-        f.advance(by: 60)
-        #expect(f.fired.isEmpty)
-    }
+    // "skips firing when no bucket matches" moved to `TelemetrySpecTests` as T-CNT-3, where it is
+    // asserted against the specification's fixture — a pixel with no zero bucket staying silent while
+    // the pixels that have one still fire.
 
     @Test("resets state and starts a new period after firing")
     func resetsStateAndStartsNewPeriodAfterFiring() throws {

--- a/SharedPackages/EventHub/Sources/EventHubTests/Unit/Core/EventHubTests.swift
+++ b/SharedPackages/EventHub/Sources/EventHubTests/Unit/Core/EventHubTests.swift
@@ -198,10 +198,6 @@ struct EventHubTests {
         #expect(f.fired.isEmpty)
     }
 
-    // "skips firing when no bucket matches" moved to `TelemetrySpecTests` as T-CNT-3, where it is
-    // asserted against the specification's fixture — a pixel with no zero bucket staying silent while
-    // the pixels that have one still fire.
-
     @Test("resets state and starts a new period after firing")
     func resetsStateAndStartsNewPeriodAfterFiring() throws {
         let f = EventHubFixture.active(Self.dayConfig)

--- a/SharedPackages/EventHub/Sources/EventHubTests/Unit/Core/ParameterTests.swift
+++ b/SharedPackages/EventHub/Sources/EventHubTests/Unit/Core/ParameterTests.swift
@@ -112,8 +112,9 @@ struct DataParameterTests {
 
     @Test("restoreState round trips lastDataValue")
     func restoreStateRoundTrips() {
+        // Compact JSON, the form the parameter now stores and emits — the transport does the encoding.
         let parameter = DataParameter(dataKey: "loginState")
-        parameter.restoreState(ParamState(value: 0, lastDataValue: "%22a%22"))
-        #expect(parameter.queryValue() == "%22a%22")
+        parameter.restoreState(ParamState(value: 0, lastDataValue: #""a""#))
+        #expect(parameter.queryValue() == #""a""#)
     }
 }

--- a/SharedPackages/EventHub/Sources/EventHubTests/Unit/Core/ParameterTests.swift
+++ b/SharedPackages/EventHub/Sources/EventHubTests/Unit/Core/ParameterTests.swift
@@ -112,7 +112,7 @@ struct DataParameterTests {
 
     @Test("restoreState round trips lastDataValue")
     func restoreStateRoundTrips() {
-        // Compact JSON, the form the parameter now stores and emits — the transport does the encoding.
+        // Compact JSON, the form the parameter stores and emits — the transport does the encoding.
         let parameter = DataParameter(dataKey: "loginState")
         parameter.restoreState(ParamState(value: 0, lastDataValue: #""a""#))
         #expect(parameter.queryValue() == #""a""#)

--- a/SharedPackages/EventHub/Sources/EventHubTests/Unit/Wiring/EventHubExperimentSettingsTests.swift
+++ b/SharedPackages/EventHub/Sources/EventHubTests/Unit/Wiring/EventHubExperimentSettingsTests.swift
@@ -1,0 +1,153 @@
+//
+//  EventHubExperimentSettingsTests.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Testing
+import Foundation
+import PrivacyConfig
+import PrivacyConfigTestsUtils
+@testable import EventHub
+
+/// The step that finds the experiments declaring metrics, reading a real `AppPrivacyConfiguration`.
+///
+/// The metrics specification suite injects its experiment settings straight into the hub, which is
+/// what keeps those 18 cases readable — but it means the reading itself runs in no case there. In
+/// particular M-SEL-8's claim that *both* experiment parent features are read is invisible to that
+/// suite: removing a parent from `parentFeatures` leaves every spec case green. This is where that
+/// claim is pinned.
+@Suite("EventHubExperimentSettings")
+struct EventHubExperimentSettingsTests {
+
+    /// A privacy config with one experiment under each parent feature that may declare metrics, using
+    /// the specification fixture's own IDs: CSS experiments live under `contentScopeExperiments`, and
+    /// on Apple TDS experiments live under `contentBlocking`.
+    private static let bothParents = """
+    {
+        "readme": "test",
+        "version": 1,
+        "features": {
+            "contentScopeExperiments": {
+                "state": "enabled",
+                "exceptions": [],
+                "features": {
+                    "contentScopeExperiment1": {
+                        "state": "enabled",
+                        "settings": { "metrics": { "captchaSeen": { "event": "captchaDetected" } } }
+                    }
+                }
+            },
+            "contentBlocking": {
+                "state": "enabled",
+                "exceptions": [],
+                "features": {
+                    "tdsNextExperiment007": {
+                        "state": "enabled",
+                        "settings": { "metrics": { "pageLoad": { "event": "pageLoaded" } } }
+                    }
+                }
+            }
+        },
+        "unprotectedTemporary": []
+    }
+    """
+
+    private func configuration(_ json: String) throws -> AppPrivacyConfiguration {
+        let data = try PrivacyConfigurationData(data: Data(json.utf8))
+        return AppPrivacyConfiguration(data: data,
+                                       identifier: "test",
+                                       localProtection: MockDomainsProtectionStore(),
+                                       internalUserDecider: MockInternalUserDecider())
+    }
+
+    @Test("both experiment parent features are read")
+    func bothExperimentParentFeaturesAreRead() throws {
+        // The wiring leg of M-SEL-8. Drop either entry from `parentFeatures` and this fails — which is
+        // exactly what the specification suite cannot see.
+        let result = EventHubExperimentSettings.current(try configuration(Self.bothParents))
+
+        #expect(result.keys.sorted() == ["contentScopeExperiment1", "tdsNextExperiment007"])
+        #expect(result["contentScopeExperiment1"]?.contains("captchaSeen") == true)
+        #expect(result["tdsNextExperiment007"]?.contains("pageLoad") == true)
+    }
+
+    @Test("parentFeatures names exactly the two features metrics may be declared under")
+    func parentFeaturesNamesTheTwoExperimentParents() {
+        // Stated as its own expectation so a change to the list is a deliberate act, not a side effect.
+        #expect(EventHubExperimentSettings.parentFeatures == [.contentScopeExperiments, .contentBlocking])
+    }
+
+    @Test("a subfeature with no settings is omitted")
+    func aSubfeatureWithNoSettingsIsOmitted() throws {
+        let result = EventHubExperimentSettings.current(try configuration("""
+        {
+            "readme": "test",
+            "version": 1,
+            "features": {
+                "contentScopeExperiments": {
+                    "state": "enabled",
+                    "exceptions": [],
+                    "features": {
+                        "withSettings":    { "state": "enabled", "settings": { "metrics": {} } },
+                        "withoutSettings": { "state": "enabled" }
+                    }
+                }
+            },
+            "unprotectedTemporary": []
+        }
+        """))
+
+        #expect(result.keys.sorted() == ["withSettings"])
+    }
+
+    @Test("on a subfeature ID present under both parents, the first parent listed wins")
+    func onACollisionTheFirstParentListedWins() throws {
+        // Documented behaviour of `current(_:)`, and arbitrary by design — nothing downstream depends
+        // on which parent a metric came from, since a conversion request names only the subfeature.
+        // Pinned so the arbitrary choice cannot change unnoticed.
+        let result = EventHubExperimentSettings.current(try configuration("""
+        {
+            "readme": "test",
+            "version": 1,
+            "features": {
+                "contentScopeExperiments": {
+                    "state": "enabled",
+                    "exceptions": [],
+                    "features": { "sharedID": { "state": "enabled", "settings": { "from": "css" } } }
+                },
+                "contentBlocking": {
+                    "state": "enabled",
+                    "exceptions": [],
+                    "features": { "sharedID": { "state": "enabled", "settings": { "from": "tds" } } }
+                }
+            },
+            "unprotectedTemporary": []
+        }
+        """))
+
+        #expect(result.count == 1)
+        #expect(result["sharedID"]?.contains("css") == true)
+    }
+
+    @Test("a config declaring no experiment features yields nothing")
+    func aConfigWithNoExperimentFeaturesYieldsNothing() throws {
+        let result = EventHubExperimentSettings.current(try configuration("""
+        { "readme": "test", "version": 1, "features": {}, "unprotectedTemporary": [] }
+        """))
+
+        #expect(result.isEmpty)
+    }
+}

--- a/SharedPackages/EventHub/Sources/EventHubTests/Unit/Wiring/WebEventsHandlerTests.swift
+++ b/SharedPackages/EventHub/Sources/EventHubTests/Unit/Wiring/WebEventsHandlerTests.swift
@@ -28,8 +28,7 @@ struct WebEventsHandlerTests {
         func handleWebEvent(_ webEventData: [String: Any], tabID: EventHubTabID) {
             handledWebEvents.append((webEventData, tabID))
         }
-        func handleImmediateEvent(_ type: String, data: Encodable?) {}
-        func handleAggregatedEvent(_ type: String, data: Encodable?) {}
+        func handleNativeEvent(_ type: String, data: Encodable?) {}
         func onNavigationStarted(tabID: EventHubTabID, url: String) {}
         func onTabClosed(tabID: EventHubTabID) {}
         func onConfigChanged() {}

--- a/iOS/DuckDuckGo/EventHub/EventHubService.swift
+++ b/iOS/DuckDuckGo/EventHub/EventHubService.swift
@@ -52,6 +52,11 @@ final class EventHubService {
             privacyConfigurationManager.privacyConfig.isEnabled(featureKey: .eventHub))
         let settingsSubject = CurrentValueSubject<[String: Any]?, Never>(
             privacyConfigurationManager.privacyConfig.settings(for: PrivacyFeature.eventHub))
+        // Experiment metrics live in the CSS/TDS experiment subfeatures rather than in the `eventHub`
+        // feature, so they arrive on their own publisher rather than through `EventHubSettings` — which
+        // exists to strip consent-gated telemetry, and a conversion request carries nothing gated.
+        let experimentSettingsSubject = CurrentValueSubject<[String: String], Never>(
+            EventHubExperimentSettings.current(privacyConfigurationManager.privacyConfig))
 
         let settings = EventHubSettings(
             featureEnabledPublisher: enabledSubject.eraseToAnyPublisher(),
@@ -67,7 +72,9 @@ final class EventHubService {
             parser: parser,
             settings: settings,
             scheduler: DispatchQueueEventHubScheduler(queue: DispatchQueue(label: "com.duckduckgo.eventhub.scheduler")),
-            pixelFiring: IOSEventHubPixelFiring()
+            pixelFiring: IOSEventHubPixelFiring(),
+            conversionReporting: IOSEventHubConversionReporting(),
+            experimentSettings: experimentSettingsSubject.eraseToAnyPublisher()
         )
 
         // Pushing the new values is all that is needed: `EventHub` subscribes to both publishers and
@@ -81,6 +88,7 @@ final class EventHubService {
                 Logger.eventHub.debug("Remote config updated — pushing to EventHub (enabled=\(enabled, privacy: .public))")
                 enabledSubject.send(enabled)
                 settingsSubject.send(privacyConfigurationManager.privacyConfig.settings(for: PrivacyFeature.eventHub))
+                experimentSettingsSubject.send(EventHubExperimentSettings.current(privacyConfigurationManager.privacyConfig))
             }
             .store(in: &cancellables)
     }

--- a/iOS/DuckDuckGo/EventHub/IOSEventHubPixelFiring.swift
+++ b/iOS/DuckDuckGo/EventHub/IOSEventHubPixelFiring.swift
@@ -21,6 +21,7 @@ import Common
 import EventHub
 import Foundation
 import os.log
+import PixelExperimentKit
 import PixelKit
 
 /// PixelKit event for EventHub-originated pixels, shared by the telemetry and failure paths below.
@@ -62,5 +63,25 @@ final class IOSEventHubDebugEventMapping: EventMapping<EventHubDebugEvent> {
 
     override init(mapping: @escaping EventMapping<EventHubDebugEvent>.Mapping) {
         fatalError("Use init()")
+    }
+}
+
+/// Hands EventHub's experiment-metric conversion requests to the Native Apps experiment framework.
+///
+/// Lives beside the pixel-firing conformance rather than in the EventHub package: the package must not
+/// depend on `PixelExperimentKit`, whose product is already linked by this app target and whose
+/// products cannot be linked twice without breaking this project's test-target link graph.
+///
+/// Everything the framework owns happens past this call — enrollment and cohort resolution, conversion
+/// window containment, threshold accumulation, repeat suppression and the pixel itself. A request for
+/// an experiment the user is not enrolled in is a no-op there, which is why the hub does not filter.
+struct IOSEventHubConversionReporting: EventHubConversionReporting {
+
+    func reportConversion(experiment: String, metric: String, windowDays: ClosedRange<Int>, threshold: Int) {
+        Logger.eventHub.info("experiment metric conversion: \(experiment, privacy: .public)/\(metric, privacy: .public) window \(windowDays.lowerBound, privacy: .public)-\(windowDays.upperBound, privacy: .public) threshold \(threshold, privacy: .public)")
+        PixelKit.fireExperimentPixelIfThresholdReached(for: experiment,
+                                                       metric: metric,
+                                                       conversionWindowDays: windowDays,
+                                                       threshold: threshold)
     }
 }

--- a/iOS/SharedTestUtils/Mocks/BrowserServiceKit/PrivacyConfig/MockPrivacyConfiguration.swift
+++ b/iOS/SharedTestUtils/Mocks/BrowserServiceKit/PrivacyConfig/MockPrivacyConfiguration.swift
@@ -61,6 +61,10 @@ class MockPrivacyConfiguration: PrivacyConfiguration {
         return subfeatureSettings
     }
 
+    func allSubfeatureSettings(for feature: PrivacyFeature) -> [SubfeatureID: PrivacyConfigurationData.PrivacyFeature.SubfeatureSettings] {
+        [:]
+    }
+
     func exceptionsList(forFeature featureKey: PrivacyFeature) -> [String] { exceptionsList(featureKey) }
     var isFeatureKeyEnabled: ((PrivacyFeature, AppVersionProvider) -> Bool)?
     func isEnabled(featureKey: PrivacyFeature, versionProvider: AppVersionProvider) -> Bool {

--- a/iOS/SharedTestUtils/Mocks/BrowserServiceKit/PrivacyConfig/PrivacyConfigurationManagerMock.swift
+++ b/iOS/SharedTestUtils/Mocks/BrowserServiceKit/PrivacyConfig/PrivacyConfigurationManagerMock.swift
@@ -107,6 +107,10 @@ class PrivacyConfigurationMock: PrivacyConfiguration {
         return subfeatureSettings[subfeature.rawValue] ?? ""
     }
 
+    func allSubfeatureSettings(for feature: PrivacyFeature) -> [SubfeatureID: PrivacyConfigurationData.PrivacyFeature.SubfeatureSettings] {
+        [:]
+    }
+
     var userUnprotected = Set<String>()
     func userEnabledProtection(forDomain domain: String) {
         userUnprotected.remove(domain)

--- a/iOS/SharedTestUtils/Mocks/DuckDuckGo/Tabs/MockTabDelegate.swift
+++ b/iOS/SharedTestUtils/Mocks/DuckDuckGo/Tabs/MockTabDelegate.swift
@@ -311,8 +311,7 @@ final class StubEventHub: EventHubManaging {
     private(set) var closedTabIDs: [EventHubTabID] = []
 
     func handleWebEvent(_ webEventData: [String: Any], tabID: EventHubTabID) {}
-    func handleImmediateEvent(_ type: String, data: Encodable?) {}
-    func handleAggregatedEvent(_ type: String, data: Encodable?) {}
+    func handleNativeEvent(_ type: String, data: Encodable?) {}
 
     func onNavigationStarted(tabID: EventHubTabID, url: String) {
         navigationStarts.append((tabID, url))

--- a/macOS/DuckDuckGo/EventHub/MacOSEventHubIntegration.swift
+++ b/macOS/DuckDuckGo/EventHub/MacOSEventHubIntegration.swift
@@ -46,6 +46,11 @@ final class MacOSEventHubIntegration {
             privacyConfigurationManager.privacyConfig.isEnabled(featureKey: .eventHub))
         let settingsSubject = CurrentValueSubject<[String: Any]?, Never>(
             privacyConfigurationManager.privacyConfig.settings(for: PrivacyFeature.eventHub))
+        // Experiment metrics live in the CSS/TDS experiment subfeatures rather than in the `eventHub`
+        // feature, so they arrive on their own publisher rather than through `EventHubSettings` — which
+        // exists to strip consent-gated telemetry, and a conversion request carries nothing gated.
+        let experimentSettingsSubject = CurrentValueSubject<[String: String], Never>(
+            EventHubExperimentSettings.current(privacyConfigurationManager.privacyConfig))
 
         let settings = EventHubSettings(
             featureEnabledPublisher: enabledSubject.eraseToAnyPublisher(),
@@ -61,7 +66,9 @@ final class MacOSEventHubIntegration {
             parser: parser,
             settings: settings,
             scheduler: DispatchQueueEventHubScheduler(queue: DispatchQueue(label: "com.duckduckgo.eventhub.scheduler")),
-            pixelFiring: MacOSEventHubPixelFiring()
+            pixelFiring: MacOSEventHubPixelFiring(),
+            conversionReporting: MacOSEventHubConversionReporting(),
+            experimentSettings: experimentSettingsSubject.eraseToAnyPublisher()
         )
         self.eventHub = eventHub
 
@@ -76,6 +83,7 @@ final class MacOSEventHubIntegration {
                 Logger.eventHub.debug("Remote config updated — pushing to EventHub (enabled=\(enabled, privacy: .public))")
                 enabledSubject.send(enabled)
                 settingsSubject.send(privacyConfigurationManager.privacyConfig.settings(for: PrivacyFeature.eventHub))
+                experimentSettingsSubject.send(EventHubExperimentSettings.current(privacyConfigurationManager.privacyConfig))
             }
             .store(in: &cancellables)
     }

--- a/macOS/DuckDuckGo/EventHub/MacOSEventHubPixelFiring.swift
+++ b/macOS/DuckDuckGo/EventHub/MacOSEventHubPixelFiring.swift
@@ -20,6 +20,7 @@ import Common
 import EventHub
 import Foundation
 import os.log
+import PixelExperimentKit
 import PixelKit
 
 /// The macOS platform marker EventHub appends itself, rather than letting PixelKit derive one.
@@ -74,5 +75,25 @@ final class MacOSEventHubDebugEventMapping: EventMapping<EventHubDebugEvent> {
 
     override init(mapping: @escaping EventMapping<EventHubDebugEvent>.Mapping) {
         fatalError("Use init()")
+    }
+}
+
+/// Hands EventHub's experiment-metric conversion requests to the Native Apps experiment framework.
+///
+/// Lives beside the pixel-firing conformance rather than in the EventHub package: the package must not
+/// depend on `PixelExperimentKit`, whose product is already linked by this app target and whose
+/// products cannot be linked twice without breaking this project's test-target link graph.
+///
+/// Everything the framework owns happens past this call — enrollment and cohort resolution, conversion
+/// window containment, threshold accumulation, repeat suppression and the pixel itself. A request for
+/// an experiment the user is not enrolled in is a no-op there, which is why the hub does not filter.
+struct MacOSEventHubConversionReporting: EventHubConversionReporting {
+
+    func reportConversion(experiment: String, metric: String, windowDays: ClosedRange<Int>, threshold: Int) {
+        Logger.eventHub.info("experiment metric conversion: \(experiment, privacy: .public)/\(metric, privacy: .public) window \(windowDays.lowerBound, privacy: .public)-\(windowDays.upperBound, privacy: .public) threshold \(threshold, privacy: .public)")
+        PixelKit.fireExperimentPixelIfThresholdReached(for: experiment,
+                                                       metric: metric,
+                                                       conversionWindowDays: windowDays,
+                                                       threshold: threshold)
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1218062429029804
Tech Design URL: https://app.asana.com/1/137249556945/project/481882893211075/task/1216911265362552
CC:

### Description

Adds experiment metrics to the EventHub. Metrics are declared in the `settings` of Content Scope Scripts and TDS experiment subfeatures in the remote config, and a matching event now reports a conversion to the Native Apps experiment framework — so a new metric can be hooked up to an experiment entirely through config, with no client release.

Metrics consume the same de-duplicated event stream the telemetry handlers do: the hub takes one de-duplication decision per web event, before fan-out, so a repeat on a page reaches no handler at all. Enrollment, conversion windows, threshold counting and the pixel itself remain the experiment framework's job — this side only reports.

Also folds the three native-event entry points into one, so a native occurrence reaches every handler exactly as a web event does, and fixes data parameter values arriving at the endpoint percent-encoded twice.

This is the second branch in a stack and targets `michal/eventhub-metrics-1-dedup`.

### Testing Steps

Use the setup in https://app.asana.com/1/137249556945/task/1218049910864102 and the Xcode debugger to see EventHub logs, then **add** the following override alongside the `webDetection` and `eventHub` ones from that task. It declares two metrics on one auto-enrolling CSS experiment: `adwallSeen` on the `test` event with two windows and two thresholds (four conversion requests), and `ytAdBlocker` on the `youtube_adBlocker` event (one request).

```json
"contentScopeExperiments": {
    "state": "enabled",
    "exceptions": [],
    "features": {
        "contentScopeExperimentMetricsTest": {
            "state": "enabled",
            "settings": {
                "metrics": {
                    "adwallSeen": {
                        "event": "test",
                        "conversions": [
                            { "windows": [[0, 0], [0, 7]], "thresholds": [1, 2] }
                        ]
                    },
                    "ytAdBlocker": {
                        "event": "youtube_adBlocker",
                        "conversions": [
                            { "windows": [[0, 7]], "thresholds": [1] }
                        ]
                    }
                }
            },
            "cohorts": [
                { "name": "control", "weight": 1 },
                { "name": "treatment", "weight": 1 }
            ]
        }
    }
}
```

Conversions are reported as `experiment_metrics_contentScopeExperimentMetricsTest_<cohort>` pixels carrying `metric`, `conversionWindowDays` and `value` (the threshold). Those fire unique by name and parameters, so each `(metric, window, threshold)` combination converts at most once.

**Test case 0:**

1. Load the config and launch the app
2. Filter the Xcode console on `EventHub`

- [x] A `parsed 5 metric conversion request(s) from N experiment(s)` line appears (the request count is the number to check — `N` counts every experiment subfeature carrying any settings, so it will be larger than one)

**Test case 1:**

1. Navigate to https://www.wikihow.com/Disable-Your-Ad-Blocker (detector needs to find "disable your ad blocker" text on the page)

- [x] `metric routing for test →` lists **four** requests for `adwallSeen` — both windows (`0-0`, `0-7`) against both thresholds (`1`, `2`). Order is not significant
- [x] Conversion pixels fire for `value=1` in both windows; the `value=2` combinations do not convert yet

2. Reload the same tab

- [x] No new `metric routing` line at all — the repeat is dropped at the hub before any handler runs, the same decision the counters and immediate pixels see

3. Navigate to some other page, then back to the wikihow page

- [x] `metric routing for test →` appears again (navigation cleared the de-dup state for that tab)
- [x] The `value=2` pixels now fire — a threshold of 2 means two distinct page loads, not two events on one page

4. Open the wikihow page in two more new tabs

- [x] Each tab produces its own `metric routing` line (de-dup is per tab)

**Test case 2:**

1. Navigate to https://privacy-test-pages.site/features/web-interference-detection/youtube-detection-events.html
2. Click "Show Ad-Blocker Modal" button

- [x] `test_ytVideoAd_immediate` fires with the `loginState` parameter, the `test_ytVideoAd_60s` counter increments, **and** `metric routing for youtube_adBlocker →` lists `ytAdBlocker 0-7×1` — one delivered event reaching all three handlers
- [x] The `ytAdBlocker` conversion pixel fires

3. Click "Show Ad-Blocker Modal" button again without reloading

- [x] No immediate pixel, no counter increment and no `metric routing` line — all three handlers share the one de-duplication decision

**Test case 3:**

1. On the same page, click "Show Ad-Blocker Modal" button

- [x] The EventHub log shows the data parameter as compact JSON with no percent escapes, e.g. `loginState: "unknown"`
- [ ] Inspecting the pixel request (network proxy) shows `loginState=%22unknown%22` — **not** `%2522unknown%2522`. Percent-decoding it once yields `"unknown"`, and JSON-decoding that yields `unknown`

**Test case 4:**

1. Trigger the `test` event on a fresh page and confirm `adwallSeen` converts
2. Remove `adwallSeen` from the experiment's `settings.metrics`, leaving `ytAdBlocker`, and reload the config

- [x] A new `parsed 1 metric conversion request(s)` line appears
- [x] A `test` event on a fresh page reports nothing for `adwallSeen`; `youtube_adBlocker` still reports `ytAdBlocker`

3. Restore `adwallSeen`, set the experiment's `state` to `disabled`, reload the config, trigger the `test` event on a fresh page

- [ ] No conversion pixels fire — a disabled experiment leaves the framework's active set

4. Set the `eventHub` feature's `state` to `disabled`, reload the config, trigger the `test` event on a fresh page

- [ ] No `metric routing` line at all — events reach metrics only through the hub, so the feature gate stops them

**Test case 5:**

1. Trigger an event type that no metric declares (any `webDetection` detector firing a different `fireEvent` type)

- [ ] `metric routing for <type> → no metric is declared for it (N request(s) loaded)`

### Impact

Medium. Metrics are inert until a config declares them, so nothing changes for users on current config. The de-duplication and telemetry paths from the previous branch in the stack are unchanged in behaviour.

The data parameter encoding fix does change the value of telemetry pixels that carry a `data` parameter — they were arriving double-encoded and unusable, and now arrive decodable. Worth flagging to Data Science, since any dashboard reading those values sees the format change.

#### What could go wrong?

- A misconfigured metric could report conversions for the wrong experiment → mitigated by requests being built per (experiment, metric) from the declaring experiment's own settings, covered by the M-SEL spec cases.
- A config typo could produce a runaway pixel → mitigated by the parser dropping thresholds below 1 and rejecting inverted or negative conversion windows.
- A period persisted before this change holds an already-encoded data value, so one pixel per data parameter can still go out double-encoded after upgrade, until the next matching event overwrites it.

### Quality Considerations

Conformance with the cross-platform behavioural specification is now complete on Apple: every case ID in the de-duplication, telemetry and metrics suites is covered by a named test, and `grep -o '[DMT]-[A-Z]\{3\}-[0-9]\+'` over `SharedPackages/EventHub/Sources/EventHubTests/Spec` returns the same set as the documents. 192 tests pass via both the iOS and macOS schemes.

Metrics hold no state and persist nothing — the registry is a derived view of the current config, rebuilt on every config change, and the event-time path is a filter over a flat list.

`platform-support.md` in `ddg-workflow` needs updating after this lands: it records five Apple divergences that this stack resolves, and its Apple column should become de-duplication-at-ingestion `Yes`, experiment metrics `Yes`, and `data` parameters `Yes`.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes telemetry wire format for data parameters and adds a new experiment conversion reporting path tied to remote config parsing; behavior is gated by `eventHub` and config but affects pixels Data Science may consume.
> 
> **Overview**
> Adds **config-driven experiment metrics** to EventHub: metrics declared in CSS/TDS experiment subfeature `settings` are parsed into flat `MetricRequest`s (windows × thresholds), kept in memory from a dedicated `experimentSettings` publisher, and on each delivered event reported through `EventHubConversionReporting` to **PixelExperimentKit** on iOS and macOS. **`PrivacyConfiguration.allSubfeatureSettings`** supports remote-only experiment IDs without compile-time subfeature enums; **`EventHubExperimentSettings`** merges settings from `contentScopeExperiments` and `contentBlocking`.
> 
> **Native ingress** replaces separate immediate and aggregated handlers with **`handleNativeEvent`**, which uses the same **`deliverLocked`** path as web events (immediate telemetry, period counters, and metrics). **`DataParameter`** now emits compact JSON only—percent-encoding is left to the pixel transport, fixing double-encoded telemetry `data` parameters.
> 
> Includes cross-platform **metrics spec tests**, expanded telemetry spec coverage, and mock/protocol updates across PrivacyConfig and app integration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d91e134bdb454be3ea41e1d55cce2b92aaef8b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->