### PR TITLE
iOS: Add the duckai_session wide event

### DIFF
--- a/SharedPackages/AIChat/Sources/AIChat/Shared/URL+Extension.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/URL+Extension.swift
@@ -80,7 +80,7 @@ extension URL {
     /// Returns `true` for the bare DuckDuckGo homepage, including variants that carry only
     /// non-search query parameters (e.g. `?ia=web`, `?atb=…`). Returns `false` for SERP URLs
     /// (which require a `q=` parameter) and for sub-pages like `/settings` or `/about`.
-    var isDuckDuckGoHomepage: Bool {
+    public var isDuckDuckGoHomepage: Bool {
         guard host == DuckDuckGo.host, path.isEmpty || path == "/" else { return false }
         return queryItems?.contains { $0.name == DuckDuckGo.bangQueryName } != true
     }

--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -337,6 +337,9 @@
 		4B359FD82FB52B9A0020D70F /* InfoPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B359FD72FB52B9A0020D70F /* InfoPanelView.swift */; };
 		4B359FDB2FB5321C0020D70F /* DuckAIPromptWideEventData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B359FDA2FB5321C0020D70F /* DuckAIPromptWideEventData.swift */; };
 		4B359FDD2FB5322C0020D70F /* DuckAIWideEventInstrumentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B359FDC2FB5322C0020D70F /* DuckAIWideEventInstrumentation.swift */; };
+		D1A2B3C4E5F60003AABB0109 /* MainViewController+DuckAISession.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A2B3C4E5F60003AABB010A /* MainViewController+DuckAISession.swift */; };
+		D1A2B3C4E5F60003AABB0105 /* DuckAISessionInstrumentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A2B3C4E5F60003AABB0106 /* DuckAISessionInstrumentation.swift */; };
+		D1A2B3C4E5F60003AABB0101 /* DuckAISessionWideEventData.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A2B3C4E5F60003AABB0102 /* DuckAISessionWideEventData.swift */; };
 		4B412ACC2BBB3D0900A39F5E /* LazyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B412ACB2BBB3D0900A39F5E /* LazyView.swift */; };
 		4B470EE4299C6DFB0086EBDC /* Core.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F143C2E41E4A4CD400CFDE3A /* Core.framework */; };
 		4B52648B25F9613B00CB4C24 /* trackerData.json in Resources */ = {isa = PBXBuildFile; fileRef = 4B52648A25F9613B00CB4C24 /* trackerData.json */; };
@@ -361,6 +364,8 @@
 		4B97357A2F704924002E4A54 /* CredentialsCleanupErrorHandling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37CEFCAB2A673B90001EF741 /* CredentialsCleanupErrorHandling.swift */; };
 		4B97357B2F704924002E4A54 /* CreditCardsCleanupErrorHandling.swift in Sources */ = {isa = PBXBuildFile; fileRef = C13C54A22E7472A5003451F5 /* CreditCardsCleanupErrorHandling.swift */; };
 		4BA2C1752FC1232500D7C62E /* DuckAIWideEventInstrumentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BA2C1742FC1232500D7C62E /* DuckAIWideEventInstrumentationTests.swift */; };
+		D1A2B3C4E5F60003AABB0107 /* DuckAISessionInstrumentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A2B3C4E5F60003AABB0108 /* DuckAISessionInstrumentationTests.swift */; };
+		D1A2B3C4E5F60003AABB0103 /* DuckAISessionWideEventDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A2B3C4E5F60003AABB0104 /* DuckAISessionWideEventDataTests.swift */; };
 		4BABF9183022746600B46B44 /* AppRouting in Frameworks */ = {isa = PBXBuildFile; productRef = 4BABF9173022746600B46B44 /* AppRouting */; };
 		4BB7CBB02AF59C310014A35F /* VPNWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BB7CBAF2AF59C310014A35F /* VPNWidget.swift */; };
 		4BB88F3F2E5D701200DE539A /* PixelKit in Frameworks */ = {isa = PBXBuildFile; productRef = 4BB88F3E2E5D701200DE539A /* PixelKit */; };
@@ -3258,6 +3263,9 @@
 		4B359FD72FB52B9A0020D70F /* InfoPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfoPanelView.swift; sourceTree = "<group>"; };
 		4B359FDA2FB5321C0020D70F /* DuckAIPromptWideEventData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DuckAIPromptWideEventData.swift; sourceTree = "<group>"; };
 		4B359FDC2FB5322C0020D70F /* DuckAIWideEventInstrumentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DuckAIWideEventInstrumentation.swift; sourceTree = "<group>"; };
+		D1A2B3C4E5F60003AABB010A /* MainViewController+DuckAISession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MainViewController+DuckAISession.swift"; sourceTree = "<group>"; };
+		D1A2B3C4E5F60003AABB0106 /* DuckAISessionInstrumentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DuckAISessionInstrumentation.swift"; sourceTree = "<group>"; };
+		D1A2B3C4E5F60003AABB0102 /* DuckAISessionWideEventData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DuckAISessionWideEventData.swift"; sourceTree = "<group>"; };
 		4B412ACB2BBB3D0900A39F5E /* LazyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LazyView.swift; sourceTree = "<group>"; };
 		4B4A6D122F0EC5620074444F /* DuckDuckGoExperimental.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = DuckDuckGoExperimental.entitlements; sourceTree = "<group>"; };
 		4B52648A25F9613B00CB4C24 /* trackerData.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = trackerData.json; sourceTree = "<group>"; };
@@ -3281,6 +3289,8 @@
 		4B8E798C2F2C191900FDFC65 /* VPNConnectionError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VPNConnectionError.swift; sourceTree = "<group>"; };
 		4B94B79C2D4831700014AAB8 /* SyncUI-iOS */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = "SyncUI-iOS"; sourceTree = "<group>"; };
 		4BA2C1742FC1232500D7C62E /* DuckAIWideEventInstrumentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DuckAIWideEventInstrumentationTests.swift; sourceTree = "<group>"; };
+		D1A2B3C4E5F60003AABB0108 /* DuckAISessionInstrumentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DuckAISessionInstrumentationTests.swift"; sourceTree = "<group>"; };
+		D1A2B3C4E5F60003AABB0104 /* DuckAISessionWideEventDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DuckAISessionWideEventDataTests.swift"; sourceTree = "<group>"; };
 		4BABF9153022746600B46B44 /* AppRouting */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = AppRouting; sourceTree = "<group>"; };
 		4BB7CBAF2AF59C310014A35F /* VPNWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VPNWidget.swift; sourceTree = "<group>"; };
 		4BBBBA912B03291700D965DA /* VPNWaitlistUserText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VPNWaitlistUserText.swift; sourceTree = "<group>"; };
@@ -6353,6 +6363,8 @@
 			children = (
 				D5A100062FD0000000000006 /* DuckAISelectionJourneyInstrumentationTests.swift */,
 				4BA2C1742FC1232500D7C62E /* DuckAIWideEventInstrumentationTests.swift */,
+				D1A2B3C4E5F60003AABB0108 /* DuckAISessionInstrumentationTests.swift */,
+				D1A2B3C4E5F60003AABB0104 /* DuckAISessionWideEventDataTests.swift */,
 				C11F41142F2CCBE900C126C3 /* AIChatContextualChatSessionStateTests.swift */,
 				AD5E1ED02B0000000000F003 /* AIChatTextSelectionFeatureTests.swift */,
 				AD5E1ED02B0000000000F007 /* AIChatSelectionContextTests.swift */,
@@ -7151,6 +7163,9 @@
 				D5A100042FD0000000000004 /* DuckAISelectionJourneyInstrumentation.swift */,
 				4B359FDA2FB5321C0020D70F /* DuckAIPromptWideEventData.swift */,
 				4B359FDC2FB5322C0020D70F /* DuckAIWideEventInstrumentation.swift */,
+				D1A2B3C4E5F60003AABB010A /* MainViewController+DuckAISession.swift */,
+				D1A2B3C4E5F60003AABB0106 /* DuckAISessionInstrumentation.swift */,
+				D1A2B3C4E5F60003AABB0102 /* DuckAISessionWideEventData.swift */,
 			);
 			path = WideEvent;
 			sourceTree = "<group>";
@@ -13987,6 +14002,9 @@
 				CBE77C792FD2F49000CB7C6D /* SuggestionRowMapper.swift in Sources */,
 				EEF0F8CC2ABC832300630031 /* NetworkProtectionDebugFeatures.swift in Sources */,
 				4B359FDD2FB5322C0020D70F /* DuckAIWideEventInstrumentation.swift in Sources */,
+				D1A2B3C4E5F60003AABB0109 /* MainViewController+DuckAISession.swift in Sources */,
+				D1A2B3C4E5F60003AABB0105 /* DuckAISessionInstrumentation.swift in Sources */,
+				D1A2B3C4E5F60003AABB0101 /* DuckAISessionWideEventData.swift in Sources */,
 				D5A100032FD0000000000003 /* DuckAISelectionJourneyInstrumentation.swift in Sources */,
 				5644419D2D4D1EDD003C53B8 /* FeatureFlagsMenuView.swift in Sources */,
 				CBECDB7A2CD981CE005B8B87 /* AppPageRefreshMonitor.swift in Sources */,
@@ -14944,6 +14962,8 @@
 				C1E2C2272D9F1D0F0011C66C /* AutofillCreditCardDetailsViewModelTests.swift in Sources */,
 				C1056A562E253D98003220BA /* AutofillCredentialsImportPresentationManagerTests.swift in Sources */,
 				4BA2C1752FC1232500D7C62E /* DuckAIWideEventInstrumentationTests.swift in Sources */,
+				D1A2B3C4E5F60003AABB0107 /* DuckAISessionInstrumentationTests.swift in Sources */,
+				D1A2B3C4E5F60003AABB0103 /* DuckAISessionWideEventDataTests.swift in Sources */,
 				D5A100052FD0000000000005 /* DuckAISelectionJourneyInstrumentationTests.swift in Sources */,
 				C13C60DC2E6D7B0F00ED2211 /* SwitchBarSubmissionMetricsTests.swift in Sources */,
 				5BF0B1762FC78C74009D088E /* NavigationResponseRouterTests.swift in Sources */,

--- a/iOS/DuckDuckGo/AIChat/AIChatEntryPointSource.swift
+++ b/iOS/DuckDuckGo/AIChat/AIChatEntryPointSource.swift
@@ -18,6 +18,7 @@
 //
 
 import Foundation
+import AIChat
 import Core
 import PixelKit
 
