### PR TITLE
iOS: Remove unified input button backgrounds

### DIFF
--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarButtonsView.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarButtonsView.swift
@@ -148,15 +148,6 @@ class SwitchBarButtonsView: UIView {
     }()
     private let voiceButton = BrowserChromeButton(.primary)
     private let aiChatShortcutButton = BrowserChromeButton(.primary)
-    private let aiChatShortcutBackdrop: UIView = {
-        let view = UIView()
-        view.translatesAutoresizingMaskIntoConstraints = false
-        view.backgroundColor = UIColor(designSystemColor: .controlsFillPrimary)
-        view.layer.cornerRadius = Constants.aiChatShortcutChipSize / 2
-        view.clipsToBounds = true
-        view.isUserInteractionEnabled = false
-        return view
-    }()
     private let separatorView = UIView()
 
     init() {
@@ -191,7 +182,6 @@ class SwitchBarButtonsView: UIView {
         stack.addArrangedSubview(stopGeneratingButton)
         stack.addArrangedSubview(voiceButton)
         stack.addArrangedSubview(separatorView)
-        aiChatShortcutButton.insertSubview(aiChatShortcutBackdrop, at: 0)
         stack.addArrangedSubview(aiChatShortcutButton)
     }
 
@@ -218,11 +208,6 @@ class SwitchBarButtonsView: UIView {
 
             aiChatShortcutButton.widthAnchor.constraint(equalToConstant: Constants.aiChatShortcutChipSize),
             aiChatShortcutButton.heightAnchor.constraint(equalToConstant: Constants.aiChatShortcutChipSize),
-
-            aiChatShortcutBackdrop.topAnchor.constraint(equalTo: aiChatShortcutButton.topAnchor),
-            aiChatShortcutBackdrop.leadingAnchor.constraint(equalTo: aiChatShortcutButton.leadingAnchor),
-            aiChatShortcutBackdrop.trailingAnchor.constraint(equalTo: aiChatShortcutButton.trailingAnchor),
-            aiChatShortcutBackdrop.bottomAnchor.constraint(equalTo: aiChatShortcutButton.bottomAnchor),
 
             separatorView.widthAnchor.constraint(equalToConstant: Constants.separatorWidth),
             separatorView.heightAnchor.constraint(equalToConstant: Constants.separatorHeight),

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
@@ -1667,7 +1667,6 @@ private extension UnifiedToggleInputView {
         let button = UIButton(type: .system)
         button.setImage(DesignSystemImages.Glyphs.Size24.chevronLeft, for: .normal)
         button.tintColor = UIColor(designSystemColor: .icons)
-        button.backgroundColor = UIColor(designSystemColor: .controlsFillPrimary)
         button.layer.cornerRadius = Constants.inlineDismissSize / 2
         button.translatesAutoresizingMaskIntoConstraints = false
         button.accessibilityLabel = UserText.backButtonTitle

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputViewTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputViewTests.swift
@@ -50,6 +50,45 @@ final class UnifiedToggleInputViewTests: XCTestCase {
         XCTAssertFalse(sut.subviews.contains { $0.layer.borderWidth > 0 })
     }
 
+    func testWhenExpandedInputShowsToggleThenDismissButtonHasNoBackground() throws {
+        let handler = UnifiedToggleInputHandler(isVoiceSearchEnabled: false)
+        let sut = UnifiedToggleInputView(handler: handler)
+
+        sut.applyCardLayout(.expanded(showsToggle: true, showsToolbar: false), animated: false)
+
+        let dismissButton = try XCTUnwrap(findButton(accessibilityIdentifier: "UnifiedToggleInput.Button.Dismiss", in: sut))
+        XCTAssertEqual(dismissButton.alpha, 1)
+        XCTAssertNil(dismissButton.backgroundColor)
+    }
+
+    func testWhenExpandedInputHidesToggleThenDismissButtonHasNoBackground() throws {
+        let handler = UnifiedToggleInputHandler(isVoiceSearchEnabled: false, isToggleEnabled: false)
+        let sut = UnifiedToggleInputView(handler: handler, isToggleEnabled: false)
+
+        sut.applyCardLayout(.expanded(showsToggle: false, showsToolbar: false), animated: false)
+
+        let dismissButton = try XCTUnwrap(findButton(accessibilityIdentifier: "UnifiedToggleInput.Button.Dismiss", in: sut))
+        XCTAssertEqual(dismissButton.alpha, 1)
+        XCTAssertNil(dismissButton.backgroundColor)
+    }
+
+    func testWhenSearchOnlyInputShowsAIChatShortcutThenButtonHasNoPersistentBackdrop() throws {
+        let handler = UnifiedToggleInputHandler(
+            isVoiceSearchEnabled: false,
+            isToggleEnabled: false,
+            isAIChatShortcutAvailable: true
+        )
+        handler.setToggleState(.search)
+        let sut = UnifiedToggleInputView(handler: handler, isToggleEnabled: false)
+
+        sut.applyCardLayout(.expanded(showsToggle: false, showsToolbar: false), animated: false)
+
+        let aiChatButton = try XCTUnwrap(findButton(accessibilityIdentifier: "Browser.OmniBar.Button.AIChat", in: sut))
+        let persistentBackgroundColor = UIColor(designSystemColor: .controlsFillPrimary)
+        XCTAssertFalse(aiChatButton.isHidden)
+        XCTAssertFalse(aiChatButton.subviews.contains { $0.backgroundColor?.isEqual(persistentBackgroundColor) == true })
+    }
+
     func testWhenExpandedInputHidesToggleThenModeSyncDoesNotShowOutline() {
         let handler = UnifiedToggleInputHandler(isVoiceSearchEnabled: false)
         let sut = UnifiedToggleInputView(handler: handler)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206488453854252/task/1217216887143853?focus=true

### Description

Removes the persistent gray backgrounds from the back and Duck.ai buttons when the unified input is focused. Button sizing, icons, accessibility, and actions remain unchanged.

<img width="660" height="1434" alt="IMG_1008" src="https://github.com/user-attachments/assets/f64d4193-1511-40c6-a34e-c11c3a2afd5c" />

### Testing Steps

1. On iPhone in light mode with the Search/Duck.ai toggle enabled, focus an empty address bar → the back button has no gray background.
2. Disable the toggle then focus an empty address bar → the back and Duck.ai buttons have no gray backgrounds.
3. Enter text → the Duck.ai button remains unfilled beside the clear button.
4. Tap Back, then repeat and tap Duck.ai → both actions still work and their touch targets remain unchanged.
5. Repeat steps 1–4 in dark mode → both buttons remain unfilled and legible.

### Impact

Low: Focused unified-input button styling only.

#### What could go wrong?

The controls could lose visual clarity or feedback → covered by the light/dark interaction checks above.

### Quality Considerations

Automated coverage checks the back button with the toggle shown and hidden, plus the Duck.ai shortcut when the toggle is hidden. No privacy, data, networking, or performance impact.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Focused-input styling only; sizing, actions, and accessibility identifiers are unchanged, with new unit tests covering the removed backgrounds.
> 
> **Overview**
> Removes the persistent **controlsFillPrimary** gray fills on focused unified input chrome so the back chevron and Duck.ai shortcut read as icon-only controls.
> 
> In `UnifiedToggleInputView`, `makeInlineDismissButton()` no longer sets a background on the inline dismiss button. In `SwitchBarButtonsView`, the dedicated `aiChatShortcutBackdrop` view and its layout are deleted so the AI chat shortcut no longer sits on a circular chip behind the button.
> 
> **Tests** lock in the new look: expanded dismiss has `nil` background (toggle on or off), and the omnibar AI chat button has no subview still using the primary control fill.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1f1529dd3e4b57654503a92427e64764ac831b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

