### PR TITLE
[macOS] Sync V2 dark mode and alignment fixes

### DIFF
--- a/macOS/LocalPackages/SyncUI-macOS/Sources/SyncUI-macOS/Views/Dialogs/DeleteAccountViewV2.swift
+++ b/macOS/LocalPackages/SyncUI-macOS/Sources/SyncUI-macOS/Views/Dialogs/DeleteAccountViewV2.swift
@@ -32,6 +32,7 @@ struct DeleteAccountViewV2: View {
         SyncDialogV2(spacing: 20.0) {
             VStack(alignment: .center, spacing: 20) {
                 Image(.syncWarnFeature128)
+                    .accessibilityHidden(true)
                 SyncUIViews.TextHeader(text: UserText.deleteAccountConfirmTitleV2)
                 SyncUIViewsV2.TextDetailMultiline(text: UserText.deleteAccountConfirmMessageV2)
 

--- a/macOS/LocalPackages/SyncUI-macOS/Sources/SyncUI-macOS/Views/Dialogs/DeviceDetailsViewV2.swift
+++ b/macOS/LocalPackages/SyncUI-macOS/Sources/SyncUI-macOS/Views/Dialogs/DeviceDetailsViewV2.swift
@@ -55,6 +55,7 @@ struct DeviceDetailsViewV2: View {
         SyncDialogV2(spacing: 20.0) {
             VStack(alignment: .center, spacing: 20) {
                 illustration
+                    .accessibilityHidden(true)
                 VStack(alignment: .center, spacing: 8) {
                     SyncUIViews.TextHeader(text: title)
                     SyncUIViewsV2.TextCaption(text: UserText.deviceDetailsSyncedStatusV2)

--- a/macOS/LocalPackages/SyncUI-macOS/Sources/SyncUI-macOS/Views/Dialogs/RemoveDeviceViewV2.swift
+++ b/macOS/LocalPackages/SyncUI-macOS/Sources/SyncUI-macOS/Views/Dialogs/RemoveDeviceViewV2.swift
@@ -41,6 +41,7 @@ struct RemoveDeviceViewV2: View {
         SyncDialogV2(spacing: 20.0) {
             VStack(alignment: .center, spacing: 20) {
                 illustration
+                    .accessibilityHidden(true)
                 SyncUIViews.TextHeader(text: UserText.removeDeviceConfirmTitleV2)
                 SyncUIViewsV2.TextDetailMultilineMarkdown(text: UserText.removeDeviceConfirmMessageV2(device.name))
             }

--- a/macOS/LocalPackages/SyncUI-macOS/Sources/SyncUI-macOS/Views/Dialogs/RemoveDeviceViewV2.swift
+++ b/macOS/LocalPackages/SyncUI-macOS/Sources/SyncUI-macOS/Views/Dialogs/RemoveDeviceViewV2.swift
@@ -29,7 +29,12 @@ struct RemoveDeviceViewV2: View {
     @State private var isRemoving = false
 
     private var illustration: Image {
-        device.kind == .mobile ? Image(.syncRemoveDeviceMobile) : Image(.syncRemoveDeviceDesktop)
+        switch device.kind {
+        case .current, .desktop:
+            return Image(.syncRemoveDeviceDesktop)
+        case .mobile, .thirdParty:
+            return Image(.syncRemoveDeviceMobile)
+        }
     }
 
     var body: some View {

--- a/macOS/LocalPackages/SyncUI-macOS/Sources/SyncUI-macOS/Views/Dialogs/SyncWithAnotherDeviceViewV2.swift
+++ b/macOS/LocalPackages/SyncUI-macOS/Sources/SyncUI-macOS/Views/Dialogs/SyncWithAnotherDeviceViewV2.swift
@@ -234,6 +234,7 @@ struct SyncWithAnotherDeviceViewV2: View {
                         Text(UserText.share)
                     }
                     .padding(.horizontal, 6)
+                    .padding(.vertical, 4)
                 }
                 .buttonStyle(DismissActionButtonStyle(showsBorder: false,
                                                       stateColors: .themedDismissButton))
@@ -249,6 +250,7 @@ struct SyncWithAnotherDeviceViewV2: View {
                         Text(showCopyConfirmation ? UserText.syncWithAnotherDeviceCopiedV2 : UserText.copy)
                     }
                     .padding(.horizontal, 6)
+                    .padding(.vertical, 4)
                 }
                 .buttonStyle(DismissActionButtonStyle(showsBorder: false,
                                                       stateColors: .themedDismissButton))
@@ -262,6 +264,7 @@ struct SyncWithAnotherDeviceViewV2: View {
         .padding(.bottom, 20)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(innerCardBackground)
+        .environment(\.colorScheme, .light)
     }
 
     private var enterCodeCard: some View {

--- a/macOS/LocalPackages/SyncUI-macOS/Sources/SyncUI-macOS/Views/ManagementView/SyncWithAnotherDeviceButtonStyleV2.swift
+++ b/macOS/LocalPackages/SyncUI-macOS/Sources/SyncUI-macOS/Views/ManagementView/SyncWithAnotherDeviceButtonStyleV2.swift
@@ -35,7 +35,7 @@ struct SyncWithAnotherDeviceButtonStyleV2: ButtonStyle {
         return configuration.label
             .lineLimit(1)
             .frame(height: 32)
-            .padding(.horizontal, 24)
+            .padding(.horizontal, 12)
             .background(enabled ? enabledBackgroundColor : disabledBackgroundColor)
             .foregroundColor(labelColor)
             .cornerRadius(16)

--- a/macOS/LocalPackages/SyncUI-macOS/Sources/SyncUI-macOS/Views/ManagementView/SyncedDevicesListV2.swift
+++ b/macOS/LocalPackages/SyncUI-macOS/Sources/SyncUI-macOS/Views/ManagementView/SyncedDevicesListV2.swift
@@ -134,5 +134,6 @@ struct SyncedDeviceIconV2: View {
     var body: some View {
         Image(nsImage: image)
             .accessibilityIdentifier(accessibilityIdentifier)
+            .padding(.leading, 8)
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214200115953388/task/1217193470431163?focus=true

### Description

Visual fixes for the V2 Sync screens in dark mode. The QR code card now always renders in light appearance, since the QR itself is drawn dark-on-light and became unreadable against the dark card. Also gives the Share/Copy buttons a bit more vertical breathing room, and fixes the alignment of the device icons and the "Sync with Another Device" button label in the My Devices list.

### Testing Steps

1. Debug menu → Set Internal User State, then Feature Flag Overrides → Sync → enable `simplifiedSyncSetupV2`.
2. Switch macOS to Dark Appearance (System Settings → Appearance).
3. Settings → Sync & Backup → Sync with Another Device. Confirm the QR code card stays light and the code, Share and Copy buttons are all legible, with the buttons not feeling cramped.
4. Hover and press Share and Copy. Confirm the hover/pressed highlight covers the whole button and the copied-confirmation popover still appears.
5. Set up Sync so the My Devices list shows at least two devices. Confirm the device icons line up with the rest of the list and the "Sync with Another Device" button hugs its label.
6. Switch back to Light Appearance and repeat steps 3–5. Confirm nothing regressed.

### Impact

Low — padding and appearance tweaks only, behind the off-by-default `simplifiedSyncSetupV2` flag.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual and accessibility-only changes in Sync V2 UI behind the off-by-default feature flag; no auth or data-path changes.
> 
> **Overview**
> Polishes macOS Sync V2 UI for dark mode and list alignment, with small accessibility tweaks on decorative dialog art.
> 
> The **Sync with Another Device** QR card is forced to **light** appearance so the dark-on-light QR and controls stay readable in system dark mode. Share and Copy get extra vertical padding so hover/press highlights cover the full control.
> 
> **My Devices** tightens the “Sync with Another Device” pill (less horizontal padding) and adds leading padding on row device icons for alignment. **Remove device** illustration selection now treats **current** and **desktop** like desktop art (not only a binary mobile check).
> 
> Decorative header illustrations in delete account, device details, and remove device dialogs are marked **accessibility hidden** so VoiceOver focuses on titles and actions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35617c25c65b6469659f44913a242538969b5013. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->