### PR TITLE
iOS: Recover the current tab when its web process is killed while backgrounded

### DIFF
--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -324,6 +324,10 @@ class MainViewController: UIViewController {
     private var lastWindowControlsRowState: (sharesRow: Bool, tabsBarHidden: Bool, topInset: CGFloat) = (false, false, -1)
     private lazy var isWindowControlsRowEnabled = WindowControlsRowLayout.isEnabled(featureFlagger: featureFlagger)
     private var lastForegroundEntryDate = Date.distantPast
+
+    /// Current tab whose web process died while backgrounded; its reload is deferred to `onForeground()`.
+    /// Weak so a tab closed while backgrounded is simply dropped.
+    private weak var tabPendingReloadOnForeground: TabViewController?
     private var syncRecoveryPromptService: SyncRecoveryPromptService?
     private var currentNTPEscapeHatch: EscapeHatchModel?
     private var hasCompletedInitialLoad = false
@@ -2454,6 +2458,8 @@ class MainViewController: UIViewController {
     func onForeground() {
         lastForegroundEntryDate = Date()
 
+        reloadCurrentTabTerminatedWhileBackgrounded()
+
         fireExperimentalAddressBarPixel()
         fireIPadToggleStateOnAppOpenPixel()
         fireContextualAutoAttachPixel()
@@ -2479,6 +2485,15 @@ class MainViewController: UIViewController {
         if daxDialogsManager.shouldShowFireButtonPulse && !daxDialogsManager.shouldShowPrivacyButtonPulse {
             showFireButtonPulse()
         }
+    }
+
+    /// Completes the reload that `tabContentProcessDidTerminate` deferred while backgrounded, reusing the
+    /// same recovery as an active termination: reloads if the tab is still current, otherwise evicts it so
+    /// it rebuilds on reselect (a launch action may have switched tabs before this runs).
+    private func reloadCurrentTabTerminatedWhileBackgrounded() {
+        guard let tab = tabPendingReloadOnForeground else { return }
+        tabPendingReloadOnForeground = nil
+        tabManager.invalidateCache(forController: tab, reloadCurrent: true)
     }
 
     /// Forces a viewport-size IPC to the WebContent process after foreground. Works around a
@@ -6965,6 +6980,12 @@ extension MainViewController: TabDelegate {
         //  in inactive state in case we're coming to the foreground
         let shouldReload = UIApplication.shared.applicationState != .background
         tabManager.invalidateCache(forController: tab, reloadCurrent: shouldReload)
+
+        // #6148 intentionally skips reloading the current tab while backgrounded, but never reloaded it
+        // on return either - leaving it blank until the app is force-quit. Defer the reload to foreground.
+        if !shouldReload, tabManager.current() === tab {
+            tabPendingReloadOnForeground = tab
+        }
     }
 
     func showBars() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414709148257752/task/1217680259754828

### Description

Fixes a blank/black tab that persisted until force-quit. When iOS kills a backgrounded tab's web-page process ("jetsam"), #6148 deliberately skips reloading it — intending to reload once foregrounded — but that deferred reload was never wired up, so the current tab was left blank on return. This adds the missing half: reload it when the app comes back to the foreground.

Production telemetry: ~37.5% of web-content terminations happen while backgrounded (the un-recovered path). Dead-tab colour is just the theme (white in light, black in dark), so this also covers the "black screen after video/backgrounding" reports.

Regression from #6148, compounded by #6222 (current tab exempted from eviction, removing the fallback recovery).

### Testing Steps

1. Open a website, let it load.
2. Background the app.
3. `kill -9` the app's `WebContent` process (simulates jetsam), or open heavy apps on device until iOS reclaims it.
4. Return to the app → page reloads. Before: stayed blank until force-quit.
5. Regression: kill in the **foreground** → still reloads immediately (unchanged).
6. Regression: 3 terminations in 60s while foregrounded → tab-termination error page still shows.

### Impact

Medium — recovers a persistent blank tab for a large share of backgrounded terminations. Additive; foreground and error-page paths unchanged.

#### What could go wrong?

- A deep link that navigates the just-terminated tab before foreground → one redundant reload (brief flash). Benign.
- Backgrounded crash-loops are recorded once (at foreground) not per-termination, so a purely-background loop reloads instead of showing the error page — a pre-existing property of #6148's guard, flagged for awareness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Unable to generate summary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26dd2f9d1ec2b5da3df711a9913d11d3c1142f9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->