### PR TITLE
iOS: Inset the address field content and fix the trackers-blocked shield burst

### DIFF
--- a/iOS/DuckDuckGo/DefaultOmniBarSearchView.swift
+++ b/iOS/DuckDuckGo/DefaultOmniBarSearchView.swift
@@ -145,12 +145,12 @@ final class DefaultOmniBarSearchView: UIView {
         modeToggleContainer.translatesAutoresizingMaskIntoConstraints = false
         modeToggleView.translatesAutoresizingMaskIntoConstraints = false
 
-        let leadingConstraint = mainStackView.leadingAnchor.constraint(equalTo: leadingAnchor)
+        let leadingConstraint = mainStackView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Metrics.horizontalInset)
         mainStackLeadingConstraint = leadingConstraint
 
         NSLayoutConstraint.activate([
             leadingConstraint,
-            mainStackView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            mainStackView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -Metrics.horizontalInset),
 
             notificationContainer.leadingAnchor.constraint(equalTo: leftIconContainerPlaceholder.leadingAnchor, constant: 4),
             notificationContainer.trailingAnchor.constraint(equalTo: textField.trailingAnchor),
@@ -263,6 +263,15 @@ final class DefaultOmniBarSearchView: UIView {
 
     func setLeftIconAreaHidden(_ hidden: Bool) {
         leftIconContainerPlaceholder.isHidden = hidden
-        mainStackLeadingConstraint?.constant = hidden ? 16 : 0
+        mainStackLeadingConstraint?.constant = hidden ? Metrics.textOnlyLeadingInset : Metrics.horizontalInset
+    }
+
+    private enum Metrics {
+        /// Keeps the 44pt icon slots clear of the field's capsule ends. With the field at 48pt this
+        /// also lands the shield's centre on the centre of the leading arc, so the trackers-blocked
+        /// animation bursts symmetrically instead of being trimmed against the edge.
+        static let horizontalInset: CGFloat = 2
+        /// Text inset used when the leading icon slot is hidden.
+        static let textOnlyLeadingInset: CGFloat = 16
     }
 }

--- a/iOS/DuckDuckGo/DefaultOmniBarView.swift
+++ b/iOS/DuckDuckGo/DefaultOmniBarView.swift
@@ -61,6 +61,7 @@ final class DefaultOmniBarView: UIView, OmniBarView, ExpandableOmniBarView {
     var fireButton: UIButton! { fireButtonView }
     var refreshButton: UIButton! { searchAreaView.reloadButton }
     var customizableButton: UIButton! { searchAreaView.customizableButton }
+    var urlSeparatorView: UIView { searchAreaView.separatorView }
     var privacyIconView: UIView? { privacyInfoContainer.privacyIcon }
     var searchContainer: UIView! { searchAreaContainerView }
     var expectedHeight: CGFloat {

--- a/iOS/DuckDuckGo/PrivacyIconView.swift
+++ b/iOS/DuckDuckGo/PrivacyIconView.swift
@@ -93,14 +93,16 @@ class PrivacyIconView: UIView {
         shieldAnimationView.translatesAutoresizingMaskIntoConstraints = false
         shieldAnimationView.contentMode = .scaleAspectFit
         shieldAnimationView.backgroundBehavior = .pauseAndRestore
-        shieldAnimationView.configuration = LottieConfiguration(renderingEngine: .mainThread)
+        // The Core Animation engine is needed for the Repeater that fans the trackers-blocked
+        // confetti out around the shield; the main-thread engine skips it and draws a single dot.
+        shieldAnimationView.configuration = LottieConfiguration(renderingEngine: .automatic)
         addSubview(shieldAnimationView)
 
         shieldDotAnimationView = LottieAnimationView(frame: bounds)
         shieldDotAnimationView.translatesAutoresizingMaskIntoConstraints = false
         shieldDotAnimationView.contentMode = .scaleAspectFit
         shieldDotAnimationView.backgroundBehavior = .pauseAndRestore
-        shieldDotAnimationView.configuration = LottieConfiguration(renderingEngine: .mainThread)
+        shieldDotAnimationView.configuration = LottieConfiguration(renderingEngine: .automatic)
         addSubview(shieldDotAnimationView)
 
         // Static image view for Dax logo and other images

--- a/iOS/DuckDuckGoTests/FloatingUITests.swift
+++ b/iOS/DuckDuckGoTests/FloatingUITests.swift
@@ -463,6 +463,44 @@ final class DefaultOmniBarViewMinimalChromeTests: XCTestCase {
         }
     }
 
+    func testWhenEmbeddedFieldLaysOutThenIconSlotsAreInsetFromTheCapsuleEnds() throws {
+        let barView = DefaultOmniBarView.create(isFloatingUIEnabled: true)
+        barView.isUsingSmallTopSpacing = true
+        barView.frame = CGRect(x: 0, y: 0, width: 390, height: barView.expectedHeight)
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 800))
+        window.addSubview(barView)
+        window.makeKeyAndVisible()
+        barView.layoutIfNeeded()
+
+        let field = try XCTUnwrap(barView.searchContainer)
+        let fieldFrame = barView.convert(field.bounds, from: field)
+        let slot = try XCTUnwrap(barView.leftIconContainerView)
+        let slotFrame = barView.convert(slot.bounds, from: slot)
+        let shield = try XCTUnwrap(barView.privacyInfoContainer)
+        let shieldCentre = barView.convert(shield.center, from: shield.superview)
+
+        let inset: CGFloat = 2
+
+        // The 44pt slot sits 2pt in from the capsule so its 47pt shield animation is not trimmed
+        // against the leading edge.
+        XCTAssertEqual(slotFrame.minX, fieldFrame.minX + inset, accuracy: 0.5)
+
+        // With a 48pt field the inset lands the shield on the centre of the leading arc, so the
+        // trackers-blocked burst is symmetrical inside the capsule.
+        XCTAssertEqual(shieldCentre.x, fieldFrame.minX + fieldFrame.height / 2, accuracy: 0.5)
+
+        // The trailing end of the content row (whichever control, or the text field, is last) gets
+        // the same breathing room from the trailing arc.
+        let trailingViews: [UIView] = [barView.clearButton, barView.cancelButton, barView.refreshButton,
+                                       barView.customizableButton, barView.urlSeparatorView, barView.aiChatButton,
+                                       barView.textField]
+        let trailingEdge = try XCTUnwrap(trailingViews
+            .filter { !$0.isHidden }
+            .map { barView.convert($0.bounds, from: $0).maxX }
+            .max())
+        XCTAssertEqual(trailingEdge, fieldFrame.maxX - inset, accuracy: 0.5)
+    }
+
     func testWhenNonFloatingIPadSearchAreaExpandsThenModeToggleDoesNotOverlapBottomControls() throws {
         let barView = DefaultOmniBarView.create(isFloatingUIEnabled: false)
         barView.frame = CGRect(x: 0, y: 0, width: 1024, height: DefaultOmniBarView.expectedHeight)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414235014887631/task/1216033800174500
Tech Design URL: N/A
CC: N/A

Stacked on `kk/remove-fire-button-select-mode`.

### Description
- Insets the address field's content 2pt from both capsule ends. The 44pt icon slots were flush with the field's edges, so the shield sat 2pt short of the leading arc's centre and the trailing buttons ran up to the edge.
- Fixes the trackers-blocked shield animation only ever showing confetti to the bottom-right. The confetti is one dot copied eight times by a Lottie Repeater, which the main-thread rendering engine skips. The shield views now use the automatic engine, which renders it through Core Animation and falls back if a file isn't supported.

### Testing Steps
1. Enable the floating UI and set the address bar to the bottom.
2. Load a page → the shield sits centred on the field's leading arc, and the trailing buttons keep 2pt of air from the trailing end.
3. Load a tracker-heavy page (e.g. cnn.com) → after the "N Trackers Blocked" notification, the shield bursts with a full ring of dots rather than a single dot to the bottom-right.
4. Toggle dark mode and repeat step 3 → the shield renders as before at rest and during the burst.

### Impact
Low: visual change to the address field and its animation.

#### What could go wrong?
- A Lottie file unsupported by the Core Animation engine could render differently → `.automatic` falls back to the main-thread engine for such files; the three shield files were checked on device.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual layout and Lottie rendering only; `.automatic` falls back to main-thread for unsupported files, which were verified on device.
> 
> **Overview**
> **Insets embedded address-field content** by 2pt on the leading and trailing edges so icon slots and trailing controls sit inside the capsule rather than flush with the ends. On a 48pt-tall field that also centers the privacy shield on the leading arc for a symmetrical trackers-blocked burst. When the leading icon area is hidden, leading inset stays at 16pt via shared `Metrics` constants.
> 
> **Fixes the trackers-blocked confetti** by switching shield Lottie views from the main-thread engine to `.automatic` (Core Animation), so the animation’s Repeater renders a full ring of dots instead of a single dot.
> 
> Adds a floating-UI layout test (and exposes `urlSeparatorView` on `DefaultOmniBarView` for trailing-edge assertions).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c4459f6a52623c15e2011631630161346e419d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->