@@ -80,6 +81,7 @@ public enum AIChatEntryPointSource: String {
     case siri
     case deepLinkOther = "deep_link_other"
     case returnToChatCard = "return_to_chat_card"
+    case ddgHomepage = "ddg_homepage"
 }
 
 extension AIChatEntryPointSource {
@@ -97,9 +99,19 @@ extension AIChatEntryPointSource {
 
     /// Names the page behind an `openAIChat` user-script request so it is not reported as a typed
     /// address. `nil` for duck.ai and debug hosts, which have no entry of their own.
-    static func forFrontEndOpenRequest(messageHost: String?) -> AIChatEntryPointSource? {
+    static func forFrontEndOpenRequest(messageHost: String?, pageURL: URL?) -> AIChatEntryPointSource? {
+        if pageURL?.isDuckDuckGoHomepage == true { return .ddgHomepage }
         guard let messageHost, messageHost == URL.ddg.host else { return nil }
         return .serp
+    }
+
+    /// Attributes a navigation the page itself started into Duck.ai. Only the DuckDuckGo homepage
+    /// is named; links from other pages stay unattributed rather than being lumped into a catch-all.
+    static func forInPageNavigation(from currentURL: URL?, to targetURL: URL) -> AIChatEntryPointSource? {
+        guard let currentURL, currentURL.isDuckDuckGoHomepage, !currentURL.isDuckAIURL, targetURL.isDuckAIURL else {
+            return nil
+        }
+        return .ddgHomepage
     }
 }
 

--- a/iOS/DuckDuckGo/AIChat/AIChatEntryPointSource.swift
+++ b/iOS/DuckDuckGo/AIChat/AIChatEntryPointSource.swift
@@ -100,7 +100,7 @@ extension AIChatEntryPointSource {
     /// Names the page behind an `openAIChat` user-script request so it is not reported as a typed
     /// address. `nil` for duck.ai and debug hosts, which have no entry of their own.
     static func forFrontEndOpenRequest(messageHost: String?, pageURL: URL?) -> AIChatEntryPointSource? {
-        if pageURL?.isDuckDuckGoHomepage == true { return .ddgHomepage }
+        if pageURL?.isDuckDuckGoHomepageEntry == true { return .ddgHomepage }
         guard let messageHost, messageHost == URL.ddg.host else { return nil }
         return .serp
     }
@@ -108,11 +108,14 @@ extension AIChatEntryPointSource {
     /// Attributes a navigation the page itself started into Duck.ai. Only the DuckDuckGo homepage
     /// is named; links from other pages stay unattributed rather than being lumped into a catch-all.
     static func forInPageNavigation(from currentURL: URL?, to targetURL: URL) -> AIChatEntryPointSource? {
-        guard let currentURL, currentURL.isDuckDuckGoHomepage, !currentURL.isDuckAIURL, targetURL.isDuckAIURL else {
-            return nil
-        }
+        guard currentURL?.isDuckDuckGoHomepageEntry == true, targetURL.isDuckAIURL else { return nil }
         return .ddgHomepage
     }
+}
+
+private extension URL {
+    /// The homepage proper: `duckduckgo.com/?ia=chat` shares its shape but is a Duck.ai page.
+    var isDuckDuckGoHomepageEntry: Bool { isDuckDuckGoHomepage && !isDuckAIURL }
 }
 
 extension WidgetSourceType {

--- a/iOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
+++ b/iOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
@@ -285,11 +285,11 @@ final class AIChatUserScriptHandler: AIChatUserScriptHandling {
             payload = paramsDict[AIChatKeys.aiChatPayload] as? AIChatPayload
         }
 
-        NotificationCenter.default.post(
-            name: .urlInterceptAIChat,
-            object: payload,
-            userInfo: [TabURLInterceptorParameter.aiChatRequestHost: message.messageHost]
-        )
+        var userInfo: [AnyHashable: Any] = [TabURLInterceptorParameter.aiChatRequestHost: message.messageHost]
+        if let pageURL = message.messageWebView?.url {
+            userInfo[TabURLInterceptorParameter.aiChatRequestURL] = pageURL
+        }
+        NotificationCenter.default.post(name: .urlInterceptAIChat, object: payload, userInfo: userInfo)
 
         return nil
     }

--- a/iOS/DuckDuckGo/AIChat/WideEvent/DuckAISessionInstrumentation.swift
+++ b/iOS/DuckDuckGo/AIChat/WideEvent/DuckAISessionInstrumentation.swift
@@ -36,6 +36,7 @@ protocol DuckAISessionInstrumentation: AnyObject {
     func visibleTabDidChange(_ tab: DuckAISessionTabSnapshot?)
 
     /// A user action that will leave Duck.ai is about to run. The next visible-tab change consumes it.
+    /// First trigger wins, and `newTab()` records `.newTabOpened`, so record more specific triggers before it.
     func recordPendingExit(tabUID: TabUID, trigger: DuckAISessionWideEventData.ExitTrigger)
 
     func promptSubmitted(tabUID: TabUID)

--- a/iOS/DuckDuckGo/AIChat/WideEvent/DuckAISessionInstrumentation.swift
+++ b/iOS/DuckDuckGo/AIChat/WideEvent/DuckAISessionInstrumentation.swift
@@ -1,0 +1,158 @@
+//
+//  DuckAISessionInstrumentation.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import PixelKit
+
+/// What the Duck.ai session instrumentation needs to know about the tab on screen.
+struct DuckAISessionTabSnapshot: Equatable {
+    let uid: TabUID
+    let isDuckAI: Bool
+    let url: URL?
+    let chatID: String?
+}
+
+/// Session-scoped hooks for the Duck.ai session wide event. One session spans a full Duck.ai tab
+/// being on screen; only one is in flight at a time. Callers report what is visible, this decides.
+protocol DuckAISessionInstrumentation: AnyObject {
+
+    /// The tab on screen changed, or its URL did. `nil` means no tab is on screen.
+    func visibleTabDidChange(_ tab: DuckAISessionTabSnapshot?)
+
+    /// A user action that will leave Duck.ai is about to run. The next visible-tab change consumes it.
+    func recordPendingExit(tabUID: TabUID, trigger: DuckAISessionWideEventData.ExitTrigger)
+
+    func promptSubmitted(tabUID: TabUID)
+    func newChatCreated(tabUID: TabUID)
+
+    /// App was backgrounded with a session still active. Completes as CANCELLED.
+    func sessionCancelledByBackground()
+}
+
+final class DefaultDuckAISessionInstrumentation: DuckAISessionInstrumentation {
+
+    private struct ActiveSession {
+        let data: DuckAISessionWideEventData
+        var lastSnapshot: DuckAISessionTabSnapshot
+        var tabUID: TabUID { lastSnapshot.uid }
+    }
+
+    private struct PendingExit {
+        let tabUID: TabUID
+        let trigger: DuckAISessionWideEventData.ExitTrigger
+    }
+
+    private let wideEvent: WideEventManaging
+    /// Read per session rather than cached, so turning the flag off remotely lands without a relaunch.
+    private let isEnabled: () -> Bool
+    private var activeSession: ActiveSession?
+    private var pendingExit: PendingExit?
+
+    init(wideEvent: WideEventManaging,
+         isEnabled: @escaping () -> Bool = { true },
+         completeOrphanedFlowsOnInit: Bool = false) {
+        self.wideEvent = wideEvent
+        self.isEnabled = isEnabled
+
+        if completeOrphanedFlowsOnInit {
+            completeOrphanedFlowsFromPreviousAppSession()
+        }
+    }
+
+    func visibleTabDidChange(_ tab: DuckAISessionTabSnapshot?) {
+        if let session = activeSession {
+            if let tab, tab.uid == session.tabUID {
+                guard tab != session.lastSnapshot else { return }
+                if tab.isDuckAI {
+                    continueSession(with: tab, previousChatID: session.lastSnapshot.chatID)
+                    return
+                }
+            }
+            endSession(session)
+        }
+
+        guard let tab, tab.isDuckAI, isEnabled() else { return }
+        startSession(with: tab)
+    }
+
+    func recordPendingExit(tabUID: TabUID, trigger: DuckAISessionWideEventData.ExitTrigger) {
+        guard activeSession?.tabUID == tabUID, pendingExit == nil else { return }
+        pendingExit = PendingExit(tabUID: tabUID, trigger: trigger)
+    }
+
+    func promptSubmitted(tabUID: TabUID) {
+        recordStep(\.promptSubmitted, tabUID: tabUID)
+    }
+
+    func newChatCreated(tabUID: TabUID) {
+        recordStep(\.newChatCreated, tabUID: tabUID)
+    }
+
+    func sessionCancelledByBackground() {
+        pendingExit = nil
+        guard let session = activeSession else { return }
+        activeSession = nil
+
+        session.data.statusReason = .appBackgrounded
+        wideEvent.completeFlow(session.data, status: .cancelled, onComplete: { _, _ in })
+    }
+
+    // MARK: - Helpers
+
+    private func startSession(with tab: DuckAISessionTabSnapshot) {
+        pendingExit = nil
+        let data = DuckAISessionWideEventData()
+        activeSession = ActiveSession(data: data, lastSnapshot: tab)
+        wideEvent.startFlow(data)
+    }
+
+    private func continueSession(with tab: DuckAISessionTabSnapshot, previousChatID: String?) {
+        pendingExit = nil
+        activeSession?.lastSnapshot = tab
+        if tab.chatID != previousChatID {
+            recordStep(\.chatIDChanged, tabUID: tab.uid)
+        }
+    }
+
+    private func endSession(_ session: ActiveSession) {
+        let trigger = pendingExit?.tabUID == session.tabUID ? pendingExit?.trigger : nil
+        pendingExit = nil
+        activeSession = nil
+
+        session.data.statusReason = .leftDuckai
+        session.data.exitTrigger = trigger ?? .otherNavigation
+        wideEvent.completeFlow(session.data,
+                               status: .success(reason: DuckAISessionWideEventData.StatusReason.leftDuckai.rawValue),
+                               onComplete: { _, _ in })
+    }
+
+    private func recordStep(_ step: ReferenceWritableKeyPath<DuckAISessionWideEventData, Bool>, tabUID: TabUID) {
+        guard let session = activeSession, session.tabUID == tabUID, !session.data[keyPath: step] else { return }
+        session.data[keyPath: step] = true
+        wideEvent.updateFlow(session.data)
+    }
+
+    private func completeOrphanedFlowsFromPreviousAppSession() {
+        for orphan in wideEvent.getAllFlowData(DuckAISessionWideEventData.self) {
+            wideEvent.completeFlow(orphan,
+                                   status: .unknown(reason: DuckAISessionWideEventData.appTerminatedReason),
+                                   onComplete: { _, _ in })
+        }
+    }
+}

--- a/iOS/DuckDuckGo/AIChat/WideEvent/DuckAISessionWideEventData.swift
+++ b/iOS/DuckDuckGo/AIChat/WideEvent/DuckAISessionWideEventData.swift
@@ -1,0 +1,117 @@
+//
+//  DuckAISessionWideEventData.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import FoundationExtensions
+import PixelKit
+
+/// Wide-event payload for the Duck.ai session pixel (`m_ios_wide_duckai_session`): one visit to a
+/// full Duck.ai tab, from the tab becoming visible until Duck.ai is left, the app backgrounds, or the process ends.
+final class DuckAISessionWideEventData: WideEventData {
+
+    static let metadata = WideEventMetadata(
+        pixelName: "duckai_session",
+        featureName: "duckai_session",
+        mobileMetaType: "ios-duckai-session",
+        // API requires both; only mobileMetaType is read on iOS.
+        desktopMetaType: "macos-duckai-session",
+        version: "1.0.0"
+    )
+
+    enum StatusReason: String, Codable, CaseIterable {
+        case leftDuckai = "left_duckai"
+        case appBackgrounded = "app_backgrounded"
+    }
+
+    enum ExitTrigger: String, Codable, CaseIterable {
+        case backOrClose = "back_or_close"
+        case tabSwitched = "tab_switched"
+        case newTabOpened = "new_tab_opened"
+        case fireTabOpened = "fire_tab_opened"
+        case searchStarted = "search_started"
+        case otherNavigation = "other_navigation"
+    }
+
+    var globalData: WideEventGlobalData
+    var contextData: WideEventContextData
+    var appData: WideEventAppData
+    var errorData: WideEventErrorData?
+
+    /// Carried explicitly because the sender only writes a status reason for SUCCESS and UNKNOWN.
+    var statusReason: StatusReason?
+    var exitTrigger: ExitTrigger?
+    var promptSubmitted: Bool
+    var newChatCreated: Bool
+    var chatIDChanged: Bool
+
+    init(statusReason: StatusReason? = nil,
+         exitTrigger: ExitTrigger? = nil,
+         promptSubmitted: Bool = false,
+         newChatCreated: Bool = false,
+         chatIDChanged: Bool = false,
+         contextData: WideEventContextData = WideEventContextData(),
+         appData: WideEventAppData = WideEventAppData(),
+         globalData: WideEventGlobalData = WideEventGlobalData()) {
+        self.statusReason = statusReason
+        self.exitTrigger = exitTrigger
+        self.promptSubmitted = promptSubmitted
+        self.newChatCreated = newChatCreated
+        self.chatIDChanged = chatIDChanged
+        self.contextData = contextData
+        self.appData = appData
+        self.globalData = globalData
+    }
+
+    /// The instrumentation sweeps orphans synchronously at construction; letting
+    /// `WideEventService.resume()` do it would race and complete a fresh flow as UNKNOWN.
+    func completionDecision(for trigger: WideEventCompletionTrigger) async -> WideEventCompletionDecision {
+        .keepPending
+    }
+
+    static let appTerminatedReason = "app_terminated"
+}
+
+extension DuckAISessionWideEventData {
+
+    /// Absent when false: a present `true` means the action happened at least once.
+    private func whenDone(_ happened: Bool) -> Bool? {
+        happened ? true : nil
+    }
+
+    func jsonParameters() -> [String: Encodable] {
+        let reportedExitTrigger = statusReason == .leftDuckai ? exitTrigger?.rawValue : nil
+        return Dictionary(compacting: [
+            (WideEventParameter.Feature.statusReason, statusReason?.rawValue),
+            (WideEventParameter.DuckAISessionFeature.exitTrigger, reportedExitTrigger),
+            (WideEventParameter.DuckAISessionFeature.promptSubmitted, whenDone(promptSubmitted)),
+            (WideEventParameter.DuckAISessionFeature.newChatCreated, whenDone(newChatCreated)),
+            (WideEventParameter.DuckAISessionFeature.chatIDChanged, whenDone(chatIDChanged)),
+        ])
+    }
+}
+
+extension WideEventParameter {
+
+    enum DuckAISessionFeature {
+        static let exitTrigger = "feature.data.ext.exit_trigger"
+        static let promptSubmitted = "feature.data.ext.step.prompt_submitted"
+        static let newChatCreated = "feature.data.ext.step.new_chat_created"
+        static let chatIDChanged = "feature.data.ext.step.chat_id_changed"
+    }
+}

--- a/iOS/DuckDuckGo/AIChat/WideEvent/MainViewController+DuckAISession.swift
+++ b/iOS/DuckDuckGo/AIChat/WideEvent/MainViewController+DuckAISession.swift
@@ -1,0 +1,20 @@
+//
+//  MainViewController+DuckAISession.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation

--- a/iOS/DuckDuckGo/AIChat/WideEvent/MainViewController+DuckAISession.swift
+++ b/iOS/DuckDuckGo/AIChat/WideEvent/MainViewController+DuckAISession.swift
@@ -17,4 +17,56 @@
 //  limitations under the License.
 //
 
+import AIChat
 import Foundation
+
+/// Call sites for the Duck.ai session wide event, which measures one visit to a full Duck.ai tab.
+extension MainViewController {
+
+    /// Reports the tab that is (about to be) on screen. Unchanged snapshots are ignored downstream.
+    func reportDuckAISessionVisibleTab(_ tab: Tab?) {
+        duckAISessionInstrumentation.visibleTabDidChange(tab.map(duckAISessionSnapshot))
+    }
+
+    func reportDuckAISessionCurrentTab() {
+        reportDuckAISessionVisibleTab(tabManager.currentTabsModel.currentTab)
+    }
+
+    /// Records the action about to leave Duck.ai, if the visible tab is a Duck.ai tab.
+    func recordDuckAISessionPendingExit(_ trigger: DuckAISessionWideEventData.ExitTrigger) {
+        guard let tab = tabManager.currentTabsModel.currentTab, tab.isAITab else { return }
+        duckAISessionInstrumentation.recordPendingExit(tabUID: tab.uid, trigger: trigger)
+    }
+
+    /// Any close of the visible Duck.ai tab is the close exit, whichever surface closed it.
+    func recordDuckAISessionCloseIfNeeded(closingTabs: [Tab]) {
+        guard let current = tabManager.currentTabsModel.currentTab,
+              closingTabs.contains(where: { $0.uid == current.uid }) else { return }
+        recordDuckAISessionPendingExit(.backOrClose)
+    }
+
+    func recordDuckAISessionPromptSubmitted(for handler: AIChatContentHandling) {
+        guard let tab = currentTab, tab.aiChatContentHandler === handler else { return }
+        duckAISessionInstrumentation.promptSubmitted(tabUID: tab.tabModel.uid)
+    }
+
+    func recordDuckAISessionPromptSubmittedOnCurrentTab() {
+        guard let tab = tabManager.currentTabsModel.currentTab, tab.isAITab else { return }
+        duckAISessionInstrumentation.promptSubmitted(tabUID: tab.uid)
+    }
+
+    func recordDuckAISessionNewChatCreated(for handler: AIChatContentHandling) {
+        guard let tab = currentTab, tab.aiChatContentHandler === handler else { return }
+        duckAISessionInstrumentation.newChatCreated(tabUID: tab.tabModel.uid)
+    }
+
+    func recordDuckAISessionNewChatCreatedOnCurrentTab() {
+        guard let tab = tabManager.currentTabsModel.currentTab, tab.isAITab else { return }
+        duckAISessionInstrumentation.newChatCreated(tabUID: tab.uid)
+    }
+
+    private func duckAISessionSnapshot(_ tab: Tab) -> DuckAISessionTabSnapshot {
+        let url = tab.link?.url
+        return DuckAISessionTabSnapshot(uid: tab.uid, isDuckAI: tab.isAITab, url: url, chatID: url?.duckAIChatID)
+    }
+}

--- a/iOS/DuckDuckGo/MainViewController+AIChatHistoryViewModelDelegate.swift
+++ b/iOS/DuckDuckGo/MainViewController+AIChatHistoryViewModelDelegate.swift
@@ -26,6 +26,7 @@ extension MainViewController: AIChatHistoryViewModelDelegate {
         if let tab = currentTab, tab.isAITab {
             fireAIChatEntryPointPixel(source: .chatHistoryNewChat, opensNewTab: false, hasPrompt: false)
             stampDuckAIEntrySourceOnCurrentTab(.chatHistoryNewChat)
+            recordDuckAISessionNewChatCreatedOnCurrentTab()
             unifiedToggleInputCoordinator?.startNewChat()
             tab.submitStartChatAction()
             dismiss(animated: true) { [weak self] in

--- a/iOS/DuckDuckGo/MainViewController+KeyCommands.swift
+++ b/iOS/DuckDuckGo/MainViewController+KeyCommands.swift
@@ -217,6 +217,7 @@ extension MainViewController {
         guard isShortcutEnabled() else { return }
         guard fireModeCapability.isFireModeEnabled else { return }
 
+        recordDuckAISessionPendingExit(.fireTabOpened)
         tabManager.setBrowsingMode(.fire, source: .keyCommand)
         performCancel()
         newTab()
@@ -264,7 +265,8 @@ extension MainViewController {
     @objc func keyboardBrowserBack() {
         guard tabSwitcherController == nil else { return }
         guard isShortcutEnabled() else { return }
-        
+
+        recordDuckAISessionPendingExit(.backOrClose)
         currentTab?.goBack()
     }
     

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -6725,6 +6725,7 @@ extension MainViewController: TabDelegate {
     func tab(_ tab: TabViewController,
              didRequestNewFireTabForUrl url: URL,
              inheritingAttribution attribution: AdClickAttributionLogic.State?) {
+        recordDuckAISessionPendingExit(.fireTabOpened)
         tabManager.setBrowsingMode(.fire, source: .longPressLink)
         loadUrlInNewTab(url, inheritedAttribution: attribution)
     }

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -3849,7 +3849,8 @@ class MainViewController: UIViewController {
             .sink { [weak self] notification in
                 let payload = notification.object as? AIChatPayload
                 let requestHost = notification.userInfo?[TabURLInterceptorParameter.aiChatRequestHost] as? String
-                let source = AIChatEntryPointSource.forFrontEndOpenRequest(messageHost: requestHost)
+                let requestURL = notification.userInfo?[TabURLInterceptorParameter.aiChatRequestURL] as? URL
+                let source = AIChatEntryPointSource.forFrontEndOpenRequest(messageHost: requestHost, pageURL: requestURL)
                     ?? .directURL
                 self?.openAIChat(source: source, payload: payload)
             }
@@ -6751,6 +6752,22 @@ extension MainViewController: TabDelegate {
              didRequestNewDuckAITabForUrl url: URL,
              entrySource: AIChatEntryPointSource) {
         openNewTab(from: tab, url: url, openedByPage: false, inheritedAttribution: nil) {
+            $0.duckAIEntrySource = entrySource
+        }
+    }
+
+    func tab(_ tab: TabViewController,
+             didStartDuckAINavigationTo url: URL,
+             entrySource: AIChatEntryPointSource,
+             opensNewTab: Bool,
+             inheritingAttribution attribution: AdClickAttributionLogic.State?) {
+        let hasPrompt = url.getParameter(named: AIChatURLParameters.promptQueryName)?.isEmpty == false
+        fireAIChatEntryPointPixel(source: entrySource, opensNewTab: opensNewTab, hasPrompt: hasPrompt)
+        guard opensNewTab else {
+            tab.tabModel.duckAIEntrySource = entrySource
+            return
+        }
+        openNewTab(from: tab, url: url, openedByPage: true, inheritedAttribution: attribution) {
             $0.duckAIEntrySource = entrySource
         }
     }

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -226,6 +226,7 @@ class MainViewController: UIViewController {
     /// there can be told apart from a reconnect that happened on its own.
     var vpnConnectedWhenLeavingNewTabPage: Bool?
     let duckAIWideEventInstrumentation: DuckAIWideEventInstrumentation
+    let duckAISessionInstrumentation: DuckAISessionInstrumentation
     let syncAutoRestoreHandler: SyncAutoRestoreHandling
     private let lastActiveTabStore: LastActiveTabStoring
     let fireModeCapability: FireModeCapable
@@ -671,6 +672,11 @@ class MainViewController: UIViewController {
         )
         self.duckAIWideEventInstrumentation = DefaultDuckAIWideEventInstrumentation(
             wideEvent: AppDependencyProvider.shared.wideEvent,
+            completeOrphanedFlowsOnInit: true
+        )
+        self.duckAISessionInstrumentation = DefaultDuckAISessionInstrumentation(
+            wideEvent: AppDependencyProvider.shared.wideEvent,
+            isEnabled: { featureFlagger.isFeatureOn(.duckAISessionWideEvent) },
             completeOrphanedFlowsOnInit: true
         )
         self.syncAutoRestoreHandler = syncAutoRestoreHandler
@@ -1586,6 +1592,7 @@ class MainViewController: UIViewController {
             ntpAfterIdleInstrumentation.appBackgroundedFromNTP(afterIdle: tab.openedAfterIdle)
         }
         postIdleSessionInstrumentation.sessionCancelledByBackground()
+        duckAISessionInstrumentation.sessionCancelledByBackground()
         recordNewTabPageSessionVPNChangeIfNeeded()
         newTabPageSessionInstrumentation.visitBackgrounded()
 
@@ -2145,6 +2152,7 @@ class MainViewController: UIViewController {
                                       previousTab: TabViewController? = nil,
                                       openedAfterIdle: Bool = false,
                                       startsNewTabPageSessionVisit: Bool = true) {
+        reportDuckAISessionCurrentTab()
         guard !autoClearInProgress else { return }
 
         if tabManager.currentTabsModel.tabs.isEmpty && tabManager.currentTabsModel.allowsEmpty {
@@ -2440,6 +2448,7 @@ class MainViewController: UIViewController {
         performCancel()
         hideSuggestionTray()
         hideNotificationBarIfBrokenSitePromptShown()
+        recordDuckAISessionPendingExit(.backOrClose)
         currentTab?.goBack()
     }
 
@@ -2453,6 +2462,7 @@ class MainViewController: UIViewController {
     
     func onForeground() {
         lastForegroundEntryDate = Date()
+        reportDuckAISessionCurrentTab()
 
         fireExperimentalAddressBarPixel()
         fireIPadToggleStateOnAppOpenPixel()
@@ -2793,6 +2803,7 @@ class MainViewController: UIViewController {
     }
 
     private func attachTab(tab: TabViewController) {
+        reportDuckAISessionVisibleTab(tab.tabModel)
         // The user moved on to an existing tab, so whatever New Tab Page they reach later is not the
         // page a burn landed them on.
         isAttachingNewTabPageAfterFire = false
@@ -3658,6 +3669,7 @@ class MainViewController: UIViewController {
         hideNotificationBarIfBrokenSitePromptShown()
         currentTab?.aiChatContextualSheetCoordinator.dismissSheet()
 
+        recordDuckAISessionPendingExit(.newTabOpened)
         let previousTab = tabManager.current()
         dismissSystemFindNavigator(for: previousTab)
         currentTab?.dismiss()
@@ -5032,6 +5044,7 @@ extension MainViewController: BrowserChromeDelegate {
         switch suggestion {
         case .phrase(phrase: let phrase):
             if let url = URL.makeSearchURL(query: phrase, useUnifiedLogic: isUnifiedURLPredictionEnabled, forceSearchQuery: true) {
+                recordDuckAISessionPendingExit(.searchStarted)
                 loadUrlRespectingAIBoundary(url)
             } else {
                 Logger.lifecycle.error("Couldn't form URL for suggestion: \(phrase, privacy: .public)")
@@ -5227,6 +5240,9 @@ extension MainViewController: OmniBarDelegate {
         }
         postIdleSessionInstrumentation.sessionEnded(reason: postIdleSubmissionReason(for: query))
         recordNewTabPageSessionAction { $0.hitSubmit() }
+        if postIdleSubmissionReason(for: query) == .searchSubmitted {
+            recordDuckAISessionPendingExit(.searchStarted)
+        }
         loadQuery(query)
         hideNotificationBarIfBrokenSitePromptShown()
         showHomeRowReminder()
@@ -5683,12 +5699,14 @@ extension MainViewController: OmniBarDelegate {
 
     private func newFireTabLongPressMenuAction() {
         postIdleSessionInstrumentation.sessionEnded(reason: .tabSwitcherSelected)
+        recordDuckAISessionPendingExit(.fireTabOpened)
         tabManager.setBrowsingMode(.fire, source: .longPressTabsIcon)
         newTab()
     }
 
     private func newNormalTabLongPressMenuAction() {
         postIdleSessionInstrumentation.sessionEnded(reason: .tabSwitcherSelected)
+        recordDuckAISessionPendingExit(.newTabOpened)
         tabManager.setBrowsingMode(.normal, source: .longPressTabsIcon)
         newTab()
     }
@@ -6639,6 +6657,7 @@ extension MainViewController: TabDelegate {
         }
 
         guard currentTab == tab else { return }
+        reportDuckAISessionVisibleTab(tab.tabModel)
         refreshControls()
         themeColorManager.updateThemeColor()
         tabManager.save()
@@ -6740,6 +6759,9 @@ extension MainViewController: TabDelegate {
                             openedByPage: Bool,
                             inheritedAttribution attribution: AdClickAttributionLogic.State?,
                             completion: ((Tab) -> Void)? = nil) {
+        if !openedByPage {
+            recordDuckAISessionPendingExit(.newTabOpened)
+        }
         _ = findInPageView?.resignFirstResponder()
         hideNotificationBarIfBrokenSitePromptShown()
         tab.aiChatContextualSheetCoordinator.dismissSheet()
@@ -7069,6 +7091,9 @@ extension MainViewController: TabDelegate {
     }
 
     func selectTab(_ tab: Tab) {
+        if tab.uid != tabManager.currentTabsModel.currentTab?.uid {
+            recordDuckAISessionPendingExit(.tabSwitched)
+        }
         viewCoordinator.navigationBarContainer.alpha = 1
         allowContentUnderflow = false
 
@@ -7124,6 +7149,7 @@ extension MainViewController: TabSwitcherDelegate {
             if tab.isAITab {
                 fireAIChatEntryPointPixel(source: .tabSwitcherExistingChat, opensNewTab: false, hasPrompt: false)
             }
+            recordDuckAISessionPendingExit(.tabSwitched)
             tabManager.select(tab, dismissCurrent: false)
         }
 
@@ -7155,11 +7181,13 @@ extension MainViewController: TabSwitcherDelegate {
     }
 
     func tabSwitcherDidRequestNewFireTab(tabSwitcher: TabSwitcherViewController, source: FireModeSwitchSource) {
+        recordDuckAISessionPendingExit(.fireTabOpened)
         tabManager.setBrowsingMode(.fire, source: source)
         tabSwitcherNewTabWithAnimation()
     }
 
     func tabSwitcherDidRequestNewNormalTab(tabSwitcher: TabSwitcherViewController) {
+        recordDuckAISessionPendingExit(.newTabOpened)
         tabManager.setBrowsingMode(.normal, source: .tabSwitcherLongPress)
         tabSwitcherNewTabWithAnimation()
     }
@@ -7182,6 +7210,7 @@ extension MainViewController: TabSwitcherDelegate {
 
     /// Per-tab close side effects `bulkRemoveTabs` skips: Duck.ai generation instrumentation + (18.4+) web-extension close events.
     func notifyTabsWillClose(_ tabs: [Tab]) {
+        recordDuckAISessionCloseIfNeeded(closingTabs: tabs)
         discardNewTabPageSessionIfHostingTabClosed(tabs)
 
         for tab in tabs {
@@ -7199,7 +7228,8 @@ extension MainViewController: TabSwitcherDelegate {
                   behavior: TabClosingBehavior = .onlyClose,
                   clearTabHistory: Bool = true,
                   refreshInPlace: Bool = false) {
-        
+        recordDuckAISessionCloseIfNeeded(closingTabs: [tab])
+
         func replaceTabWith(newTab: Tab) {
             tabManager.replace(tab: tab, withNewTab: newTab, clearTabHistory: clearTabHistory)
             tabManager.select(newTab, dismissCurrent: false)
@@ -7257,6 +7287,7 @@ extension MainViewController: TabSwitcherDelegate {
     }
 
     func tabSwitcherDidRequestCloseAll(tabSwitcher: TabSwitcherViewController) {
+        recordDuckAISessionCloseIfNeeded(closingTabs: tabSwitcher.tabsModel.tabs)
         for tab in tabSwitcher.tabsModel.tabs {
             reportDuckAITabClosedIfNeeded(tab)
         }
@@ -8156,10 +8187,12 @@ extension MainViewController: AIChatContentHandlingDelegate {
     func aiChatContentHandlerDidReceivePromptSubmission(_ handler: AIChatContentHandling) {
         let origin = currentTab?.aiChatContentHandler === handler ? currentTab?.tabModel.duckAIEntrySource : nil
         postIdleSessionInstrumentation.promptSubmittedWithoutNavigation(origin: origin)
+        recordDuckAISessionPromptSubmitted(for: handler)
         reportDuckAIFrontendSubmissionAcknowledged()
     }
 
     func aiChatContentHandlerDidReceiveNewChatCreated(_ handler: AIChatContentHandling) {
+        recordDuckAISessionNewChatCreated(for: handler)
         DispatchQueue.main.async { [weak self] in
             self?.unifiedToggleInputCoordinator?.startNewChat()
             self?.unifiedToggleInputCoordinator?.showExpanded(inputMode: .aiChat)

--- a/iOS/DuckDuckGo/TabDelegate.swift
+++ b/iOS/DuckDuckGo/TabDelegate.swift
@@ -63,6 +63,14 @@ protocol TabDelegate: AnyObject {
              didRequestNewDuckAITabForUrl url: URL,
              entrySource: AIChatEntryPointSource)
 
+    /// A navigation the page started into Duck.ai from a page native attributes, today the DuckDuckGo homepage.
+    /// Opens a page-owned tab when `opensNewTab`; either way the tab hosting the chat is stamped with `entrySource`.
+    func tab(_ tab: TabViewController,
+             didStartDuckAINavigationTo url: URL,
+             entrySource: AIChatEntryPointSource,
+             opensNewTab: Bool,
+             inheritingAttribution: AdClickAttributionLogic.State?)
+
     /// Called on navigate forward on a tab that had just closed a link-opened tab via back.
     /// Re-open that tab at `url` as a child of `tab` again.
     func tab(_ tab: TabViewController, didRequestReopenClosedTabAt url: URL)

--- a/iOS/DuckDuckGo/TabURLInterceptor.swift
+++ b/iOS/DuckDuckGo/TabURLInterceptor.swift
@@ -91,4 +91,6 @@ public enum TabURLInterceptorParameter {
     /// Set only by the front-end `openAIChat` message, never by the interceptor: the page that asked
     /// native to open Duck.ai, so its entry is attributed to that page rather than to a typed address.
     public static let aiChatRequestHost = "aiChatRequestHost"
+    /// The requesting page's URL, when its web view is known; tells the homepage apart from the SERP.
+    public static let aiChatRequestURL = "aiChatRequestURL"
 }

--- a/iOS/DuckDuckGo/TabViewController.swift
+++ b/iOS/DuckDuckGo/TabViewController.swift
@@ -1542,6 +1542,7 @@ class TabViewController: UIViewController {
 
         webView.stopLoading()
         dismissJSAlertIfNeeded()
+        pendingNativeLoadURL = urlRequest.url
         webView.load(urlRequest)
     }
     
@@ -1986,6 +1987,8 @@ class TabViewController: UIViewController {
         }
     }
 
+    private var pendingNativeLoadURL: URL?
+
     private lazy var navigationPixelResponder = NavigationPixelNavigationResponder(
         isErrorPageReload: { [weak self] navigationAction in
             // Keyed on URL — not just `isSpecialErrorPageVisible` — so the "error page reload" gate
@@ -2370,6 +2373,7 @@ extension TabViewController: WKNavigationDelegate {
     }
 
     func webView(_ webView: WKWebView, didCommit navigation: WKNavigation!) {
+        pendingNativeLoadURL = nil
         userScripts?.selectionFrameScript.reset()
 
         if let url = webView.url {
@@ -3055,6 +3059,7 @@ extension TabViewController: WKNavigationDelegate {
     
     func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
         Logger.general.debug("didFailProvisionalNavigation; error: \(error)")
+        pendingNativeLoadURL = nil
         adClickAttributionDetection.onDidFailNavigation()
         adClickExternalOpenDetector.failNavigation(error: error)
         hideProgressIndicator()
@@ -3233,6 +3238,10 @@ extension TabViewController: WKNavigationDelegate {
             break
         }
 
+        let inPageDuckAIEntrySource = Self.inPageDuckAIEntrySource(currentURL: url,
+                                                                   navigationAction: navigationAction,
+                                                                   pendingNativeLoadURL: pendingNativeLoadURL)
+
         // Same-frame boundary-cross link taps spawn a new tab (cross-frame is handled by `aiChatNewWindowDecision` above). Skip when ⌘ is held.
         // Runs before tracking-link/referrer/DNS rewrites — acceptable since the new tab re-runs the full policy pipeline; only originating-frame context is lost, which a boundary cross severs anyway.
         if navigationAction.navigationType == .linkActivated,
@@ -3249,12 +3258,28 @@ extension TabViewController: WKNavigationDelegate {
             )
             if decision == .openInNewTab {
                 wrappedHandler(.cancel)
-                delegate?.tab(self,
-                              didRequestNewTabForUrl: linkURL,
-                              openedByPage: true,
-                              inheritingAttribution: adClickAttributionLogic.state)
+                if let inPageDuckAIEntrySource {
+                    delegate?.tab(self,
+                                  didStartDuckAINavigationTo: linkURL,
+                                  entrySource: inPageDuckAIEntrySource,
+                                  opensNewTab: true,
+                                  inheritingAttribution: adClickAttributionLogic.state)
+                } else {
+                    delegate?.tab(self,
+                                  didRequestNewTabForUrl: linkURL,
+                                  openedByPage: true,
+                                  inheritingAttribution: adClickAttributionLogic.state)
+                }
                 return
             }
+        }
+
+        if let inPageDuckAIEntrySource, let targetURL = navigationAction.request.url {
+            delegate?.tab(self,
+                          didStartDuckAINavigationTo: targetURL,
+                          entrySource: inPageDuckAIEntrySource,
+                          opensNewTab: false,
+                          inheritingAttribution: nil)
         }
 
         // This check needs to happen before GPC checks. Otherwise the navigation type may be rewritten to `.other`

--- a/iOS/DuckDuckGo/TabViewControllerAIChatExtension.swift
+++ b/iOS/DuckDuckGo/TabViewControllerAIChatExtension.swift
@@ -168,4 +168,19 @@ extension TabViewController {
 
         return .openInNewTab(url)
     }
+
+    /// Page-started main-frame navigations into Duck.ai that native attributes. The tab's own loads
+    /// report their entry where they start, so the one still pending is skipped.
+    static func inPageDuckAIEntrySource(currentURL: URL?,
+                                        navigationAction: WKNavigationAction,
+                                        pendingNativeLoadURL: URL?) -> AIChatEntryPointSource? {
+        guard navigationAction.isTargetingMainFrame(),
+              navigationAction.navigationType != .backForward,
+              navigationAction.navigationType != .reload,
+              let targetURL = navigationAction.request.url,
+              targetURL != pendingNativeLoadURL else {
+            return nil
+        }
+        return AIChatEntryPointSource.forInPageNavigation(from: currentURL, to: targetURL)
+    }
 }

--- a/iOS/DuckDuckGo/TabsBarViewController.swift
+++ b/iOS/DuckDuckGo/TabsBarViewController.swift
@@ -998,11 +998,13 @@ extension MainViewController: TabsBarDelegate {
     }
 
     func tabsBarDidRequestNewFireTab(_ controller: TabsBarViewController) {
+        recordDuckAISessionPendingExit(.fireTabOpened)
         tabManager.setBrowsingMode(.fire, source: .longPressTabsIcon)
         newTab()
     }
 
     func tabsBarDidRequestNewNormalTab(_ controller: TabsBarViewController) {
+        recordDuckAISessionPendingExit(.newTabOpened)
         tabManager.setBrowsingMode(.normal, source: .longPressTabsIcon)
         newTab()
     }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
@@ -1216,6 +1216,9 @@ extension MainViewController {
         }
         postIdleSessionInstrumentation.sessionEnded(reason: postIdleSubmissionReason(for: query))
         recordNewTabPageSessionAction { $0.hitSubmit() }
+        if postIdleSubmissionReason(for: query) == .searchSubmitted {
+            recordDuckAISessionPendingExit(.searchStarted)
+        }
         loadQuery(query) { tab in
             if let duckAIEntrySource {
                 tab.duckAIEntrySource = duckAIEntrySource
@@ -1302,6 +1305,7 @@ extension MainViewController: UnifiedToggleInputDelegate {
 
     func unifiedToggleInputDidSubmitDuckAIPrompt(origin: AIChatEntryPointSource?) {
         postIdleSessionInstrumentation.promptSubmittedWithoutNavigation(origin: origin)
+        recordDuckAISessionPromptSubmittedOnCurrentTab()
     }
 
     func unifiedToggleInputDidSubmitPrompt(_ prompt: String, modelId: String?, tools: [AIChatRAGTool]?, reasoningEffort: AIChatReasoningEffort?, images: [AIChatNativePrompt.NativePromptImage]?, files: [AIChatNativePrompt.NativePromptFile]?) {
@@ -1520,6 +1524,7 @@ extension MainViewController: AIChatTabChatHeaderViewDelegate {
     }
 
     func aiChatTabChatHeaderDidTapNewChat() {
+        recordDuckAISessionNewChatCreatedOnCurrentTab()
         unifiedToggleInputCoordinator?.startNewChat()
         unifiedToggleInputCoordinator?.showExpanded(inputMode: .aiChat)
         currentTab?.submitStartChatAction()
@@ -1531,6 +1536,7 @@ extension MainViewController: AIChatTabChatHeaderViewDelegate {
 
     func aiChatTabChatHeaderDidTapNewImage() {
         DailyPixel.fireDailyAndCount(pixel: .aiChatNewImageTapped)
+        recordDuckAISessionNewChatCreatedOnCurrentTab()
         unifiedToggleInputCoordinator?.startNewChat()
         unifiedToggleInputCoordinator?.selectTool(.imageGeneration)
         unifiedToggleInputCoordinator?.showExpanded(inputMode: .aiChat)
@@ -1543,11 +1549,13 @@ extension MainViewController: AIChatTabChatHeaderViewDelegate {
 
     /// Force-search NTP. Override mode without committing — preserved toggle preference must survive.
     func aiChatTabChatHeaderDidTapNewSearch() {
+        recordDuckAISessionPendingExit(.searchStarted)
         newTab(reuseExisting: false, allowingKeyboard: true)
         unifiedToggleInputCoordinator?.syncInputModeFromExternalSource(.search)
     }
 
     func aiChatTabChatHeaderDidTapNewFireTab() {
+        recordDuckAISessionPendingExit(.fireTabOpened)
         tabManager.setBrowsingMode(.fire, source: .aiChatHeaderPlusMenu)
         newTab(reuseExisting: false, allowingKeyboard: true)
     }

--- a/iOS/DuckDuckGoTests/AIChat/AIChatUserScriptHandlerTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatUserScriptHandlerTests.swift
@@ -131,6 +131,26 @@ class AIChatUserScriptHandlerTests: XCTestCase {
         XCTAssertEqual(configValues?.installAge, 0)
     }
 
+    @MainActor
+    func testWhenOpenAIChatIsRequestedThenNotificationCarriesTheRequestingPageURL() async {
+        let homepage = URL(string: "https://duckduckgo.com/")!
+        let webView = StubURLWebView(frame: .zero)
+        webView.stubbedURL = homepage
+        let message = MockUserScriptMessage(messageName: "openAIChat",
+                                            messageBody: [:],
+                                            messageHost: "duckduckgo.com",
+                                            isMainFrame: true,
+                                            messageWebView: webView)
+        let notificationPosted = expectation(forNotification: .urlInterceptAIChat, object: nil) { notification in
+            notification.userInfo?[TabURLInterceptorParameter.aiChatRequestURL] as? URL == homepage
+                && notification.userInfo?[TabURLInterceptorParameter.aiChatRequestHost] as? String == "duckduckgo.com"
+        }
+
+        _ = await aiChatUserScriptHandler.openAIChat(params: [:], message: message)
+
+        await fulfillment(of: [notificationPosted], timeout: 1)
+    }
+
     func testGetAIChatNativeConfigValues() {
         // Given
         // MockFeatureFlagger is already initialized with .aiChatDeepLink enabled
@@ -990,6 +1010,11 @@ struct MockUserScriptMessage: UserScriptMessage {
     }
 }
 // swiftlint: enable inclusive_language
+
+private final class StubURLWebView: WKWebView {
+    var stubbedURL: URL?
+    override var url: URL? { stubbedURL }
+}
 
 private final class MockDevicePlatform: DevicePlatformProviding {
     static var isIphone = false

--- a/iOS/DuckDuckGoTests/AIChat/DuckAISessionInstrumentationTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/DuckAISessionInstrumentationTests.swift
@@ -68,6 +68,7 @@ struct DuckAISessionInstrumentationTests {
 
     // MARK: - Starting
 
+    @available(iOS 16, *)
     @Test("When a Duck.ai tab becomes visible then a session starts", .timeLimit(.minutes(1)))
     func whenDuckAITabBecomesVisibleThenSessionStarts() {
         let (sut, wideEvent) = makeSUT()
@@ -76,6 +77,7 @@ struct DuckAISessionInstrumentationTests {
         #expect(completions(wideEvent).isEmpty)
     }
 
+    @available(iOS 16, *)
     @Test("When the same snapshot is reported again then nothing happens", .timeLimit(.minutes(1)))
     func whenSameSnapshotRepeatsThenNothingHappens() {
         let (sut, wideEvent) = makeSUT()
@@ -86,6 +88,7 @@ struct DuckAISessionInstrumentationTests {
         #expect(completions(wideEvent).isEmpty)
     }
 
+    @available(iOS 16, *)
     @Test("When a web tab becomes visible with no session then nothing starts", .timeLimit(.minutes(1)))
     func whenWebTabVisibleWithoutSessionThenNothingStarts() {
         let (sut, wideEvent) = makeSUT()
@@ -93,6 +96,7 @@ struct DuckAISessionInstrumentationTests {
         #expect(started(wideEvent).isEmpty)
     }
 
+    @available(iOS 16, *)
     @Test("When the feature is disabled then no session starts", .timeLimit(.minutes(1)))
     func whenDisabledThenNothingStarts() {
         let (sut, wideEvent) = makeSUT(isEnabled: false)
@@ -102,6 +106,7 @@ struct DuckAISessionInstrumentationTests {
 
     // MARK: - Ending
 
+    @available(iOS 16, *)
     @Test("When another tab becomes visible with no pending exit then the session ends as other_navigation", .timeLimit(.minutes(1)))
     func whenAnotherTabVisibleWithoutPendingExitThenOtherNavigation() {
         let (sut, wideEvent) = makeSUT()
@@ -115,6 +120,7 @@ struct DuckAISessionInstrumentationTests {
         #expect(completed.first?.0.exitTrigger == .otherNavigation)
     }
 
+    @available(iOS 16, *)
     @Test("When a pending exit was recorded then it becomes the exit trigger", .timeLimit(.minutes(1)))
     func whenPendingExitRecordedThenItIsUsed() {
         let (sut, wideEvent) = makeSUT()
@@ -124,6 +130,7 @@ struct DuckAISessionInstrumentationTests {
         #expect(completions(wideEvent).first?.0.exitTrigger == .tabSwitched)
     }
 
+    @available(iOS 16, *)
     @Test("When a pending exit is recorded for another tab then it is ignored", .timeLimit(.minutes(1)))
     func whenPendingExitForOtherTabThenIgnored() {
         let (sut, wideEvent) = makeSUT()
@@ -133,6 +140,7 @@ struct DuckAISessionInstrumentationTests {
         #expect(completions(wideEvent).first?.0.exitTrigger == .otherNavigation)
     }
 
+    @available(iOS 16, *)
     @Test("When two pending exits are recorded then the first one wins", .timeLimit(.minutes(1)))
     func whenTwoPendingExitsThenFirstWins() {
         let (sut, wideEvent) = makeSUT()
@@ -143,6 +151,7 @@ struct DuckAISessionInstrumentationTests {
         #expect(completions(wideEvent).first?.0.exitTrigger == .searchStarted)
     }
 
+    @available(iOS 16, *)
     @Test("When the same tab stays on Duck.ai after a pending exit then the exit is cleared and the session continues", .timeLimit(.minutes(1)))
     func whenSameTabStaysOnDuckAIThenPendingExitIsCleared() {
         let (sut, wideEvent) = makeSUT()
@@ -155,6 +164,7 @@ struct DuckAISessionInstrumentationTests {
         #expect(completions(wideEvent).first?.0.exitTrigger == .otherNavigation)
     }
 
+    @available(iOS 16, *)
     @Test("When the same tab navigates to a non-Duck.ai page then the session ends", .timeLimit(.minutes(1)))
     func whenSameTabLeavesDuckAIThenSessionEnds() {
         let (sut, wideEvent) = makeSUT()
@@ -168,6 +178,7 @@ struct DuckAISessionInstrumentationTests {
         #expect(started(wideEvent).count == 1)
     }
 
+    @available(iOS 16, *)
     @Test("When switching between two Duck.ai tabs then the old session ends and a new one starts", .timeLimit(.minutes(1)))
     func whenSwitchingBetweenDuckAITabsThenOldEndsAndNewStarts() {
         let (sut, wideEvent) = makeSUT()
@@ -180,6 +191,7 @@ struct DuckAISessionInstrumentationTests {
         #expect(started(wideEvent).count == 2)
     }
 
+    @available(iOS 16, *)
     @Test("When no tab is visible then the session ends", .timeLimit(.minutes(1)))
     func whenNoTabVisibleThenSessionEnds() {
         let (sut, wideEvent) = makeSUT()
@@ -189,6 +201,7 @@ struct DuckAISessionInstrumentationTests {
         #expect(completions(wideEvent).first?.0.exitTrigger == .otherNavigation)
     }
 
+    @available(iOS 16, *)
     @Test("When a session ended then a later Duck.ai tab starts a new session", .timeLimit(.minutes(1)))
     func whenSessionEndedThenNewSessionCanStart() {
         let (sut, wideEvent) = makeSUT()
@@ -201,6 +214,7 @@ struct DuckAISessionInstrumentationTests {
 
     // MARK: - Background
 
+    @available(iOS 16, *)
     @Test("When the app backgrounds with a session then it completes as CANCELLED app_backgrounded", .timeLimit(.minutes(1)))
     func whenBackgroundedThenCancelledWithAppBackgrounded() {
         let (sut, wideEvent) = makeSUT()
@@ -215,6 +229,7 @@ struct DuckAISessionInstrumentationTests {
         #expect(completed.first?.0.exitTrigger == nil)
     }
 
+    @available(iOS 16, *)
     @Test("When the app backgrounds then a stale pending exit does not leak into the next session", .timeLimit(.minutes(1)))
     func whenBackgroundedThenPendingExitIsCleared() {
         let (sut, wideEvent) = makeSUT()
@@ -227,6 +242,7 @@ struct DuckAISessionInstrumentationTests {
         #expect(completions(wideEvent).last?.0.exitTrigger == .otherNavigation)
     }
 
+    @available(iOS 16, *)
     @Test("When the app backgrounds with no session then nothing completes", .timeLimit(.minutes(1)))
     func whenBackgroundedWithoutSessionThenNothingCompletes() {
         let (sut, wideEvent) = makeSUT()
@@ -236,6 +252,7 @@ struct DuckAISessionInstrumentationTests {
 
     // MARK: - Orphans
 
+    @available(iOS 16, *)
     @Test("When constructed with orphaned flows then they complete as UNKNOWN app_terminated", .timeLimit(.minutes(1)))
     func whenOrphansExistAtInitThenCompletedAsAppTerminated() {
         let orphan = DuckAISessionWideEventData(promptSubmitted: true)
@@ -247,6 +264,7 @@ struct DuckAISessionInstrumentationTests {
         #expect(completed.first?.0.promptSubmitted == true)
     }
 
+    @available(iOS 16, *)
     @Test("When constructed without the orphan sweep then persisted flows are left alone", .timeLimit(.minutes(1)))
     func whenNoOrphanSweepThenPersistedFlowsUntouched() {
         let (_, wideEvent) = makeSUT(completeOrphanedFlowsOnInit: false, seededFlows: [DuckAISessionWideEventData()])
@@ -255,6 +273,7 @@ struct DuckAISessionInstrumentationTests {
 
     // MARK: - Steps
 
+    @available(iOS 16, *)
     @Test("When a prompt is submitted then the step is recorded once", .timeLimit(.minutes(1)))
     func whenPromptSubmittedThenStepRecordedOnce() {
         let (sut, wideEvent) = makeSUT()
@@ -266,6 +285,7 @@ struct DuckAISessionInstrumentationTests {
         #expect(started(wideEvent).first?.promptSubmitted == true)
     }
 
+    @available(iOS 16, *)
     @Test("When a prompt is submitted in another tab then it is ignored", .timeLimit(.minutes(1)))
     func whenPromptSubmittedInOtherTabThenIgnored() {
         let (sut, wideEvent) = makeSUT()
@@ -275,6 +295,7 @@ struct DuckAISessionInstrumentationTests {
         #expect(started(wideEvent).first?.promptSubmitted == false)
     }
 
+    @available(iOS 16, *)
     @Test("When a prompt is submitted with no session then nothing is recorded", .timeLimit(.minutes(1)))
     func whenPromptSubmittedWithoutSessionThenIgnored() {
         let (sut, wideEvent) = makeSUT()
@@ -282,6 +303,7 @@ struct DuckAISessionInstrumentationTests {
         #expect(updates(wideEvent).isEmpty)
     }
 
+    @available(iOS 16, *)
     @Test("When a new chat is created then the step is recorded", .timeLimit(.minutes(1)))
     func whenNewChatCreatedThenStepRecorded() {
         let (sut, wideEvent) = makeSUT()
@@ -291,6 +313,7 @@ struct DuckAISessionInstrumentationTests {
         #expect(updates(wideEvent).count == 1)
     }
 
+    @available(iOS 16, *)
     @Test("When the session starts with a chat ID then that baseline is not a change", .timeLimit(.minutes(1)))
     func whenSessionStartsWithChatIDThenNotCounted() {
         let (sut, wideEvent) = makeSUT()
@@ -299,6 +322,7 @@ struct DuckAISessionInstrumentationTests {
         #expect(updates(wideEvent).isEmpty)
     }
 
+    @available(iOS 16, *)
     @Test("When the chat ID goes from missing to present then chat_id_changed is recorded", .timeLimit(.minutes(1)))
     func whenChatIDAppearsThenChangeRecorded() {
         let (sut, wideEvent) = makeSUT()
@@ -307,6 +331,7 @@ struct DuckAISessionInstrumentationTests {
         #expect(started(wideEvent).first?.chatIDChanged == true)
     }
 
+    @available(iOS 16, *)
     @Test("When the chat ID changes to another value then chat_id_changed is recorded", .timeLimit(.minutes(1)))
     func whenChatIDChangesThenChangeRecorded() {
         let (sut, wideEvent) = makeSUT()
@@ -316,6 +341,7 @@ struct DuckAISessionInstrumentationTests {
         #expect(completions(wideEvent).isEmpty)
     }
 
+    @available(iOS 16, *)
     @Test("When the URL changes but the chat ID does not then no step is recorded", .timeLimit(.minutes(1)))
     func whenURLChangesWithoutChatIDChangeThenNoStep() {
         let (sut, wideEvent) = makeSUT()
@@ -325,6 +351,7 @@ struct DuckAISessionInstrumentationTests {
         #expect(updates(wideEvent).isEmpty)
     }
 
+    @available(iOS 16, *)
     @Test("When steps were recorded then they are present on the completed flow", .timeLimit(.minutes(1)))
     func whenStepsRecordedThenPresentOnCompletion() {
         let (sut, wideEvent) = makeSUT()

--- a/iOS/DuckDuckGoTests/AIChat/DuckAISessionInstrumentationTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/DuckAISessionInstrumentationTests.swift
@@ -1,0 +1,341 @@
+//
+//  DuckAISessionInstrumentationTests.swift
+//  DuckDuckGoTests
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import Testing
+@_spi(Testing) import PixelKit
+@testable import DuckDuckGo
+
+@Suite("Duck.ai Session Instrumentation")
+struct DuckAISessionInstrumentationTests {
+
+    private static let chatTab: TabUID = "chat-tab"
+    private static let otherChatTab: TabUID = "other-chat-tab"
+    private static let webTab: TabUID = "web-tab"
+
+    private func makeSUT(isEnabled: Bool = true,
+                         completeOrphanedFlowsOnInit: Bool = false,
+                         seededFlows: [DuckAISessionWideEventData] = []) -> (DefaultDuckAISessionInstrumentation, WideEventMock) {
+        let wideEvent = WideEventMock()
+        seededFlows.forEach { wideEvent.startFlow($0) }
+        let sut = DefaultDuckAISessionInstrumentation(wideEvent: wideEvent,
+                                                      isEnabled: { isEnabled },
+                                                      completeOrphanedFlowsOnInit: completeOrphanedFlowsOnInit)
+        return (sut, wideEvent)
+    }
+
+    private func duckAI(_ uid: TabUID, chatID: String? = nil, path: String = "") -> DuckAISessionTabSnapshot {
+        var components = URLComponents(string: "https://duckduckgo.com/\(path)?q=DuckDuckGo+AI+Chat&ia=chat&duckai=4")!
+        if let chatID {
+            components.queryItems?.append(URLQueryItem(name: "chatID", value: chatID))
+        }
+        return DuckAISessionTabSnapshot(uid: uid, isDuckAI: true, url: components.url, chatID: chatID)
+    }
+
+    private func web(_ uid: TabUID) -> DuckAISessionTabSnapshot {
+        DuckAISessionTabSnapshot(uid: uid, isDuckAI: false, url: URL(string: "https://example.com")!, chatID: nil)
+    }
+
+    private func started(_ wideEvent: WideEventMock) -> [DuckAISessionWideEventData] {
+        wideEvent.started.compactMap { $0 as? DuckAISessionWideEventData }
+    }
+
+    private func updates(_ wideEvent: WideEventMock) -> [DuckAISessionWideEventData] {
+        wideEvent.updates.compactMap { $0 as? DuckAISessionWideEventData }
+    }
+
+    private func completions(_ wideEvent: WideEventMock) -> [(DuckAISessionWideEventData, WideEventStatus)] {
+        wideEvent.completions.compactMap { data, status in
+            (data as? DuckAISessionWideEventData).map { ($0, status) }
+        }
+    }
+
+    // MARK: - Starting
+
+    @Test("When a Duck.ai tab becomes visible then a session starts")
+    func whenDuckAITabBecomesVisibleThenSessionStarts() {
+        let (sut, wideEvent) = makeSUT()
+        sut.visibleTabDidChange(duckAI(Self.chatTab))
+        #expect(started(wideEvent).count == 1)
+        #expect(completions(wideEvent).isEmpty)
+    }
+
+    @Test("When the same snapshot is reported again then nothing happens")
+    func whenSameSnapshotRepeatsThenNothingHappens() {
+        let (sut, wideEvent) = makeSUT()
+        sut.visibleTabDidChange(duckAI(Self.chatTab, chatID: "abc"))
+        sut.visibleTabDidChange(duckAI(Self.chatTab, chatID: "abc"))
+        #expect(started(wideEvent).count == 1)
+        #expect(updates(wideEvent).isEmpty)
+        #expect(completions(wideEvent).isEmpty)
+    }
+
+    @Test("When a web tab becomes visible with no session then nothing starts")
+    func whenWebTabVisibleWithoutSessionThenNothingStarts() {
+        let (sut, wideEvent) = makeSUT()
+        sut.visibleTabDidChange(web(Self.webTab))
+        #expect(started(wideEvent).isEmpty)
+    }
+
+    @Test("When the feature is disabled then no session starts")
+    func whenDisabledThenNothingStarts() {
+        let (sut, wideEvent) = makeSUT(isEnabled: false)
+        sut.visibleTabDidChange(duckAI(Self.chatTab))
+        #expect(started(wideEvent).isEmpty)
+    }
+
+    // MARK: - Ending
+
+    @Test("When another tab becomes visible with no pending exit then the session ends as other_navigation")
+    func whenAnotherTabVisibleWithoutPendingExitThenOtherNavigation() {
+        let (sut, wideEvent) = makeSUT()
+        sut.visibleTabDidChange(duckAI(Self.chatTab))
+        sut.visibleTabDidChange(web(Self.webTab))
+
+        let completed = completions(wideEvent)
+        #expect(completed.count == 1)
+        #expect(completed.first?.1 == .success(reason: "left_duckai"))
+        #expect(completed.first?.0.statusReason == .leftDuckai)
+        #expect(completed.first?.0.exitTrigger == .otherNavigation)
+    }
+
+    @Test("When a pending exit was recorded then it becomes the exit trigger")
+    func whenPendingExitRecordedThenItIsUsed() {
+        let (sut, wideEvent) = makeSUT()
+        sut.visibleTabDidChange(duckAI(Self.chatTab))
+        sut.recordPendingExit(tabUID: Self.chatTab, trigger: .tabSwitched)
+        sut.visibleTabDidChange(web(Self.webTab))
+        #expect(completions(wideEvent).first?.0.exitTrigger == .tabSwitched)
+    }
+
+    @Test("When a pending exit is recorded for another tab then it is ignored")
+    func whenPendingExitForOtherTabThenIgnored() {
+        let (sut, wideEvent) = makeSUT()
+        sut.visibleTabDidChange(duckAI(Self.chatTab))
+        sut.recordPendingExit(tabUID: Self.webTab, trigger: .tabSwitched)
+        sut.visibleTabDidChange(web(Self.webTab))
+        #expect(completions(wideEvent).first?.0.exitTrigger == .otherNavigation)
+    }
+
+    @Test("When two pending exits are recorded then the first one wins")
+    func whenTwoPendingExitsThenFirstWins() {
+        let (sut, wideEvent) = makeSUT()
+        sut.visibleTabDidChange(duckAI(Self.chatTab))
+        sut.recordPendingExit(tabUID: Self.chatTab, trigger: .searchStarted)
+        sut.recordPendingExit(tabUID: Self.chatTab, trigger: .newTabOpened)
+        sut.visibleTabDidChange(web(Self.webTab))
+        #expect(completions(wideEvent).first?.0.exitTrigger == .searchStarted)
+    }
+
+    @Test("When the same tab stays on Duck.ai after a pending exit then the exit is cleared and the session continues")
+    func whenSameTabStaysOnDuckAIThenPendingExitIsCleared() {
+        let (sut, wideEvent) = makeSUT()
+        sut.visibleTabDidChange(duckAI(Self.chatTab, chatID: "one"))
+        sut.recordPendingExit(tabUID: Self.chatTab, trigger: .backOrClose)
+        sut.visibleTabDidChange(duckAI(Self.chatTab, chatID: "two"))
+        #expect(completions(wideEvent).isEmpty)
+
+        sut.visibleTabDidChange(web(Self.webTab))
+        #expect(completions(wideEvent).first?.0.exitTrigger == .otherNavigation)
+    }
+
+    @Test("When the same tab navigates to a non-Duck.ai page then the session ends")
+    func whenSameTabLeavesDuckAIThenSessionEnds() {
+        let (sut, wideEvent) = makeSUT()
+        sut.visibleTabDidChange(duckAI(Self.chatTab))
+        sut.recordPendingExit(tabUID: Self.chatTab, trigger: .searchStarted)
+        sut.visibleTabDidChange(web(Self.chatTab))
+
+        let completed = completions(wideEvent)
+        #expect(completed.count == 1)
+        #expect(completed.first?.0.exitTrigger == .searchStarted)
+        #expect(started(wideEvent).count == 1)
+    }
+
+    @Test("When switching between two Duck.ai tabs then the old session ends and a new one starts")
+    func whenSwitchingBetweenDuckAITabsThenOldEndsAndNewStarts() {
+        let (sut, wideEvent) = makeSUT()
+        sut.visibleTabDidChange(duckAI(Self.chatTab))
+        sut.recordPendingExit(tabUID: Self.chatTab, trigger: .tabSwitched)
+        sut.visibleTabDidChange(duckAI(Self.otherChatTab))
+
+        #expect(completions(wideEvent).count == 1)
+        #expect(completions(wideEvent).first?.0.exitTrigger == .tabSwitched)
+        #expect(started(wideEvent).count == 2)
+    }
+
+    @Test("When no tab is visible then the session ends")
+    func whenNoTabVisibleThenSessionEnds() {
+        let (sut, wideEvent) = makeSUT()
+        sut.visibleTabDidChange(duckAI(Self.chatTab))
+        sut.visibleTabDidChange(nil)
+        #expect(completions(wideEvent).count == 1)
+        #expect(completions(wideEvent).first?.0.exitTrigger == .otherNavigation)
+    }
+
+    @Test("When a session ended then a later Duck.ai tab starts a new session")
+    func whenSessionEndedThenNewSessionCanStart() {
+        let (sut, wideEvent) = makeSUT()
+        sut.visibleTabDidChange(duckAI(Self.chatTab))
+        sut.visibleTabDidChange(web(Self.webTab))
+        sut.visibleTabDidChange(duckAI(Self.chatTab))
+        #expect(started(wideEvent).count == 2)
+        #expect(completions(wideEvent).count == 1)
+    }
+
+    // MARK: - Background
+
+    @Test("When the app backgrounds with a session then it completes as CANCELLED app_backgrounded")
+    func whenBackgroundedThenCancelledWithAppBackgrounded() {
+        let (sut, wideEvent) = makeSUT()
+        sut.visibleTabDidChange(duckAI(Self.chatTab))
+        sut.recordPendingExit(tabUID: Self.chatTab, trigger: .tabSwitched)
+        sut.sessionCancelledByBackground()
+
+        let completed = completions(wideEvent)
+        #expect(completed.count == 1)
+        #expect(completed.first?.1 == .cancelled)
+        #expect(completed.first?.0.statusReason == .appBackgrounded)
+        #expect(completed.first?.0.exitTrigger == nil)
+    }
+
+    @Test("When the app backgrounds then a stale pending exit does not leak into the next session")
+    func whenBackgroundedThenPendingExitIsCleared() {
+        let (sut, wideEvent) = makeSUT()
+        sut.visibleTabDidChange(duckAI(Self.chatTab))
+        sut.recordPendingExit(tabUID: Self.chatTab, trigger: .tabSwitched)
+        sut.sessionCancelledByBackground()
+
+        sut.visibleTabDidChange(duckAI(Self.chatTab))
+        sut.visibleTabDidChange(web(Self.webTab))
+        #expect(completions(wideEvent).last?.0.exitTrigger == .otherNavigation)
+    }
+
+    @Test("When the app backgrounds with no session then nothing completes")
+    func whenBackgroundedWithoutSessionThenNothingCompletes() {
+        let (sut, wideEvent) = makeSUT()
+        sut.sessionCancelledByBackground()
+        #expect(completions(wideEvent).isEmpty)
+    }
+
+    // MARK: - Orphans
+
+    @Test("When constructed with orphaned flows then they complete as UNKNOWN app_terminated")
+    func whenOrphansExistAtInitThenCompletedAsAppTerminated() {
+        let orphan = DuckAISessionWideEventData(promptSubmitted: true)
+        let (_, wideEvent) = makeSUT(completeOrphanedFlowsOnInit: true, seededFlows: [orphan])
+
+        let completed = completions(wideEvent)
+        #expect(completed.count == 1)
+        #expect(completed.first?.1 == .unknown(reason: "app_terminated"))
+        #expect(completed.first?.0.promptSubmitted == true)
+    }
+
+    @Test("When constructed without the orphan sweep then persisted flows are left alone")
+    func whenNoOrphanSweepThenPersistedFlowsUntouched() {
+        let (_, wideEvent) = makeSUT(completeOrphanedFlowsOnInit: false, seededFlows: [DuckAISessionWideEventData()])
+        #expect(completions(wideEvent).isEmpty)
+    }
+
+    // MARK: - Steps
+
+    @Test("When a prompt is submitted then the step is recorded once")
+    func whenPromptSubmittedThenStepRecordedOnce() {
+        let (sut, wideEvent) = makeSUT()
+        sut.visibleTabDidChange(duckAI(Self.chatTab))
+        sut.promptSubmitted(tabUID: Self.chatTab)
+        sut.promptSubmitted(tabUID: Self.chatTab)
+
+        #expect(updates(wideEvent).count == 1)
+        #expect(started(wideEvent).first?.promptSubmitted == true)
+    }
+
+    @Test("When a prompt is submitted in another tab then it is ignored")
+    func whenPromptSubmittedInOtherTabThenIgnored() {
+        let (sut, wideEvent) = makeSUT()
+        sut.visibleTabDidChange(duckAI(Self.chatTab))
+        sut.promptSubmitted(tabUID: Self.otherChatTab)
+        #expect(updates(wideEvent).isEmpty)
+        #expect(started(wideEvent).first?.promptSubmitted == false)
+    }
+
+    @Test("When a prompt is submitted with no session then nothing is recorded")
+    func whenPromptSubmittedWithoutSessionThenIgnored() {
+        let (sut, wideEvent) = makeSUT()
+        sut.promptSubmitted(tabUID: Self.chatTab)
+        #expect(updates(wideEvent).isEmpty)
+    }
+
+    @Test("When a new chat is created then the step is recorded")
+    func whenNewChatCreatedThenStepRecorded() {
+        let (sut, wideEvent) = makeSUT()
+        sut.visibleTabDidChange(duckAI(Self.chatTab))
+        sut.newChatCreated(tabUID: Self.chatTab)
+        #expect(started(wideEvent).first?.newChatCreated == true)
+        #expect(updates(wideEvent).count == 1)
+    }
+
+    @Test("When the session starts with a chat ID then that baseline is not a change")
+    func whenSessionStartsWithChatIDThenNotCounted() {
+        let (sut, wideEvent) = makeSUT()
+        sut.visibleTabDidChange(duckAI(Self.chatTab, chatID: "abc"))
+        #expect(started(wideEvent).first?.chatIDChanged == false)
+        #expect(updates(wideEvent).isEmpty)
+    }
+
+    @Test("When the chat ID goes from missing to present then chat_id_changed is recorded")
+    func whenChatIDAppearsThenChangeRecorded() {
+        let (sut, wideEvent) = makeSUT()
+        sut.visibleTabDidChange(duckAI(Self.chatTab))
+        sut.visibleTabDidChange(duckAI(Self.chatTab, chatID: "abc"))
+        #expect(started(wideEvent).first?.chatIDChanged == true)
+    }
+
+    @Test("When the chat ID changes to another value then chat_id_changed is recorded")
+    func whenChatIDChangesThenChangeRecorded() {
+        let (sut, wideEvent) = makeSUT()
+        sut.visibleTabDidChange(duckAI(Self.chatTab, chatID: "abc"))
+        sut.visibleTabDidChange(duckAI(Self.chatTab, chatID: "def"))
+        #expect(started(wideEvent).first?.chatIDChanged == true)
+        #expect(completions(wideEvent).isEmpty)
+    }
+
+    @Test("When the URL changes but the chat ID does not then no step is recorded")
+    func whenURLChangesWithoutChatIDChangeThenNoStep() {
+        let (sut, wideEvent) = makeSUT()
+        sut.visibleTabDidChange(duckAI(Self.chatTab, chatID: "abc"))
+        sut.visibleTabDidChange(duckAI(Self.chatTab, chatID: "abc", path: "settings"))
+        #expect(started(wideEvent).first?.chatIDChanged == false)
+        #expect(updates(wideEvent).isEmpty)
+    }
+
+    @Test("When steps were recorded then they are present on the completed flow")
+    func whenStepsRecordedThenPresentOnCompletion() {
+        let (sut, wideEvent) = makeSUT()
+        sut.visibleTabDidChange(duckAI(Self.chatTab))
+        sut.promptSubmitted(tabUID: Self.chatTab)
+        sut.visibleTabDidChange(duckAI(Self.chatTab, chatID: "abc"))
+        sut.visibleTabDidChange(web(Self.webTab))
+
+        let data = completions(wideEvent).first?.0
+        #expect(data?.promptSubmitted == true)
+        #expect(data?.chatIDChanged == true)
+        #expect(data?.newChatCreated == false)
+    }
+}

--- a/iOS/DuckDuckGoTests/AIChat/DuckAISessionInstrumentationTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/DuckAISessionInstrumentationTests.swift
@@ -68,7 +68,7 @@ struct DuckAISessionInstrumentationTests {
 
     // MARK: - Starting
 
-    @Test("When a Duck.ai tab becomes visible then a session starts")
+    @Test("When a Duck.ai tab becomes visible then a session starts", .timeLimit(.minutes(1)))
     func whenDuckAITabBecomesVisibleThenSessionStarts() {
         let (sut, wideEvent) = makeSUT()
         sut.visibleTabDidChange(duckAI(Self.chatTab))
@@ -76,7 +76,7 @@ struct DuckAISessionInstrumentationTests {
         #expect(completions(wideEvent).isEmpty)
     }
 
-    @Test("When the same snapshot is reported again then nothing happens")
+    @Test("When the same snapshot is reported again then nothing happens", .timeLimit(.minutes(1)))
     func whenSameSnapshotRepeatsThenNothingHappens() {
         let (sut, wideEvent) = makeSUT()
         sut.visibleTabDidChange(duckAI(Self.chatTab, chatID: "abc"))
@@ -86,14 +86,14 @@ struct DuckAISessionInstrumentationTests {
         #expect(completions(wideEvent).isEmpty)
     }
 
-    @Test("When a web tab becomes visible with no session then nothing starts")
+    @Test("When a web tab becomes visible with no session then nothing starts", .timeLimit(.minutes(1)))
     func whenWebTabVisibleWithoutSessionThenNothingStarts() {
         let (sut, wideEvent) = makeSUT()
         sut.visibleTabDidChange(web(Self.webTab))
         #expect(started(wideEvent).isEmpty)
     }
 
-    @Test("When the feature is disabled then no session starts")
+    @Test("When the feature is disabled then no session starts", .timeLimit(.minutes(1)))
     func whenDisabledThenNothingStarts() {
         let (sut, wideEvent) = makeSUT(isEnabled: false)
         sut.visibleTabDidChange(duckAI(Self.chatTab))
@@ -102,7 +102,7 @@ struct DuckAISessionInstrumentationTests {
 
     // MARK: - Ending
 
-    @Test("When another tab becomes visible with no pending exit then the session ends as other_navigation")
+    @Test("When another tab becomes visible with no pending exit then the session ends as other_navigation", .timeLimit(.minutes(1)))
     func whenAnotherTabVisibleWithoutPendingExitThenOtherNavigation() {
         let (sut, wideEvent) = makeSUT()
         sut.visibleTabDidChange(duckAI(Self.chatTab))
@@ -115,7 +115,7 @@ struct DuckAISessionInstrumentationTests {
         #expect(completed.first?.0.exitTrigger == .otherNavigation)
     }
 
-    @Test("When a pending exit was recorded then it becomes the exit trigger")
+    @Test("When a pending exit was recorded then it becomes the exit trigger", .timeLimit(.minutes(1)))
     func whenPendingExitRecordedThenItIsUsed() {
         let (sut, wideEvent) = makeSUT()
         sut.visibleTabDidChange(duckAI(Self.chatTab))
@@ -124,7 +124,7 @@ struct DuckAISessionInstrumentationTests {
         #expect(completions(wideEvent).first?.0.exitTrigger == .tabSwitched)
     }
 
-    @Test("When a pending exit is recorded for another tab then it is ignored")
+    @Test("When a pending exit is recorded for another tab then it is ignored", .timeLimit(.minutes(1)))
     func whenPendingExitForOtherTabThenIgnored() {
         let (sut, wideEvent) = makeSUT()
         sut.visibleTabDidChange(duckAI(Self.chatTab))
@@ -133,7 +133,7 @@ struct DuckAISessionInstrumentationTests {
         #expect(completions(wideEvent).first?.0.exitTrigger == .otherNavigation)
     }
 
-    @Test("When two pending exits are recorded then the first one wins")
+    @Test("When two pending exits are recorded then the first one wins", .timeLimit(.minutes(1)))
     func whenTwoPendingExitsThenFirstWins() {
         let (sut, wideEvent) = makeSUT()
         sut.visibleTabDidChange(duckAI(Self.chatTab))
@@ -143,7 +143,7 @@ struct DuckAISessionInstrumentationTests {
         #expect(completions(wideEvent).first?.0.exitTrigger == .searchStarted)
     }
 
-    @Test("When the same tab stays on Duck.ai after a pending exit then the exit is cleared and the session continues")
+    @Test("When the same tab stays on Duck.ai after a pending exit then the exit is cleared and the session continues", .timeLimit(.minutes(1)))
     func whenSameTabStaysOnDuckAIThenPendingExitIsCleared() {
         let (sut, wideEvent) = makeSUT()
         sut.visibleTabDidChange(duckAI(Self.chatTab, chatID: "one"))
@@ -155,7 +155,7 @@ struct DuckAISessionInstrumentationTests {
         #expect(completions(wideEvent).first?.0.exitTrigger == .otherNavigation)
     }
 
-    @Test("When the same tab navigates to a non-Duck.ai page then the session ends")
+    @Test("When the same tab navigates to a non-Duck.ai page then the session ends", .timeLimit(.minutes(1)))
     func whenSameTabLeavesDuckAIThenSessionEnds() {
         let (sut, wideEvent) = makeSUT()
         sut.visibleTabDidChange(duckAI(Self.chatTab))
@@ -168,7 +168,7 @@ struct DuckAISessionInstrumentationTests {
         #expect(started(wideEvent).count == 1)
     }
 
-    @Test("When switching between two Duck.ai tabs then the old session ends and a new one starts")
+    @Test("When switching between two Duck.ai tabs then the old session ends and a new one starts", .timeLimit(.minutes(1)))
     func whenSwitchingBetweenDuckAITabsThenOldEndsAndNewStarts() {
         let (sut, wideEvent) = makeSUT()
         sut.visibleTabDidChange(duckAI(Self.chatTab))
@@ -180,7 +180,7 @@ struct DuckAISessionInstrumentationTests {
         #expect(started(wideEvent).count == 2)
     }
 
-    @Test("When no tab is visible then the session ends")
+    @Test("When no tab is visible then the session ends", .timeLimit(.minutes(1)))
     func whenNoTabVisibleThenSessionEnds() {
         let (sut, wideEvent) = makeSUT()
         sut.visibleTabDidChange(duckAI(Self.chatTab))
@@ -189,7 +189,7 @@ struct DuckAISessionInstrumentationTests {
         #expect(completions(wideEvent).first?.0.exitTrigger == .otherNavigation)
     }
 
-    @Test("When a session ended then a later Duck.ai tab starts a new session")
+    @Test("When a session ended then a later Duck.ai tab starts a new session", .timeLimit(.minutes(1)))
     func whenSessionEndedThenNewSessionCanStart() {
         let (sut, wideEvent) = makeSUT()
         sut.visibleTabDidChange(duckAI(Self.chatTab))
@@ -201,7 +201,7 @@ struct DuckAISessionInstrumentationTests {
 
     // MARK: - Background
 
-    @Test("When the app backgrounds with a session then it completes as CANCELLED app_backgrounded")
+    @Test("When the app backgrounds with a session then it completes as CANCELLED app_backgrounded", .timeLimit(.minutes(1)))
     func whenBackgroundedThenCancelledWithAppBackgrounded() {
         let (sut, wideEvent) = makeSUT()
         sut.visibleTabDidChange(duckAI(Self.chatTab))
@@ -215,7 +215,7 @@ struct DuckAISessionInstrumentationTests {
         #expect(completed.first?.0.exitTrigger == nil)
     }
 
-    @Test("When the app backgrounds then a stale pending exit does not leak into the next session")
+    @Test("When the app backgrounds then a stale pending exit does not leak into the next session", .timeLimit(.minutes(1)))
     func whenBackgroundedThenPendingExitIsCleared() {
         let (sut, wideEvent) = makeSUT()
         sut.visibleTabDidChange(duckAI(Self.chatTab))
@@ -227,7 +227,7 @@ struct DuckAISessionInstrumentationTests {
         #expect(completions(wideEvent).last?.0.exitTrigger == .otherNavigation)
     }
 
-    @Test("When the app backgrounds with no session then nothing completes")
+    @Test("When the app backgrounds with no session then nothing completes", .timeLimit(.minutes(1)))
     func whenBackgroundedWithoutSessionThenNothingCompletes() {
         let (sut, wideEvent) = makeSUT()
         sut.sessionCancelledByBackground()
@@ -236,7 +236,7 @@ struct DuckAISessionInstrumentationTests {
 
     // MARK: - Orphans
 
-    @Test("When constructed with orphaned flows then they complete as UNKNOWN app_terminated")
+    @Test("When constructed with orphaned flows then they complete as UNKNOWN app_terminated", .timeLimit(.minutes(1)))
     func whenOrphansExistAtInitThenCompletedAsAppTerminated() {
         let orphan = DuckAISessionWideEventData(promptSubmitted: true)
         let (_, wideEvent) = makeSUT(completeOrphanedFlowsOnInit: true, seededFlows: [orphan])
@@ -247,7 +247,7 @@ struct DuckAISessionInstrumentationTests {
         #expect(completed.first?.0.promptSubmitted == true)
     }
 
-    @Test("When constructed without the orphan sweep then persisted flows are left alone")
+    @Test("When constructed without the orphan sweep then persisted flows are left alone", .timeLimit(.minutes(1)))
     func whenNoOrphanSweepThenPersistedFlowsUntouched() {
         let (_, wideEvent) = makeSUT(completeOrphanedFlowsOnInit: false, seededFlows: [DuckAISessionWideEventData()])
         #expect(completions(wideEvent).isEmpty)
@@ -255,7 +255,7 @@ struct DuckAISessionInstrumentationTests {
 
     // MARK: - Steps
 
-    @Test("When a prompt is submitted then the step is recorded once")
+    @Test("When a prompt is submitted then the step is recorded once", .timeLimit(.minutes(1)))
     func whenPromptSubmittedThenStepRecordedOnce() {
         let (sut, wideEvent) = makeSUT()
         sut.visibleTabDidChange(duckAI(Self.chatTab))
@@ -266,7 +266,7 @@ struct DuckAISessionInstrumentationTests {
         #expect(started(wideEvent).first?.promptSubmitted == true)
     }
 
-    @Test("When a prompt is submitted in another tab then it is ignored")
+    @Test("When a prompt is submitted in another tab then it is ignored", .timeLimit(.minutes(1)))
     func whenPromptSubmittedInOtherTabThenIgnored() {
         let (sut, wideEvent) = makeSUT()
         sut.visibleTabDidChange(duckAI(Self.chatTab))
@@ -275,14 +275,14 @@ struct DuckAISessionInstrumentationTests {
         #expect(started(wideEvent).first?.promptSubmitted == false)
     }
 
-    @Test("When a prompt is submitted with no session then nothing is recorded")
+    @Test("When a prompt is submitted with no session then nothing is recorded", .timeLimit(.minutes(1)))
     func whenPromptSubmittedWithoutSessionThenIgnored() {
         let (sut, wideEvent) = makeSUT()
         sut.promptSubmitted(tabUID: Self.chatTab)
         #expect(updates(wideEvent).isEmpty)
     }
 
-    @Test("When a new chat is created then the step is recorded")
+    @Test("When a new chat is created then the step is recorded", .timeLimit(.minutes(1)))
     func whenNewChatCreatedThenStepRecorded() {
         let (sut, wideEvent) = makeSUT()
         sut.visibleTabDidChange(duckAI(Self.chatTab))
@@ -291,7 +291,7 @@ struct DuckAISessionInstrumentationTests {
         #expect(updates(wideEvent).count == 1)
     }
 
-    @Test("When the session starts with a chat ID then that baseline is not a change")
+    @Test("When the session starts with a chat ID then that baseline is not a change", .timeLimit(.minutes(1)))
     func whenSessionStartsWithChatIDThenNotCounted() {
         let (sut, wideEvent) = makeSUT()
         sut.visibleTabDidChange(duckAI(Self.chatTab, chatID: "abc"))
@@ -299,7 +299,7 @@ struct DuckAISessionInstrumentationTests {
         #expect(updates(wideEvent).isEmpty)
     }
 
-    @Test("When the chat ID goes from missing to present then chat_id_changed is recorded")
+    @Test("When the chat ID goes from missing to present then chat_id_changed is recorded", .timeLimit(.minutes(1)))
     func whenChatIDAppearsThenChangeRecorded() {
         let (sut, wideEvent) = makeSUT()
         sut.visibleTabDidChange(duckAI(Self.chatTab))
@@ -307,7 +307,7 @@ struct DuckAISessionInstrumentationTests {
         #expect(started(wideEvent).first?.chatIDChanged == true)
     }
 
-    @Test("When the chat ID changes to another value then chat_id_changed is recorded")
+    @Test("When the chat ID changes to another value then chat_id_changed is recorded", .timeLimit(.minutes(1)))
     func whenChatIDChangesThenChangeRecorded() {
         let (sut, wideEvent) = makeSUT()
         sut.visibleTabDidChange(duckAI(Self.chatTab, chatID: "abc"))
@@ -316,7 +316,7 @@ struct DuckAISessionInstrumentationTests {
         #expect(completions(wideEvent).isEmpty)
     }
 
-    @Test("When the URL changes but the chat ID does not then no step is recorded")
+    @Test("When the URL changes but the chat ID does not then no step is recorded", .timeLimit(.minutes(1)))
     func whenURLChangesWithoutChatIDChangeThenNoStep() {
         let (sut, wideEvent) = makeSUT()
         sut.visibleTabDidChange(duckAI(Self.chatTab, chatID: "abc"))
@@ -325,7 +325,7 @@ struct DuckAISessionInstrumentationTests {
         #expect(updates(wideEvent).isEmpty)
     }
 
-    @Test("When steps were recorded then they are present on the completed flow")
+    @Test("When steps were recorded then they are present on the completed flow", .timeLimit(.minutes(1)))
     func whenStepsRecordedThenPresentOnCompletion() {
         let (sut, wideEvent) = makeSUT()
         sut.visibleTabDidChange(duckAI(Self.chatTab))

--- a/iOS/DuckDuckGoTests/AIChat/DuckAISessionWideEventDataTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/DuckAISessionWideEventDataTests.swift
@@ -25,6 +25,7 @@ import Testing
 @Suite("Duck.ai Session Wide Event Data")
 struct DuckAISessionWideEventDataTests {
 
+    @available(iOS 16, *)
     @Test("Metadata exposes the shared names and 1.0.0", .timeLimit(.minutes(1)))
     func metadataExposesSharedNames() {
         #expect(DuckAISessionWideEventData.metadata.pixelName == "duckai_session")
@@ -34,12 +35,14 @@ struct DuckAISessionWideEventDataTests {
         #expect(DuckAISessionWideEventData.appTerminatedReason == "app_terminated")
     }
 
+    @available(iOS 16, *)
     @Test("When the flow is new then no optional field is emitted", .timeLimit(.minutes(1)))
     func whenFlowIsNewThenNothingIsEmitted() {
         let params = DuckAISessionWideEventData().jsonParameters()
         #expect(params.isEmpty)
     }
 
+    @available(iOS 16, *)
     @Test("When Duck.ai was left then status reason and exit trigger are emitted", .timeLimit(.minutes(1)))
     func whenLeftDuckaiThenReasonAndTriggerAreEmitted() {
         let data = DuckAISessionWideEventData(statusReason: .leftDuckai, exitTrigger: .tabSwitched)
@@ -48,6 +51,7 @@ struct DuckAISessionWideEventDataTests {
         #expect(params["feature.data.ext.exit_trigger"] as? String == "tab_switched")
     }
 
+    @available(iOS 16, *)
     @Test("When the app was backgrounded then no exit trigger is emitted", .timeLimit(.minutes(1)))
     func whenBackgroundedThenExitTriggerIsOmitted() {
         let data = DuckAISessionWideEventData(statusReason: .appBackgrounded, exitTrigger: .tabSwitched)
@@ -56,6 +60,7 @@ struct DuckAISessionWideEventDataTests {
         #expect(params["feature.data.ext.exit_trigger"] == nil)
     }
 
+    @available(iOS 16, *)
     @Test("When steps happened then only those steps are present as true", .timeLimit(.minutes(1)))
     func whenStepsHappenedThenOnlyThoseArePresent() {
         let data = DuckAISessionWideEventData(promptSubmitted: true, chatIDChanged: true)
@@ -65,12 +70,14 @@ struct DuckAISessionWideEventDataTests {
         #expect(params["feature.data.ext.step.chat_id_changed"] as? Bool == true)
     }
 
+    @available(iOS 16, *)
     @Test("Every exit trigger raw value matches the shared naming", .timeLimit(.minutes(1)))
     func exitTriggerRawValuesMatchSharedNaming() {
         let expected: Set<String> = ["back_or_close", "tab_switched", "new_tab_opened", "fire_tab_opened", "search_started", "other_navigation"]
         #expect(Set(DuckAISessionWideEventData.ExitTrigger.allCases.map(\.rawValue)) == expected)
     }
 
+    @available(iOS 16, *)
     @Test("When launch cleanup asks then the flow stays pending", .timeLimit(.minutes(1)))
     func whenLaunchCleanupAsksThenFlowStaysPending() async {
         let decision = await DuckAISessionWideEventData().completionDecision(for: .appLaunch)

--- a/iOS/DuckDuckGoTests/AIChat/DuckAISessionWideEventDataTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/DuckAISessionWideEventDataTests.swift
@@ -25,7 +25,7 @@ import Testing
 @Suite("Duck.ai Session Wide Event Data")
 struct DuckAISessionWideEventDataTests {
 
-    @Test("Metadata exposes the shared names and 1.0.0")
+    @Test("Metadata exposes the shared names and 1.0.0", .timeLimit(.minutes(1)))
     func metadataExposesSharedNames() {
         #expect(DuckAISessionWideEventData.metadata.pixelName == "duckai_session")
         #expect(DuckAISessionWideEventData.metadata.featureName == "duckai_session")
@@ -34,13 +34,13 @@ struct DuckAISessionWideEventDataTests {
         #expect(DuckAISessionWideEventData.appTerminatedReason == "app_terminated")
     }
 
-    @Test("When the flow is new then no optional field is emitted")
+    @Test("When the flow is new then no optional field is emitted", .timeLimit(.minutes(1)))
     func whenFlowIsNewThenNothingIsEmitted() {
         let params = DuckAISessionWideEventData().jsonParameters()
         #expect(params.isEmpty)
     }
 
-    @Test("When Duck.ai was left then status reason and exit trigger are emitted")
+    @Test("When Duck.ai was left then status reason and exit trigger are emitted", .timeLimit(.minutes(1)))
     func whenLeftDuckaiThenReasonAndTriggerAreEmitted() {
         let data = DuckAISessionWideEventData(statusReason: .leftDuckai, exitTrigger: .tabSwitched)
         let params = data.jsonParameters()
@@ -48,7 +48,7 @@ struct DuckAISessionWideEventDataTests {
         #expect(params["feature.data.ext.exit_trigger"] as? String == "tab_switched")
     }
 
-    @Test("When the app was backgrounded then no exit trigger is emitted")
+    @Test("When the app was backgrounded then no exit trigger is emitted", .timeLimit(.minutes(1)))
     func whenBackgroundedThenExitTriggerIsOmitted() {
         let data = DuckAISessionWideEventData(statusReason: .appBackgrounded, exitTrigger: .tabSwitched)
         let params = data.jsonParameters()
@@ -56,7 +56,7 @@ struct DuckAISessionWideEventDataTests {
         #expect(params["feature.data.ext.exit_trigger"] == nil)
     }
 
-    @Test("When steps happened then only those steps are present as true")
+    @Test("When steps happened then only those steps are present as true", .timeLimit(.minutes(1)))
     func whenStepsHappenedThenOnlyThoseArePresent() {
         let data = DuckAISessionWideEventData(promptSubmitted: true, chatIDChanged: true)
         let params = data.jsonParameters()
@@ -65,13 +65,13 @@ struct DuckAISessionWideEventDataTests {
         #expect(params["feature.data.ext.step.chat_id_changed"] as? Bool == true)
     }
 
-    @Test("Every exit trigger raw value matches the shared naming")
+    @Test("Every exit trigger raw value matches the shared naming", .timeLimit(.minutes(1)))
     func exitTriggerRawValuesMatchSharedNaming() {
         let expected: Set<String> = ["back_or_close", "tab_switched", "new_tab_opened", "fire_tab_opened", "search_started", "other_navigation"]
         #expect(Set(DuckAISessionWideEventData.ExitTrigger.allCases.map(\.rawValue)) == expected)
     }
 
-    @Test("When launch cleanup asks then the flow stays pending")
+    @Test("When launch cleanup asks then the flow stays pending", .timeLimit(.minutes(1)))
     func whenLaunchCleanupAsksThenFlowStaysPending() async {
         let decision = await DuckAISessionWideEventData().completionDecision(for: .appLaunch)
         guard case .keepPending = decision else {

--- a/iOS/DuckDuckGoTests/AIChat/DuckAISessionWideEventDataTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/DuckAISessionWideEventDataTests.swift
@@ -1,0 +1,82 @@
+//
+//  DuckAISessionWideEventDataTests.swift
+//  DuckDuckGoTests
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import Testing
+@_spi(Testing) import PixelKit
+@testable import DuckDuckGo
+
+@Suite("Duck.ai Session Wide Event Data")
+struct DuckAISessionWideEventDataTests {
+
+    @Test("Metadata exposes the shared names and 1.0.0")
+    func metadataExposesSharedNames() {
+        #expect(DuckAISessionWideEventData.metadata.pixelName == "duckai_session")
+        #expect(DuckAISessionWideEventData.metadata.featureName == "duckai_session")
+        #expect(DuckAISessionWideEventData.metadata.type == "ios-duckai-session")
+        #expect(DuckAISessionWideEventData.metadata.version == "1.0.0")
+        #expect(DuckAISessionWideEventData.appTerminatedReason == "app_terminated")
+    }
+
+    @Test("When the flow is new then no optional field is emitted")
+    func whenFlowIsNewThenNothingIsEmitted() {
+        let params = DuckAISessionWideEventData().jsonParameters()
+        #expect(params.isEmpty)
+    }
+
+    @Test("When Duck.ai was left then status reason and exit trigger are emitted")
+    func whenLeftDuckaiThenReasonAndTriggerAreEmitted() {
+        let data = DuckAISessionWideEventData(statusReason: .leftDuckai, exitTrigger: .tabSwitched)
+        let params = data.jsonParameters()
+        #expect(params["feature.data.ext.status_reason"] as? String == "left_duckai")
+        #expect(params["feature.data.ext.exit_trigger"] as? String == "tab_switched")
+    }
+
+    @Test("When the app was backgrounded then no exit trigger is emitted")
+    func whenBackgroundedThenExitTriggerIsOmitted() {
+        let data = DuckAISessionWideEventData(statusReason: .appBackgrounded, exitTrigger: .tabSwitched)
+        let params = data.jsonParameters()
+        #expect(params["feature.data.ext.status_reason"] as? String == "app_backgrounded")
+        #expect(params["feature.data.ext.exit_trigger"] == nil)
+    }
+
+    @Test("When steps happened then only those steps are present as true")
+    func whenStepsHappenedThenOnlyThoseArePresent() {
+        let data = DuckAISessionWideEventData(promptSubmitted: true, chatIDChanged: true)
+        let params = data.jsonParameters()
+        #expect(params["feature.data.ext.step.prompt_submitted"] as? Bool == true)
+        #expect(params["feature.data.ext.step.new_chat_created"] == nil)
+        #expect(params["feature.data.ext.step.chat_id_changed"] as? Bool == true)
+    }
+
+    @Test("Every exit trigger raw value matches the shared naming")
+    func exitTriggerRawValuesMatchSharedNaming() {
+        let expected: Set<String> = ["back_or_close", "tab_switched", "new_tab_opened", "fire_tab_opened", "search_started", "other_navigation"]
+        #expect(Set(DuckAISessionWideEventData.ExitTrigger.allCases.map(\.rawValue)) == expected)
+    }
+
+    @Test("When launch cleanup asks then the flow stays pending")
+    func whenLaunchCleanupAsksThenFlowStaysPending() async {
+        let decision = await DuckAISessionWideEventData().completionDecision(for: .appLaunch)
+        guard case .keepPending = decision else {
+            Issue.record("Expected keepPending, got \(decision)")
+            return
+        }
+    }
+}

--- a/iOS/DuckDuckGoTests/AIChatEntryPointSourceTests.swift
+++ b/iOS/DuckDuckGoTests/AIChatEntryPointSourceTests.swift
@@ -72,16 +72,24 @@ struct AIChatEntryPointSourceTests {
     @available(iOS 16, *)
     @Test("A front-end open request from the search results page resolves to serp", .timeLimit(.minutes(1)))
     func serpOpenRequestResolves() {
-        #expect(AIChatEntryPointSource.forFrontEndOpenRequest(messageHost: URL.ddg.host) == .serp)
+        let serp = URL(string: "https://duckduckgo.com/?q=test&ia=web")!
+        #expect(AIChatEntryPointSource.forFrontEndOpenRequest(messageHost: URL.ddg.host, pageURL: serp) == .serp)
+        #expect(AIChatEntryPointSource.forFrontEndOpenRequest(messageHost: URL.ddg.host, pageURL: nil) == .serp)
+    }
+
+    @available(iOS 16, *)
+    @Test("A front-end open request from the homepage resolves to ddg_homepage", .timeLimit(.minutes(1)))
+    func homepageOpenRequestResolves() {
+        #expect(AIChatEntryPointSource.forFrontEndOpenRequest(messageHost: URL.ddg.host, pageURL: homepage) == .ddgHomepage)
     }
 
     /// Returning nil leaves the caller's own fallback in place rather than mislabelling the entry.
     @available(iOS 16, *)
     @Test("Other hosts have no front-end open request source", .timeLimit(.minutes(1)))
     func otherHostsResolveToNil() {
-        #expect(AIChatEntryPointSource.forFrontEndOpenRequest(messageHost: URL.duckAi.host) == nil)
-        #expect(AIChatEntryPointSource.forFrontEndOpenRequest(messageHost: "localhost:8080") == nil)
-        #expect(AIChatEntryPointSource.forFrontEndOpenRequest(messageHost: nil) == nil)
+        #expect(AIChatEntryPointSource.forFrontEndOpenRequest(messageHost: URL.duckAi.host, pageURL: URL.duckAi) == nil)
+        #expect(AIChatEntryPointSource.forFrontEndOpenRequest(messageHost: "localhost:8080", pageURL: nil) == nil)
+        #expect(AIChatEntryPointSource.forFrontEndOpenRequest(messageHost: nil, pageURL: nil) == nil)
     }
 
     /// The raw values are a dashboard contract: renaming one silently breaks its series.
@@ -99,5 +107,36 @@ struct AIChatEntryPointSourceTests {
         #expect(AIChatEntryPointSource.directURL.rawValue == "direct_url")
         #expect(AIChatEntryPointSource.returnToChatCard.rawValue == "return_to_chat_card")
         #expect(AIChatEntryPointSource.tabSwitcherExistingChat.rawValue == "tab_switcher_existing_chat")
+        #expect(AIChatEntryPointSource.ddgHomepage.rawValue == "ddg_homepage")
+    }
+
+    // MARK: - In-page navigations
+
+    private let homepage = URL(string: "https://duckduckgo.com/")!
+    private let duckAIChat = URL(string: "https://duck.ai/chat?ia=chat&origin=funnel_home_website&q=hello&prompt=1")!
+
+    @available(iOS 16, *)
+    @Test("A navigation the DuckDuckGo homepage starts into Duck.ai resolves to ddg_homepage", .timeLimit(.minutes(1)))
+    func homepageNavigationResolves() {
+        let homepageWithParams = URL(string: "https://duckduckgo.com/?atb=v550-1")!
+        #expect(AIChatEntryPointSource.forInPageNavigation(from: homepage, to: duckAIChat) == .ddgHomepage)
+        #expect(AIChatEntryPointSource.forInPageNavigation(from: homepageWithParams, to: duckAIChat) == .ddgHomepage)
+    }
+
+    /// Only the homepage is attributed; links into Duck.ai from other pages stay unattributed on purpose.
+    @available(iOS 16, *)
+    @Test("Navigations from other pages have no in-page source", .timeLimit(.minutes(1)))
+    func otherPagesResolveToNil() {
+        #expect(AIChatEntryPointSource.forInPageNavigation(from: URL(string: "https://duckduckgo.com/?q=test")!, to: duckAIChat) == nil)
+        #expect(AIChatEntryPointSource.forInPageNavigation(from: URL(string: "https://example.com/")!, to: duckAIChat) == nil)
+        #expect(AIChatEntryPointSource.forInPageNavigation(from: URL(string: "https://duckduckgo.com/?ia=chat")!, to: duckAIChat) == nil)
+        #expect(AIChatEntryPointSource.forInPageNavigation(from: nil, to: duckAIChat) == nil)
+    }
+
+    @available(iOS 16, *)
+    @Test("Homepage navigations that do not reach Duck.ai have no in-page source", .timeLimit(.minutes(1)))
+    func homepageToWebResolvesToNil() {
+        #expect(AIChatEntryPointSource.forInPageNavigation(from: homepage, to: URL(string: "https://example.com/")!) == nil)
+        #expect(AIChatEntryPointSource.forInPageNavigation(from: homepage, to: URL(string: "https://duckduckgo.com/?q=test")!) == nil)
     }
 }

--- a/iOS/DuckDuckGoTests/AIChatEntryPointSourceTests.swift
+++ b/iOS/DuckDuckGoTests/AIChatEntryPointSourceTests.swift
@@ -83,6 +83,14 @@ struct AIChatEntryPointSourceTests {
         #expect(AIChatEntryPointSource.forFrontEndOpenRequest(messageHost: URL.ddg.host, pageURL: homepage) == .ddgHomepage)
     }
 
+    /// `duckduckgo.com/?ia=chat` has the homepage's shape but is a Duck.ai page, so it keeps the host mapping.
+    @available(iOS 16, *)
+    @Test("A front-end open request from a duckduckgo.com chat page is not a homepage entry", .timeLimit(.minutes(1)))
+    func chatPageOpenRequestIsNotHomepage() {
+        let chatOnDDG = URL(string: "https://duckduckgo.com/?ia=chat")!
+        #expect(AIChatEntryPointSource.forFrontEndOpenRequest(messageHost: URL.ddg.host, pageURL: chatOnDDG) == .serp)
+    }
+
     /// Returning nil leaves the caller's own fallback in place rather than mislabelling the entry.
     @available(iOS 16, *)
     @Test("Other hosts have no front-end open request source", .timeLimit(.minutes(1)))

--- a/iOS/DuckDuckGoTests/TabTests.swift
+++ b/iOS/DuckDuckGoTests/TabTests.swift
@@ -634,6 +634,76 @@ final class TabViewControllerAIChatNewWindowDecisionTests: XCTestCase {
     }
 }
 
+final class TabViewControllerInPageDuckAIEntryTests: XCTestCase {
+
+    private let homepage = URL(string: "https://duckduckgo.com/")!
+    private let duckAIChat = URL(string: "https://duck.ai/chat?ia=chat&origin=funnel_home_website&q=hello&prompt=1")!
+
+    func testWhenHomepageLinkTargetsDuckAIInMainFrameThenSourceIsHomepage() {
+        let source = TabViewController.inPageDuckAIEntrySource(currentURL: homepage,
+                                                               navigationAction: mainFrameNavigation(to: duckAIChat),
+                                                               pendingNativeLoadURL: nil)
+
+        XCTAssertEqual(source, .ddgHomepage)
+    }
+
+    func testWhenHomepageScriptOrFormNavigatesToDuckAIThenSourceIsHomepage() {
+        for navigationType in [WKNavigationType.other, .formSubmitted] {
+            let source = TabViewController.inPageDuckAIEntrySource(currentURL: homepage,
+                                                                   navigationAction: mainFrameNavigation(to: duckAIChat, type: navigationType),
+                                                                   pendingNativeLoadURL: nil)
+
+            XCTAssertEqual(source, .ddgHomepage, "\(navigationType.rawValue)")
+        }
+    }
+
+    func testWhenNavigationIsBackForwardOrReloadThenNoSource() {
+        for navigationType in [WKNavigationType.backForward, .reload] {
+            let source = TabViewController.inPageDuckAIEntrySource(currentURL: homepage,
+                                                                   navigationAction: mainFrameNavigation(to: duckAIChat, type: navigationType),
+                                                                   pendingNativeLoadURL: nil)
+
+            XCTAssertNil(source, "\(navigationType.rawValue)")
+        }
+    }
+
+    func testWhenNavigationIsTheTabsOwnLoadThenNoSource() {
+        let source = TabViewController.inPageDuckAIEntrySource(currentURL: homepage,
+                                                               navigationAction: mainFrameNavigation(to: duckAIChat, type: .other),
+                                                               pendingNativeLoadURL: duckAIChat)
+
+        XCTAssertNil(source)
+    }
+
+    func testWhenNavigationTargetsSubframeThenNoSource() {
+        let request = URLRequest(url: duckAIChat)
+        let subframe = WKFrameInfo.mock(isMainFrame: false, securityOriginHost: "duckduckgo.com", request: request)
+        let navigationAction = MockNavigationAction(request: request, navigationType: .linkActivated, targetFrame: subframe)
+
+        let source = TabViewController.inPageDuckAIEntrySource(currentURL: homepage,
+                                                               navigationAction: navigationAction,
+                                                               pendingNativeLoadURL: nil)
+
+        XCTAssertNil(source)
+    }
+
+    func testWhenCurrentPageIsNotHomepageThenNoSource() {
+        let serp = URL(string: "https://duckduckgo.com/?q=test&ia=web")!
+
+        let source = TabViewController.inPageDuckAIEntrySource(currentURL: serp,
+                                                               navigationAction: mainFrameNavigation(to: duckAIChat),
+                                                               pendingNativeLoadURL: nil)
+
+        XCTAssertNil(source)
+    }
+
+    private func mainFrameNavigation(to url: URL, type: WKNavigationType = .linkActivated) -> WKNavigationAction {
+        let request = URLRequest(url: url)
+        let mainFrame = WKFrameInfo.mock(isMainFrame: true, securityOriginHost: "duckduckgo.com", request: request)
+        return MockNavigationAction(request: request, navigationType: type, targetFrame: mainFrame)
+    }
+}
+
 private class CoderStub: NSCoder {
 
     private let properties: [String: Any]

--- a/iOS/LocalPackages/FeatureFlags-iOS/Sources/FeatureFlags/FeatureFlag.swift
+++ b/iOS/LocalPackages/FeatureFlags-iOS/Sources/FeatureFlags/FeatureFlag.swift
@@ -467,6 +467,9 @@ public enum FeatureFlag: String {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1217276406422603
     case newTabPageSessionInstrumentation
 
+    /// https://app.asana.com/1/137249556945/project/72649045549333/task/1218145365492985
+    case duckAISessionWideEvent
+
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1217645779581965
     case newTabPageRedesign
 
@@ -882,6 +885,8 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(defaultValue: .enabled, source: .remoteReleasable(iOSBrowserConfigSubfeature.customizeNTPIcons))
         case .newTabPageSessionInstrumentation:
             Config(source: .remoteReleasable(iOSBrowserConfigSubfeature.newTabPageSessionInstrumentation))
+        case .duckAISessionWideEvent:
+            Config(defaultValue: .enabled, source: .remoteReleasable(iOSBrowserConfigSubfeature.duckAISessionWideEvent))
         case .newTabPageRedesign:
             Config(source: .remoteReleasable(iOSBrowserConfigSubfeature.newTabPageRedesign))
         case .walletPassDownload:

--- a/iOS/LocalPackages/FeatureFlags-iOS/Sources/FeatureFlags/iOSBrowserConfigSubfeature.swift
+++ b/iOS/LocalPackages/FeatureFlags-iOS/Sources/FeatureFlags/iOSBrowserConfigSubfeature.swift
@@ -152,6 +152,9 @@ public enum iOSBrowserConfigSubfeature: String, PrivacySubfeature {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1217276406422603?focus=true
     case newTabPageSessionInstrumentation
 
+    /// https://app.asana.com/1/137249556945/project/72649045549333/task/1218145365492985
+    case duckAISessionWideEvent
+
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1217645779581965
     case newTabPageRedesign
 }

--- a/iOS/PixelDefinitions/pixels/definitions/ai_chat_entry_points.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/ai_chat_entry_points.json5
@@ -9,7 +9,7 @@
             "appVersion",
             {
                 "key": "source",
-                "description": "The entry path into Duck.ai, one value per case of the AIChatEntryPointSource Swift enum. serp is any Duck.ai open the search results page asks native for, e.g. Search Assist, and covers every such SERP affordance because the request does not say which one it was. direct_url is a duck.ai navigation TabURLInterceptor saw with no other attribution, so it mixes a typed address with an in-page link. Returning to an already-open Duck.ai tab fires only from the tab switcher (tab_switcher_existing_chat, distinct from the switcher's Duck.ai button, which creates a new chat and reports tab_switcher) and from the new tab page's return-to-tab card (return_to_chat_card); restoring a Duck.ai tab at launch is not an entry and does not fire.",
+                "description": "The entry path into Duck.ai, one value per case of the AIChatEntryPointSource Swift enum. serp is any Duck.ai open the search results page asks native for, e.g. Search Assist, and covers every such SERP affordance because the request does not say which one it was. direct_url is a duck.ai address typed into the address bar. ddg_homepage is a navigation into Duck.ai that the duckduckgo.com homepage started itself, whether by link, form, script or by asking native to open Duck.ai; navigations other pages start into Duck.ai are not attributed. Returning to an already-open Duck.ai tab fires only from the tab switcher (tab_switcher_existing_chat, distinct from the switcher's Duck.ai button, which creates a new chat and reports tab_switcher) and from the new tab page's return-to-tab card (return_to_chat_card); restoring a Duck.ai tab at launch is not an entry and does not fire.",
                 "type": "string",
                 "enum": [
                     "address_bar_prompt",
@@ -38,7 +38,8 @@
                     "siri",
                     "deep_link_other",
                     "return_to_chat_card",
-                    "tab_switcher_existing_chat"
+                    "tab_switcher_existing_chat",
+                    "ddg_homepage"
                 ]
             },
             {

--- a/iOS/PixelDefinitions/pixels/definitions/duckai_session_wide_event.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/duckai_session_wide_event.json5
@@ -1,0 +1,66 @@
+{
+    "m_ios_wide_duckai_session": {
+        "description": "Wide pixel sent at the end of a Duck.ai session on iOS: one visit to a full Duck.ai tab, from the tab becoming visible until Duck.ai is left, the app is backgrounded, or the process ends. Opening the tab switcher does not end the session.",
+        "owners": ["Bunn"],
+        "triggers": ["other"],
+        "suffixes": ["daily"],
+        "parameters": [
+            // Standard wide event parameters
+            "appVersion",
+            "wideEventAppName",
+            "wideEventAppVersion",
+            "wideEventPlatform",
+            "wideEventType",
+            "wideEventFormFactor",
+            "wideEventSampleRate",
+            "wideEventIsFirstDailyOccurrence",
+            "wideEventFeatureStatus",
+            "wideEventMetaVersion",
+
+            // Wide event type identifier
+            {
+                "key": "meta.type",
+                "type": "string",
+                "description": "Wide event type identifier",
+                "enum": ["ios-duckai-session"]
+            },
+
+            // Feature identifier
+            {
+                "key": "feature.name",
+                "type": "string",
+                "description": "Feature identifier for this wide pixel",
+                "enum": ["duckai_session"]
+            },
+
+            // Feature data
+            {
+                "key": "feature.data.ext.status_reason",
+                "type": "string",
+                "description": "How the session ended. SUCCESS uses left_duckai; CANCELLED uses app_backgrounded; UNKNOWN uses app_terminated when an in-flight session is recovered at the next launch.",
+                "enum": ["left_duckai", "app_backgrounded", "app_terminated"]
+            },
+            {
+                "key": "feature.data.ext.exit_trigger",
+                "type": "string",
+                "description": "The action that caused the transition away from Duck.ai. Present only when status_reason is left_duckai.",
+                "enum": ["back_or_close", "tab_switched", "new_tab_opened", "fire_tab_opened", "search_started", "other_navigation"]
+            },
+            {
+                "key": "feature.data.ext.step.prompt_submitted",
+                "type": "boolean",
+                "description": "A prompt was submitted in the visible Duck.ai tab. Present only when true."
+            },
+            {
+                "key": "feature.data.ext.step.new_chat_created",
+                "type": "boolean",
+                "description": "A new chat was created from the active Duck.ai session. Present only when true."
+            },
+            {
+                "key": "feature.data.ext.step.chat_id_changed",
+                "type": "boolean",
+                "description": "The visible tab's Duck.ai URL changed from one chatID value to another, including missing to present. Present only when true. The identifier is never sent."
+            }
+        ]
+    }
+}

--- a/iOS/PixelDefinitions/wide_events/definitions/duckai-session.json5
+++ b/iOS/PixelDefinitions/wide_events/definitions/duckai-session.json5
@@ -1,0 +1,46 @@
+{
+    "ios-duckai-session": {
+        "description": "Sent at the end of a Duck.ai session on iOS: one visit to a full Duck.ai tab, from the tab becoming visible until Duck.ai is left (another tab is selected or the tab navigates to a non-Duck.ai page), the app is backgrounded, or the process ends. Opening or dismissing the tab switcher does not end the session. Contextual chat and the Duck.ai address bar input shown before a full tab opens are out of scope.",
+        "owners": ["Bunn"],
+        "meta": {
+            "type": "ios-duckai-session",
+            "version": "0.0"
+        },
+        "feature": {
+            "name": "duckai_session",
+            "status": ["SUCCESS", "CANCELLED", "UNKNOWN"],
+            "data": {
+                "ext": {
+                    "status_reason": {
+                        "type": "string",
+                        "description": "How the session ended. left_duckai (SUCCESS): Duck.ai is no longer the visible tab or the tab navigated to a non-Duck.ai page. app_backgrounded (CANCELLED): the app moved to the background while Duck.ai was visible. app_terminated (UNKNOWN): the process ended before another outcome was recorded; completed at the next launch.",
+                        "enum": ["left_duckai", "app_backgrounded", "app_terminated"]
+                    },
+                    "exit_trigger": {
+                        "type": "string",
+                        "description": "The action that caused the transition away from Duck.ai. Present only when status_reason is left_duckai. back_or_close: Back or a close of the Duck.ai tab. tab_switched: the user selected another existing tab. new_tab_opened: the user opened a new tab. fire_tab_opened: the user opened a Fire tab. search_started: the user started a Search from Duck.ai. other_navigation: no mapped action explains the transition.",
+                        "enum": ["back_or_close", "tab_switched", "new_tab_opened", "fire_tab_opened", "search_started", "other_navigation"]
+                    },
+                    "step": {
+                        "type": "object",
+                        "description": "Session activity. A present value of true means the action happened at least once during the session; an absent field means it did not happen.",
+                        "properties": {
+                            "prompt_submitted": {
+                                "type": "boolean",
+                                "description": "A prompt was submitted in the visible Duck.ai tab."
+                            },
+                            "new_chat_created": {
+                                "type": "boolean",
+                                "description": "A new chat was created from the active Duck.ai session (frontend New Chat, the Duck.ai header's New Chat or New Image, or Recent chats' New Chat)."
+                            },
+                            "chat_id_changed": {
+                                "type": "boolean",
+                                "description": "The visible tab's Duck.ai URL changed from one chatID value to another, including a change between missing and present. The identifier itself is never sent."
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/iOS/PixelDefinitions/wide_events/generated_schemas/ios-duckai-session-1.0.0.json
+++ b/iOS/PixelDefinitions/wide_events/generated_schemas/ios-duckai-session-1.0.0.json
@@ -1,0 +1,105 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "description": "Sent at the end of a Duck.ai session on iOS: one visit to a full Duck.ai tab, from the tab becoming visible until Duck.ai is left (another tab is selected or the tab navigates to a non-Duck.ai page), the app is backgrounded, or the process ends. Opening or dismissing the tab switcher does not end the session. Contextual chat and the Duck.ai address bar input shown before a full tab opens are out of scope.",
+    "$comment": "{\"owners\":[\"Bunn\"]}",
+    "type": "object",
+    "required": ["meta", "global", "feature", "app"],
+    "additionalProperties": false,
+    "properties": {
+        "meta": {
+            "type": "object",
+            "required": ["type", "version"],
+            "additionalProperties": false,
+            "properties": { "type": { "const": "ios-duckai-session" }, "version": { "const": "1.0.0" } }
+        },
+        "app": {
+            "type": "object",
+            "required": ["name", "version"],
+            "additionalProperties": false,
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "The name of the application",
+                    "enum": ["DuckDuckGo", "DuckDuckGo-Alpha", "DuckDuckGo-Experimental", "PacketTunnelProvider"]
+                },
+                "version": { "type": "string", "description": "The version of the application", "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$" },
+                "form_factor": { "type": "string", "description": "The form factor of the device", "enum": ["phone", "tablet"] }
+            }
+        },
+        "global": {
+            "type": "object",
+            "required": ["platform", "type", "sample_rate"],
+            "additionalProperties": false,
+            "properties": {
+                "platform": { "type": "string", "description": "The platform the app is running on", "enum": ["iOS"] },
+                "type": { "type": "string", "description": "The type of application", "enum": ["app"] },
+                "sample_rate": { "type": "number", "description": "Sample rate for this event", "minimum": 0, "maximum": 1 },
+                "is_first_daily_occurrence": {
+                    "type": "boolean",
+                    "description": "Whether this is the first occurrence of this event today. Only included when true."
+                }
+            }
+        },
+        "feature": {
+            "type": "object",
+            "required": ["name", "status", "data"],
+            "additionalProperties": false,
+            "properties": {
+                "name": { "type": "string", "description": "The feature name for this event", "enum": ["duckai_session"] },
+                "status": {
+                    "type": "string",
+                    "description": "The overall status of the operation",
+                    "enum": ["SUCCESS", "CANCELLED", "UNKNOWN"]
+                },
+                "data": {
+                    "type": "object",
+                    "required": ["ext"],
+                    "additionalProperties": false,
+                    "properties": {
+                        "ext": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "status_reason": {
+                                    "type": "string",
+                                    "description": "How the session ended. left_duckai (SUCCESS): Duck.ai is no longer the visible tab or the tab navigated to a non-Duck.ai page. app_backgrounded (CANCELLED): the app moved to the background while Duck.ai was visible. app_terminated (UNKNOWN): the process ended before another outcome was recorded; completed at the next launch.",
+                                    "enum": ["left_duckai", "app_backgrounded", "app_terminated"]
+                                },
+                                "exit_trigger": {
+                                    "type": "string",
+                                    "description": "The action that caused the transition away from Duck.ai. Present only when status_reason is left_duckai. back_or_close: Back or a close of the Duck.ai tab. tab_switched: the user selected another existing tab. new_tab_opened: the user opened a new tab. fire_tab_opened: the user opened a Fire tab. search_started: the user started a Search from Duck.ai. other_navigation: no mapped action explains the transition.",
+                                    "enum": [
+                                        "back_or_close",
+                                        "tab_switched",
+                                        "new_tab_opened",
+                                        "fire_tab_opened",
+                                        "search_started",
+                                        "other_navigation"
+                                    ]
+                                },
+                                "step": {
+                                    "type": "object",
+                                    "description": "Session activity. A present value of true means the action happened at least once during the session; an absent field means it did not happen.",
+                                    "properties": {
+                                        "prompt_submitted": {
+                                            "type": "boolean",
+                                            "description": "A prompt was submitted in the visible Duck.ai tab."
+                                        },
+                                        "new_chat_created": {
+                                            "type": "boolean",
+                                            "description": "A new chat was created from the active Duck.ai session (frontend New Chat, the Duck.ai header's New Chat or New Image, or Recent chats' New Chat)."
+                                        },
+                                        "chat_id_changed": {
+                                            "type": "boolean",
+                                            "description": "The visible tab's Duck.ai URL changed from one chatID value to another, including a change between missing and present. The identifier itself is never sent."
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/iOS/SharedTestUtils/Mocks/DuckDuckGo/Tabs/MockTabDelegate.swift
+++ b/iOS/SharedTestUtils/Mocks/DuckDuckGo/Tabs/MockTabDelegate.swift
@@ -63,6 +63,8 @@ final class MockTabDelegate: TabDelegate {
 
     func tab(_ tab: DuckDuckGo.TabViewController, didRequestNewDuckAITabForUrl url: URL, entrySource: DuckDuckGo.AIChatEntryPointSource) {}
 
+    func tab(_ tab: DuckDuckGo.TabViewController, didStartDuckAINavigationTo url: URL, entrySource: DuckDuckGo.AIChatEntryPointSource, opensNewTab: Bool, inheritingAttribution: BrowserServicesKit.AdClickAttributionLogic.State?) {}
+
     func tab(_ tab: DuckDuckGo.TabViewController, didRequestReopenClosedTabAt url: URL) {}
 
     func tab(_ tab: DuckDuckGo.TabViewController, didRequestNewBackgroundTabForUrl url: URL, inheritingAttribution: BrowserServicesKit.AdClickAttributionLogic.State?) {}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1218145365492985
Tech Design URL:
CC:

### Description
Adds the `m_ios_wide_duckai_session` wide event: one event per visit to a full Duck.ai tab, recording how the visit ended (`status_reason` plus `exit_trigger`) and whether a prompt was submitted, a new chat was created, or the chat identity changed. A session starts when a Duck.ai tab becomes visible and ends when another tab is shown, the tab navigates away from Duck.ai, the app is backgrounded, or the process is killed (completed at the next launch); opening the tab switcher does not end it. Shared names match the Android design; the event ships behind the default-enabled `duckAISessionWideEvent` kill switch.

### Testing Steps
Debug build on an iPhone simulator. Stream logs with
`xcrun simctl spawn booted log stream --level debug --predicate 'subsystem == "PixelKit"'`
and read `feature.data.ext` in the JSON printed after each `Completing wide event 'duckai_session'` line. Steps 3–6 and 11 complete with `status SUCCESS` and `status_reason: left_duckai`.

1. NTP → tap the address bar Duck.ai button → log shows `Starting wide event flow 'duckai_session'`.
2. Open and dismiss the tab switcher → no completion line.
3. Header ⊕ → New Tab → `exit_trigger: new_tab_opened`.
4. Switcher → Duck.ai tile, then switcher → New Tab tile → `tab_switched`.
5. Switcher → Duck.ai tile, then header ✕ → `back_or_close`.
6. NTP → address bar Duck.ai button, then ⊕ → New Search → `search_started`.
7. Switcher → Duck.ai tile, send a prompt (tap Continue if the Terms card shows), then ⊕ → New Chat, then ⊕ → New Tab → `step.prompt_submitted`, `step.chat_id_changed`, `step.new_chat_created` all `true`.
8. Switcher → Duck.ai tile, then ⊕ → New Tab right away → no `step` keys.
9. Switcher → Duck.ai tile, press Home → `status CANCELLED`, `status_reason: app_backgrounded`.
10. Reopen, force-quit, relaunch → `status UNKNOWN`, `status_reason: app_terminated`.
11. Switcher → Duck.ai tile, then ⊕ → New Fire Tab → `fire_tab_opened` (last: leaves you in Fire mode).

### Impact
Low

#### What could go wrong?
A missed hook would misattribute an exit as `other_navigation` rather than drop the event → mitigated by the fallback in the instrumentation, the per-trigger checks above, and the remote kill switch.

### Notes to Reviewer
- `back_or_close` covers every close of the visible Duck.ai tab (header ✕, Back that closes an opener-created tab, switcher tile close, close-all), not only the header ✕.
- Only user-intended new tabs report `new_tab_opened`; tabs the AI-boundary rule opens for favorites/bookmarks from a chat tab, the Fire button burn, and page-opened tabs report `other_navigation` (Android parity).
- A pending exit is first-wins per session, so "New Search"/"New Fire Tab" beat the generic new-tab hook; Fire-tab actions record before the browsing-mode switch because that swaps the current tabs model.
- A first prompt in a fresh tab moves the URL from no `chatID` to a `chatID`, so `chat_id_changed=true` with `new_chat_created=false` also covers "first prompt in a new chat" (accepted in the shared design).
- No session-duration field: not part of the shared naming. `wide_return_session` is intentionally untouched (design note 4).
- New unit suites `DuckAISessionWideEventDataTests` and `DuckAISessionInstrumentationTests` (UnitTests target); definitions validated with `npm run validate-defs-without-formatting`, `check-wide-events`, `pixel-lint`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018FyjNch5GQNYu1D11YLxE9

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broad changes across tab/navigation and MainViewController paths could mis-attribute session exits as `other_navigation`, but behavior is telemetry-only with a remote kill switch and extensive tests.
> 
> **Overview**
> Adds **`m_ios_wide_duckai_session`**, a wide event that measures one visit to a full Duck.ai tab—from visibility until the user leaves Duck.ai, backgrounds the app, or the process ends. **`DefaultDuckAISessionInstrumentation`** tracks exit triggers (back/close, tab switch, new/fire tab, search, etc.) and session steps (prompt submitted, new chat, chat ID change), gated by **`duckAISessionWideEvent`**. Hooks are wired through **`MainViewController`** (tab attach/switch/close, omnibar, keyboard shortcuts, AI header, background).
> 
> **Entry-point analytics** are tightened in the same PR: new **`ddg_homepage`** on `AIChatEntryPointSource`, homepage vs SERP detection via the requesting page URL on **`openAIChat`**, and in-page homepage→Duck.ai navigations through **`didStartDuckAINavigationTo`** / **`pendingNativeLoadURL`**. **`isDuckDuckGoHomepage`** is made public in the AIChat package for that classification.
> 
> Pixel/wide-event definitions, generated schema, and unit tests for instrumentation and entry sources are included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4bab9491d3dfd3413e1c77fbd229d80b1335cf2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->