### PR TITLE
Send pixel on NTP favorites reordering

### DIFF
--- a/iOS/DuckDuckGo/FavoritesView.swift
+++ b/iOS/DuckDuckGo/FavoritesView.swift
@@ -47,6 +47,8 @@ struct FavoritesView<Model: FavoritesViewModel>: View {
                     withAnimation {
                         model.moveFavorites(from: from, to: to)
                     }
+                } onMoveFinished: {
+                    model.favoritesReordered()
                 }
             }
         }

--- a/iOS/DuckDuckGo/FavoritesViewModel.swift
+++ b/iOS/DuckDuckGo/FavoritesViewModel.swift
@@ -22,6 +22,7 @@ import Bookmarks
 import Combine
 import SwiftUI
 import Core
+import PixelKit
 import WidgetKit
 
 protocol NewTabPageFavoriteDataSource {
@@ -35,6 +36,22 @@ protocol NewTabPageFavoriteDataSource {
     func bookmarkEntity(for favorite: Favorite) -> BookmarkEntity?
     func favorite(at index: Int) throws -> Favorite?
     func removeFavorite(_ favorite: Favorite)
+}
+
+
+private enum NewTabPageFavoritesPixel: PixelKit.Event {
+    /// A drag gesture that reordered the grid, fired once when the gesture finishes.
+    case reorder
+
+    var name: String {
+        switch self {
+        case .reorder: return "new-tab-page_favorites_reorder"
+        }
+    }
+
+    var parameters: [String: String]? { nil }
+    var standardParameters: [PixelKitStandardParameter]? { nil }
+    var namePrefix: PixelKitNamePrefix { .none }
 }
 
 protocol FavoritesFaviconCaching {
@@ -57,8 +74,9 @@ class FavoritesViewModel: ObservableObject {
     private let isFocussedState: Bool
     private let favoriteDataSource: NewTabPageFavoriteDataSource
     private let faviconsCache: FavoritesFaviconCaching
-    private let pixelFiring: PixelFiring.Type
+    private let pixelFiring: Core.PixelFiring.Type
     private let dailyPixelFiring: DailyPixelFiring.Type
+    private let pixelKitFiring: (any PixelKitFiring)?
    
     var isEmpty: Bool {
         allFavorites.isEmpty
@@ -68,12 +86,14 @@ class FavoritesViewModel: ObservableObject {
          favoriteDataSource: NewTabPageFavoriteDataSource,
          faviconLoader: FavoritesFaviconLoading,
          faviconsCache: FavoritesFaviconCaching,
-         pixelFiring: PixelFiring.Type = Pixel.self,
-         dailyPixelFiring: DailyPixelFiring.Type = DailyPixel.self) {
+         pixelFiring: Core.PixelFiring.Type = Pixel.self,
+         dailyPixelFiring: DailyPixelFiring.Type = DailyPixel.self,
+         pixelKitFiring: (any PixelKitFiring)? = PixelKit.shared) {
         self.isFocussedState = isFocussedState
         self.favoriteDataSource = favoriteDataSource
         self.pixelFiring = pixelFiring
         self.dailyPixelFiring = dailyPixelFiring
+        self.pixelKitFiring = pixelKitFiring
         self.faviconsCache = faviconsCache
 
         self.faviconLoader = MissingFaviconWrapper(loader: faviconLoader, onFaviconMissing: { [weak self] in
@@ -152,6 +172,10 @@ class FavoritesViewModel: ObservableObject {
         favoriteDataSource.moveFavorite(favorite, fromIndex: fromIndex, toIndex: index)
         // Reload from the data source; it already republishes the reordered list, so don't re-apply the move.
         updateData()
+    }
+
+    func favoritesReordered() {
+        pixelKitFiring?.fire(NewTabPageFavoritesPixel.reorder, frequency: .dailyAndCount)
     }
 
     // MARK: -

--- a/iOS/DuckDuckGo/FavoritesViewModel.swift
+++ b/iOS/DuckDuckGo/FavoritesViewModel.swift
@@ -74,10 +74,8 @@ class FavoritesViewModel: ObservableObject {
     private let isFocussedState: Bool
     private let favoriteDataSource: NewTabPageFavoriteDataSource
     private let faviconsCache: FavoritesFaviconCaching
-    private let pixelFiring: Core.PixelFiring.Type
-    private let dailyPixelFiring: DailyPixelFiring.Type
-    private let pixelKitFiring: (any PixelKitFiring)?
-   
+    private let pixelFiring: (any PixelKitFiring)?
+
     var isEmpty: Bool {
         allFavorites.isEmpty
     }
@@ -86,14 +84,10 @@ class FavoritesViewModel: ObservableObject {
          favoriteDataSource: NewTabPageFavoriteDataSource,
          faviconLoader: FavoritesFaviconLoading,
          faviconsCache: FavoritesFaviconCaching,
-         pixelFiring: Core.PixelFiring.Type = Pixel.self,
-         dailyPixelFiring: DailyPixelFiring.Type = DailyPixel.self,
-         pixelKitFiring: (any PixelKitFiring)? = PixelKit.shared) {
+         pixelFiring: (any PixelKitFiring)? = PixelKit.shared) {
         self.isFocussedState = isFocussedState
         self.favoriteDataSource = favoriteDataSource
         self.pixelFiring = pixelFiring
-        self.dailyPixelFiring = dailyPixelFiring
-        self.pixelKitFiring = pixelKitFiring
         self.faviconsCache = faviconsCache
 
         self.faviconLoader = MissingFaviconWrapper(loader: faviconLoader, onFaviconMissing: { [weak self] in
@@ -124,10 +118,10 @@ class FavoritesViewModel: ObservableObject {
         guard let url = favorite.urlObject else { return }
 
         if isFocussedState {
-            pixelFiring.fire(.favoriteLaunchedWebsite, withAdditionalParameters: [:])
+            pixelFiring?.fire(Pixel.Event.favoriteLaunchedWebsite)
         } else {
-            pixelFiring.fire(.favoriteLaunchedNTP, withAdditionalParameters: [:])
-            dailyPixelFiring.fireDaily(.favoriteLaunchedNTPDaily)
+            pixelFiring?.fire(Pixel.Event.favoriteLaunchedNTP)
+            pixelFiring?.fire(Pixel.Event.favoriteLaunchedNTPDaily, frequency: .legacyDailyNoSuffix)
         }
         if let host = url.host {
             faviconsCache.populateFavicon(for: host, intoCache: .fireproof, fromCache: .tabs)
@@ -144,7 +138,7 @@ class FavoritesViewModel: ObservableObject {
     func deleteFavorite(_ favorite: Favorite) {
         guard let entity = favoriteDataSource.bookmarkEntity(for: favorite) else { return }
 
-        pixelFiring.fire(.homeScreenDeleteFavorite, withAdditionalParameters: [:])
+        pixelFiring?.fire(Pixel.Event.homeScreenDeleteFavorite)
 
         favoriteDataSource.removeFavorite(favorite)
 
@@ -158,7 +152,7 @@ class FavoritesViewModel: ObservableObject {
     func editFavorite(_ favorite: Favorite) {
         guard let entity = favoriteDataSource.bookmarkEntity(for: favorite) else { return }
 
-        pixelFiring.fire(.homeScreenEditFavorite, withAdditionalParameters: [:])
+        pixelFiring?.fire(Pixel.Event.homeScreenEditFavorite)
 
         onFavoriteEdit?(entity)
     }
@@ -175,7 +169,7 @@ class FavoritesViewModel: ObservableObject {
     }
 
     func favoritesReordered() {
-        pixelKitFiring?.fire(NewTabPageFavoritesPixel.reorder, frequency: .dailyAndCount)
+        pixelFiring?.fire(NewTabPageFavoritesPixel.reorder, frequency: .dailyAndCount)
     }
 
     // MARK: -

--- a/iOS/DuckDuckGo/ReorderableForEach.swift
+++ b/iOS/DuckDuckGo/ReorderableForEach.swift
@@ -81,6 +81,7 @@ struct ReorderableForEach<Data: Reorderable, ID: Hashable, Content: View, Previe
                 droppableContent(for: item, metadata: metadata)
                     .onDrag {
                         movedItem = item
+                        didMove = false
                         return metadata.itemProvider
                     } preview: {
                         preview(item)
@@ -89,6 +90,7 @@ struct ReorderableForEach<Data: Reorderable, ID: Hashable, Content: View, Previe
                 droppableContent(for: item, metadata: metadata)
                     .onDrag {
                         movedItem = item
+                        didMove = false
                         return metadata.itemProvider
                     }
             }

--- a/iOS/DuckDuckGo/ReorderableForEach.swift
+++ b/iOS/DuckDuckGo/ReorderableForEach.swift
@@ -32,8 +32,10 @@ struct ReorderableForEach<Data: Reorderable, ID: Hashable, Content: View, Previe
     private let content: ContentBuilder
     private let preview: PreviewBuilder?
     private let onMove: (_ from: IndexSet, _ to: Int) -> Void
+    private let onMoveFinished: () -> Void
 
     @State private var movedItem: Data?
+    @State private var didMove = false
 
     init(_ data: [Data],
          id: KeyPath<Data, ID>,
@@ -45,6 +47,7 @@ struct ReorderableForEach<Data: Reorderable, ID: Hashable, Content: View, Previe
         self.content = content
         self.preview = nil
         self.onMove = onMove
+        self.onMoveFinished = {}
     }
 
     init(_ data: [Data],
@@ -52,13 +55,15 @@ struct ReorderableForEach<Data: Reorderable, ID: Hashable, Content: View, Previe
          isReorderingEnabled: Bool = true,
          @ViewBuilder content: @escaping ContentBuilder,
          @ViewBuilder preview: @escaping (Data) -> Preview,
-         onMove: @escaping (_ from: IndexSet, _ to: Int) -> Void) {
+         onMove: @escaping (_ from: IndexSet, _ to: Int) -> Void,
+         onMoveFinished: @escaping () -> Void) {
         self.data = data
         self.id = id
         self.isReorderingEnabled = isReorderingEnabled
         self.content = content
         self.preview = preview
         self.onMove = onMove
+        self.onMoveFinished = onMoveFinished
     }
 
     var body: some View {
@@ -101,7 +106,9 @@ struct ReorderableForEach<Data: Reorderable, ID: Hashable, Content: View, Previe
                 data: data,
                 item: item,
                 onMove: onMove,
-                movedItem: $movedItem))
+                onMoveFinished: onMoveFinished,
+                movedItem: $movedItem,
+                didMove: $didMove))
     }
 }
 
@@ -110,8 +117,10 @@ private struct ReorderDropDelegate<Data: Reorderable>: DropDelegate {
     let data: [Data]
     let item: Data
     let onMove: (_ from: IndexSet, _ to: Int) -> Void
+    let onMoveFinished: () -> Void
 
     @Binding var movedItem: Data?
+    @Binding var didMove: Bool
 
     func dropEntered(info: DropInfo) {
         guard item != movedItem,
@@ -124,6 +133,7 @@ private struct ReorderDropDelegate<Data: Reorderable>: DropDelegate {
             let fromIndices = IndexSet(integer: from)
             let toIndex = to > from ? to + 1 : to
             onMove(fromIndices, toIndex)
+            didMove = true
         }
     }
 
@@ -133,6 +143,12 @@ private struct ReorderDropDelegate<Data: Reorderable>: DropDelegate {
 
     func performDrop(info: DropInfo) -> Bool {
         movedItem = nil
+
+        if didMove {
+            didMove = false
+            onMoveFinished()
+        }
+
         return true
     }
 }
@@ -147,18 +163,21 @@ extension ReorderableForEach where Data: Identifiable, ID == Data.ID {
         self.content = content
         self.preview = nil
         self.onMove = onMove
+        self.onMoveFinished = {}
     }
 
     init(_ data: [Data],
          @ViewBuilder content: @escaping ContentBuilder,
          @ViewBuilder preview: @escaping PreviewBuilder,
-         onMove: @escaping (_ from: IndexSet, _ to: Int) -> Void) {
+         onMove: @escaping (_ from: IndexSet, _ to: Int) -> Void,
+         onMoveFinished: @escaping () -> Void) {
         self.data = data
         self.id = \Data.id
         self.isReorderingEnabled = true
         self.content = content
         self.preview = preview
         self.onMove = onMove
+        self.onMoveFinished = onMoveFinished
     }
 }
 

--- a/iOS/DuckDuckGoTests/NewTabPageFavoritesModelTests.swift
+++ b/iOS/DuckDuckGoTests/NewTabPageFavoritesModelTests.swift
@@ -23,22 +23,27 @@ import Bookmarks
 import CoreData
 import Common
 import Persistence
-@_spi(Testing) import PixelKit
 @testable import Core
 @testable import DuckDuckGo
+@_spi(Testing) import PixelKit
 
 final class NewTabPageFavoritesModelTests: XCTestCase {
     private let favoriteDataSource = MockNewTabPageFavoriteDataSource()
-    private let pixelKitMock = PixelKitMock()
+    private var pixelKitMock: PixelKitMock!
+
+    override func setUp() {
+        super.setUp()
+        pixelKitMock = PixelKitMock()
+    }
 
     override func tearDown() {
-        PixelFiringMock.tearDown()
+        pixelKitMock = nil
     }
 
     func testReturnsAllFavoritesWhenCustomizationDisabled() {
         favoriteDataSource.favorites.append(contentsOf: Array(repeating: Favorite.stub(), count: 10))
         let sut = createSUT()
-        
+
         XCTAssertEqual(sut.allFavorites.count, 10)
     }
 
@@ -47,8 +52,8 @@ final class NewTabPageFavoritesModelTests: XCTestCase {
 
         sut.favoriteSelected(Favorite(id: "", title: "", domain: "", urlObject: URL(string: "https://foo.bar")))
 
-        XCTAssertEqual(PixelFiringMock.lastPixelName, Pixel.Event.favoriteLaunchedNTP.name)
-        XCTAssertEqual(PixelFiringMock.lastDailyPixelInfo?.pixelName, Pixel.Event.favoriteLaunchedNTPDaily.name)
+        XCTAssertTrue(pixelKitMock.actualFireCalls.contains { $0.pixel.name == Pixel.Event.favoriteLaunchedNTP.name })
+        XCTAssertTrue(pixelKitMock.actualFireCalls.contains { $0.pixel.name == Pixel.Event.favoriteLaunchedNTPDaily.name })
     }
 
     func testFiresPixelsOnFavoriteSelectedInFocussedState() {
@@ -56,8 +61,8 @@ final class NewTabPageFavoritesModelTests: XCTestCase {
 
         sut.favoriteSelected(Favorite(id: "", title: "", domain: "", urlObject: URL(string: "https://foo.bar")))
 
-        XCTAssertEqual(PixelFiringMock.lastPixelName, Pixel.Event.favoriteLaunchedWebsite.name)
-        XCTAssertNil(PixelFiringMock.lastDailyPixelInfo?.pixelName)
+        XCTAssertTrue(pixelKitMock.actualFireCalls.contains { $0.pixel.name == Pixel.Event.favoriteLaunchedWebsite.name })
+        XCTAssertFalse(pixelKitMock.actualFireCalls.contains { $0.pixel.name == Pixel.Event.favoriteLaunchedNTPDaily.name })
     }
 
     func testFiresPixelOnFavoriteDeleted() {
@@ -68,7 +73,7 @@ final class NewTabPageFavoritesModelTests: XCTestCase {
 
         sut.deleteFavorite(favorite)
 
-        XCTAssertEqual(PixelFiringMock.lastPixelName, Pixel.Event.homeScreenDeleteFavorite.name)
+        XCTAssertTrue(pixelKitMock.actualFireCalls.contains { $0.pixel.name == Pixel.Event.homeScreenDeleteFavorite.name })
     }
 
     func testFiresPixelOnFavoriteEdited() {
@@ -79,7 +84,7 @@ final class NewTabPageFavoritesModelTests: XCTestCase {
 
         sut.editFavorite(favorite)
 
-        XCTAssertEqual(PixelFiringMock.lastPixelName, Pixel.Event.homeScreenEditFavorite.name)
+        XCTAssertTrue(pixelKitMock.actualFireCalls.contains { $0.pixel.name == Pixel.Event.homeScreenEditFavorite.name })
     }
 
     func testFiresPixelOnceWhenFavoritesReordered() {
@@ -96,9 +101,7 @@ final class NewTabPageFavoritesModelTests: XCTestCase {
                            favoriteDataSource: favoriteDataSource,
                            faviconLoader: MockFavoritesFaviconLoading(),
                            faviconsCache: MockFavoritesFaviconCaching(),
-                           pixelFiring: PixelFiringMock.self,
-                           dailyPixelFiring: PixelFiringMock.self,
-                           pixelKitFiring: pixelKitMock)
+                           pixelFiring: pixelKitMock)
     }
 
     // MARK: - Reordering (regression for m_d_favorites_list_index_not_matching_bookmark)
@@ -159,9 +162,7 @@ final class NewTabPageFavoritesModelTests: XCTestCase {
                                      favoriteDataSource: adapter,
                                      faviconLoader: MockFavoritesFaviconLoading(),
                                      faviconsCache: MockFavoritesFaviconCaching(),
-                                     pixelFiring: PixelFiringMock.self,
-                                     dailyPixelFiring: PixelFiringMock.self,
-                                     pixelKitFiring: pixelKitMock)
+                                     pixelFiring: pixelKitMock)
         // `adapter` retains `model`, keeping the Core Data stack alive for the test's lifetime.
         return (sut, adapter, db, recorder)
     }

--- a/iOS/DuckDuckGoTests/NewTabPageFavoritesModelTests.swift
+++ b/iOS/DuckDuckGoTests/NewTabPageFavoritesModelTests.swift
@@ -23,11 +23,13 @@ import Bookmarks
 import CoreData
 import Common
 import Persistence
+@_spi(Testing) import PixelKit
 @testable import Core
 @testable import DuckDuckGo
 
 final class NewTabPageFavoritesModelTests: XCTestCase {
     private let favoriteDataSource = MockNewTabPageFavoriteDataSource()
+    private let pixelKitMock = PixelKitMock()
 
     override func tearDown() {
         PixelFiringMock.tearDown()
@@ -80,13 +82,23 @@ final class NewTabPageFavoritesModelTests: XCTestCase {
         XCTAssertEqual(PixelFiringMock.lastPixelName, Pixel.Event.homeScreenEditFavorite.name)
     }
 
+    func testFiresPixelOnceWhenFavoritesReordered() {
+        let sut = createSUT()
+
+        sut.favoritesReordered()
+
+        XCTAssertEqual(pixelKitMock.actualFireCalls.map(\.pixel.name), ["new-tab-page_favorites_reorder"])
+        XCTAssertEqual(pixelKitMock.actualFireCalls.last?.frequency, .dailyAndCount)
+    }
+
     private func createSUT(isFocussedState: Bool = false) -> FavoritesViewModel {
         FavoritesViewModel(isFocussedState: isFocussedState,
                            favoriteDataSource: favoriteDataSource,
                            faviconLoader: MockFavoritesFaviconLoading(),
                            faviconsCache: MockFavoritesFaviconCaching(),
                            pixelFiring: PixelFiringMock.self,
-                           dailyPixelFiring: PixelFiringMock.self)
+                           dailyPixelFiring: PixelFiringMock.self,
+                           pixelKitFiring: pixelKitMock)
     }
 
     // MARK: - Reordering (regression for m_d_favorites_list_index_not_matching_bookmark)
@@ -148,7 +160,8 @@ final class NewTabPageFavoritesModelTests: XCTestCase {
                                      faviconLoader: MockFavoritesFaviconLoading(),
                                      faviconsCache: MockFavoritesFaviconCaching(),
                                      pixelFiring: PixelFiringMock.self,
-                                     dailyPixelFiring: PixelFiringMock.self)
+                                     dailyPixelFiring: PixelFiringMock.self,
+                                     pixelKitFiring: pixelKitMock)
         // `adapter` retains `model`, keeping the Core Data stack alive for the test's lifetime.
         return (sut, adapter, db, recorder)
     }

--- a/iOS/PixelDefinitions/pixels/definitions/new_tab_page_favorites.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/new_tab_page_favorites.json5
@@ -1,0 +1,10 @@
+// New Tab Page favorites grid.
+{
+    "new-tab-page_favorites_reorder": {
+        "description": "Fires when the user finishes a drag gesture that reordered the favorites grid on the New Tab Page.",
+        "owners": ["dus7"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count", "platform", "form_factor"],
+        "parameters": ["appVersion"]
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206226850447395/task/1218086366895602
Tech Design URL:
CC:

### Description

Fires `new-tab-page_favorites_reorder` once when a drag gesture finishes having reordered the NTP favorites grid.

### Testing Steps

1. Open the app on a New Tab Page with at least three favorites.
2. Long press a favorite, drag it across two or more other favorites, release.
3. Confirm `new-tab-page_favorites_reorder` daily and count pixel is sent.
4. Drag a favorite and release it back in its original position, confirm only count pixel is sent.
5. Confirm the reorder still persists across backgrounding the app.

### Impact and Risks

Low, additive apart from a flag set in the existing drop delegate.

#### What could go wrong?

--

### Quality Considerations

--

### Notes to Reviewer

--

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly additive analytics and PixelKit wiring; reorder behavior only gains a completion callback gated on whether the list actually moved during the drag.
> 
> **Overview**
> Adds analytics when users **finish** a drag that actually reordered the New Tab Page favorites grid, instead of firing on every intermediate drop while dragging.
> 
> `ReorderableForEach` now takes an **`onMoveFinished`** callback: it tracks whether any `onMove` happened during the gesture and invokes the callback once in `performDrop` when the drag ends. `FavoritesView` hooks that to `FavoritesViewModel.favoritesReordered()`, which fires **`new-tab-page_favorites_reorder`** via PixelKit with **`.dailyAndCount`**.
> 
> **`FavoritesViewModel`** is migrated from legacy `PixelFiring` / `DailyPixelFiring` type injection to optional **`PixelKitFiring`** (`PixelKit.shared` by default). Existing favorite launch/edit/delete pixels use the new `pixelFiring?.fire(...)` API, including the NTP daily favorite launch pixel with **`.legacyDailyNoSuffix`**.
> 
> A Pixel Definitions entry documents the new event; unit tests switch to **`PixelKitMock`** and assert the reorder pixel name and frequency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6be86420f749527d60e3ad39a1a1afee0a5131b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->