### PR TITLE
iOS: Match the split toolbar to the bottom chrome and flatten the embedded address field

### DIFF
--- a/SharedPackages/Infrastructure/DesignResourcesKit/Sources/DesignResourcesKit/Colors/ColorPalettes/DefaultColorPalette.swift
+++ b/SharedPackages/Infrastructure/DesignResourcesKit/Sources/DesignResourcesKit/Colors/ColorPalettes/DefaultColorPalette.swift
@@ -340,6 +340,8 @@ struct DefaultColorPalette: ColorPaletteDefinition {
             return DynamicColor(lightColor: .shade(0.06), darkColor: .tint(0.12))
         case .floatingAddressBarBackground:
             return DynamicColor(lightColor: .shade(0.05), darkColor: .tint(0.08))
+        case .floatingEmbeddedAddressBarBackground:
+            return DynamicColor(lightColor: .tint(0.8), darkColor: .tint(0.08))
         case .unifiedToggleInputAttachmentErrorBannerBackground:
             return DynamicColor(lightColor: xF6CDD1, darkColor: x5A2A2A)
         case .unifiedToggleInputAttachmentErrorText:

--- a/SharedPackages/Infrastructure/DesignResourcesKit/Sources/DesignResourcesKit/Colors/SingleUseColor.swift
+++ b/SharedPackages/Infrastructure/DesignResourcesKit/Sources/DesignResourcesKit/Colors/SingleUseColor.swift
@@ -40,8 +40,7 @@ public enum SingleUseColor {
     /// Resting background fill for the floating address bar field (composites over the toolbar's Liquid Glass capsule)
     case floatingAddressBarBackground
 
-    /// Flat fill for the address field embedded in the bottom floating chrome, standing in for the
-    /// brightness of a glass layer without its highlights
+    /// Flat fill for the address field embedded in the bottom floating chrome (no glass highlights).
     case floatingEmbeddedAddressBarBackground
 
     /// Color used for what's New background

--- a/SharedPackages/Infrastructure/DesignResourcesKit/Sources/DesignResourcesKit/Colors/SingleUseColor.swift
+++ b/SharedPackages/Infrastructure/DesignResourcesKit/Sources/DesignResourcesKit/Colors/SingleUseColor.swift
@@ -40,6 +40,10 @@ public enum SingleUseColor {
     /// Resting background fill for the floating address bar field (composites over the toolbar's Liquid Glass capsule)
     case floatingAddressBarBackground
 
+    /// Flat fill for the address field embedded in the bottom floating chrome, standing in for the
+    /// brightness of a glass layer without its highlights
+    case floatingEmbeddedAddressBarBackground
+
     /// Color used for what's New background
     case whatsNewBackground
 

--- a/iOS/DuckDuckGo/BrowserToolbarView.swift
+++ b/iOS/DuckDuckGo/BrowserToolbarView.swift
@@ -124,19 +124,13 @@ final class BrowserToolbarView: UIView {
     private static let floatingUICornerRadius: CGFloat = 40
 
     static let floatingEmbeddedHorizontalInset: CGFloat = 16
-    /// Fallback physical inset for floating chrome on iOS 26, used only until the host's concentric
-    /// safe-area guide has resolved (it reports an empty frame outside a window). Once resolved,
-    /// the guide's own inset is used so the pill follows the system's concentric geometry.
+    /// Fallback inset before the concentric safe-area guide resolves.
     static let floatingEmbeddedConcentricInset: CGFloat = 20
-    /// Pulls floating chrome in from the system's corner-adapted guide. The guide alone leaves the
-    /// pill reading a touch too close to the display corners, so every edge tucks in by this much
-    /// on top of the device-specific guide inset.
+    /// Extra inset on top of the concentric guide, so the pill isn't flush with the display corner.
     static let floatingConcentricTuck: CGFloat = 4
     /// Outer side inset of the standalone top-address-bar toolbar.
     static let floatingStandaloneHorizontalInset: CGFloat = 24
-    /// Physical inset of every floating pill on iOS 26. Both the combined bottom chrome and the
-    /// standalone (split, top-address-bar) pill sit this far from the screen edges, so their glass
-    /// and outer buttons line up when the layout switches between them.
+    /// Legacy inset kept for pre-iOS-26 callers; superseded by `floatingEmbeddedConcentricInset`.
     static let floatingConcentricGlassInset: CGFloat = 20
     private static let floatingEmbeddedBarOuterInsets = UIEdgeInsets(top: 0, left: floatingEmbeddedHorizontalInset, bottom: 0, right: floatingEmbeddedHorizontalInset)
     private static let floatingStandaloneBarOuterInsets = UIEdgeInsets(top: 0, left: floatingStandaloneHorizontalInset, bottom: 0, right: floatingStandaloneHorizontalInset)
@@ -155,18 +149,13 @@ final class BrowserToolbarView: UIView {
         return addressBarPosition.isBottom ? floatingEmbeddedHorizontalInset : floatingStandaloneHorizontalInset
     }
 
-    /// Physical inset floating chrome keeps from the screen edges: the system's concentric
-    /// safe-area inset plus `floatingConcentricTuck` where the guide has resolved, otherwise
-    /// `floatingEmbeddedConcentricInset`. In landscape the Dynamic Island widens one guide, so the
-    /// narrower side sets the inset and the wider side simply stays at its guide.
+    /// Physical edge inset: the guide's own inset plus a tuck, or the fallback if unresolved.
     static func floatingPhysicalInset(guideInsets: (left: CGFloat, right: CGFloat)) -> CGFloat {
         let resolved = min(max(0, guideInsets.left), max(0, guideInsets.right))
         return resolved > 0 ? resolved + floatingConcentricTuck : floatingEmbeddedConcentricInset
     }
 
-    /// Extra inset inside the corner-adapted guide so floating chrome sits `physicalInset` from the
-    /// physical screen edge. Zero when the guide is already at or beyond that inset (the resolved
-    /// portrait guide, or a landscape Dynamic Island) so the glass never leaves the toolbar.
+    /// Extra inset needed inside the guide to reach `physicalInset`; zero once the guide covers it.
     static func embeddedRestStateInnerInset(guideInset: CGFloat, physicalInset: CGFloat = floatingEmbeddedConcentricInset) -> CGFloat {
         max(0, physicalInset - max(0, guideInset))
     }
@@ -324,11 +313,7 @@ final class BrowserToolbarView: UIView {
         return usesEmbeddedBottomChromeMetrics ? Self.floatingEmbeddedBarOuterInsets : Self.floatingStandaloneBarOuterInsets
     }
 
-    /// Horizontal compensation for floating chrome. Its host is pinned to the corner-adapted
-    /// guide, so this keeps the glass at the same physical inset on every edge unless the guide
-    /// already exceeds that inset. Each edge is compensated from its own guide: in landscape the
-    /// Dynamic Island only enlarges the guide on one side. Shared by the combined bottom chrome
-    /// and the standalone pill so the two are laid out identically.
+    /// Compensates the corner-adapted guide so the glass sits at the same physical inset every edge.
     @available(iOS 26.0, *)
     private var floatingRestStateOuterInsets: UIEdgeInsets {
         guard let host = superview, host.bounds.width > 0 else {
@@ -347,8 +332,7 @@ final class BrowserToolbarView: UIView {
             right: Self.embeddedRestStateInnerInset(guideInset: guideInsets.right, physicalInset: physicalInset))
     }
 
-    /// Distance from the physical bottom edge of `view` to its corner-adapted safe area guide.
-    /// Reports zero for an unresolved guide, for the same reason as `horizontalGuideInsets(in:)`.
+    /// Distance from the physical bottom edge to the corner-adapted safe area guide.
     @available(iOS 26.0, *)
     static func verticalGuideBottomInset(in view: UIView) -> CGFloat {
         let layoutFrame = view.layoutGuide(for: .safeArea(cornerAdaptation: .vertical)).layoutFrame
@@ -356,25 +340,19 @@ final class BrowserToolbarView: UIView {
         return max(0, view.bounds.maxY - layoutFrame.maxY)
     }
 
-    /// Shift that puts floating chrome `physicalInset` from the physical bottom, matching its side
-    /// insets. The layout slot's bottom sits on the guide, so a guide gap wider than the inset
-    /// shifts the glass down and a narrower one shifts it up; it is not clamped to a downward
-    /// shift, or the glass would sit flush on devices whose guide already reaches the bottom.
+    /// Shift that puts the bottom `physicalInset` from the physical edge, matching the sides.
     static func embeddedRestStateBottomOffset(guideBottomGap: CGFloat, physicalInset: CGFloat = floatingEmbeddedConcentricInset) -> CGFloat {
         guideBottomGap - physicalInset
     }
 
-    /// Physical inset the glass keeps from every screen edge, from the host's resolved guides.
+    /// Physical inset the glass keeps from every screen edge.
     @available(iOS 26.0, *)
     private var floatingPhysicalInset: CGFloat {
         guard let host = superview, host.bounds.width > 0 else { return Self.floatingEmbeddedConcentricInset }
         return Self.floatingPhysicalInset(guideInsets: Self.horizontalGuideInsets(in: host))
     }
 
-    /// Distance from each physical edge of `view` to its corner-adapted safe area guide.
-    /// The guide only resolves once the view is in a window; until then its layout frame is
-    /// empty, which carries no inset information. Reporting zero keeps callers from reading an
-    /// unresolved guide as "the whole width is unsafe".
+    /// Distance from each physical edge to the corner-adapted safe area guide; zero if unresolved.
     @available(iOS 26.0, *)
     static func horizontalGuideInsets(in view: UIView) -> (left: CGFloat, right: CGFloat) {
         let layoutFrame = view.layoutGuide(for: .safeArea(cornerAdaptation: .horizontal)).layoutFrame
@@ -965,10 +943,8 @@ final class BrowserToolbarView: UIView {
         chromeContainer.transform = CGAffineTransform(translationX: 0, y: floatingBottomOffset + standaloneHideTranslation)
     }
 
-    /// On iOS 26 the host pins this bar to the concentric vertical guide and the glass is shifted
-    /// so it keeps the same physical inset on every edge, for both the combined bottom chrome and
-    /// the standalone pill. Below iOS 26 the layout slot sits on the safe area and the glass is
-    /// shifted down toward the device bottom, leaving `floatingBottomMargin`.
+    /// Shifts the glass so it keeps the same physical inset as the sides (iOS 26), or leaves
+    /// `floatingBottomMargin` above the safe area (pre-iOS 26).
     private func updateFloatingBottomOffset() {
         let target: CGFloat
         if #available(iOS 26.0, *), isFloatingStyleEnabled {

--- a/iOS/DuckDuckGo/BrowserToolbarView.swift
+++ b/iOS/DuckDuckGo/BrowserToolbarView.swift
@@ -127,11 +127,10 @@ final class BrowserToolbarView: UIView {
     static let floatingEmbeddedConcentricInset: CGFloat = 20
     /// Outer side inset of the standalone top-address-bar toolbar.
     static let floatingStandaloneHorizontalInset: CGFloat = 24
-    /// Extra inset of the custom glass inside the concentric layout-guide pin. Used by the
-    /// standalone (split, top-address-bar) pill so it matches iOS 26 `UIToolbar` glass padding.
-    /// Combined bottom chrome instead keeps its own equal rest-state inset on every edge.
+    /// Physical inset of every floating pill on iOS 26. Both the combined bottom chrome and the
+    /// standalone (split, top-address-bar) pill sit this far from the screen edges, so their glass
+    /// and outer buttons line up when the layout switches between them.
     static let floatingConcentricGlassInset: CGFloat = 20
-    private static let floatingConcentricGlassInsets = UIEdgeInsets(top: 0, left: floatingConcentricGlassInset, bottom: 0, right: floatingConcentricGlassInset)
     private static let floatingEmbeddedBarOuterInsets = UIEdgeInsets(top: 0, left: floatingEmbeddedHorizontalInset, bottom: 0, right: floatingEmbeddedHorizontalInset)
     private static let floatingStandaloneBarOuterInsets = UIEdgeInsets(top: 0, left: floatingStandaloneHorizontalInset, bottom: 0, right: floatingStandaloneHorizontalInset)
     private static let legacyBarOuterInsets = UIEdgeInsets.zero
@@ -143,7 +142,7 @@ final class BrowserToolbarView: UIView {
     static let floatingStandaloneBottomMargin: CGFloat = 21
 
     static func floatingOuterHorizontalInset(for addressBarPosition: AddressBarPosition) -> CGFloat {
-        if #available(iOS 26.0, *), addressBarPosition.isBottom {
+        if #available(iOS 26.0, *) {
             return floatingEmbeddedConcentricInset
         }
         return addressBarPosition.isBottom ? floatingEmbeddedHorizontalInset : floatingStandaloneHorizontalInset
@@ -157,7 +156,7 @@ final class BrowserToolbarView: UIView {
     }
 
     static func floatingBottomMargin(for addressBarPosition: AddressBarPosition) -> CGFloat {
-        if #available(iOS 26.0, *), addressBarPosition.isBottom {
+        if #available(iOS 26.0, *) {
             return floatingEmbeddedConcentricInset
         }
         return addressBarPosition.isBottom ? floatingEmbeddedBottomMargin : floatingStandaloneBottomMargin
@@ -301,24 +300,21 @@ final class BrowserToolbarView: UIView {
         isFloatingStyleEnabled && !hasEmbeddedOmnibar
     }
 
-    private var usesCombinedBottomChromeGeometry: Bool {
-        isFloatingStyleEnabled && (hasEmbeddedOmnibar || isOmnibarMorphing)
-    }
-
     private var currentBarOuterInsets: UIEdgeInsets {
         guard isFloatingStyleEnabled else { return Self.legacyBarOuterInsets }
         if #available(iOS 26.0, *) {
-            return usesCombinedBottomChromeGeometry ? embeddedRestStateOuterInsets : Self.floatingConcentricGlassInsets
+            return floatingRestStateOuterInsets
         }
         return usesEmbeddedBottomChromeMetrics ? Self.floatingEmbeddedBarOuterInsets : Self.floatingStandaloneBarOuterInsets
     }
 
-    /// Horizontal compensation for the combined bottom chrome. Its host is pinned to the
-    /// corner-adapted guide, so this keeps the glass at the same physical inset on every edge
-    /// unless the guide already exceeds that inset. Each edge is compensated from its own guide:
-    /// in landscape the Dynamic Island only enlarges the guide on one side.
+    /// Horizontal compensation for floating chrome. Its host is pinned to the corner-adapted
+    /// guide, so this keeps the glass at the same physical inset on every edge unless the guide
+    /// already exceeds that inset. Each edge is compensated from its own guide: in landscape the
+    /// Dynamic Island only enlarges the guide on one side. Shared by the combined bottom chrome
+    /// and the standalone pill so the two are laid out identically.
     @available(iOS 26.0, *)
-    private var embeddedRestStateOuterInsets: UIEdgeInsets {
+    private var floatingRestStateOuterInsets: UIEdgeInsets {
         guard let host = superview, host.bounds.width > 0 else {
             return UIEdgeInsets(
                 top: 0,
@@ -365,13 +361,20 @@ final class BrowserToolbarView: UIView {
 
     private var currentButtonRowHorizontalPadding: CGFloat {
         guard isFloatingStyleEnabled else { return Self.legacyButtonRowHorizontalPadding }
+        if #available(iOS 26.0, *) {
+            // Standalone and combined pills share one button row geometry.
+            return Self.floatingEmbeddedButtonRowHorizontalPadding
+        }
         return usesEmbeddedBottomChromeMetrics
             ? Self.floatingEmbeddedButtonRowHorizontalPadding
             : Self.floatingStandaloneButtonRowHorizontalPadding
     }
 
     private var currentContentStackHorizontalInset: CGFloat {
-        usesStandaloneFloatingChrome ? 0 : Self.horizontalEdgePadding
+        if #available(iOS 26.0, *) {
+            return Self.horizontalEdgePadding
+        }
+        return usesStandaloneFloatingChrome ? 0 : Self.horizontalEdgePadding
     }
 
     /// Buttons-only bar height for the current style. Floating standalone (top address bar) keeps the
@@ -854,7 +857,7 @@ final class BrowserToolbarView: UIView {
     }
 
     var floatingBottomMargin: CGFloat {
-        if #available(iOS 26.0, *), usesCombinedBottomChromeGeometry {
+        if #available(iOS 26.0, *) {
             return Self.floatingEmbeddedConcentricInset
         }
         return hasEmbeddedOmnibar ? Self.floatingEmbeddedBottomMargin : Self.floatingStandaloneBottomMargin
@@ -878,18 +881,10 @@ final class BrowserToolbarView: UIView {
         let right: CGFloat
         let bottom: CGFloat
         if #available(iOS 26.0, *) {
-            if usesCombinedBottomChromeGeometry {
-                let guideInsets = Self.horizontalGuideInsets(in: view)
-                left = guideInsets.left + Self.embeddedRestStateInnerInset(guideInset: guideInsets.left)
-                right = guideInsets.right + Self.embeddedRestStateInnerInset(guideInset: guideInsets.right)
-                bottom = bounds.maxY - Self.floatingEmbeddedConcentricInset
-            } else {
-                let guideInsets = Self.horizontalGuideInsets(in: view)
-                let glassInset = currentBarOuterInsets.left
-                left = guideInsets.left + glassInset
-                right = guideInsets.right + glassInset
-                bottom = bounds.maxY - Self.verticalGuideBottomInset(in: view)
-            }
+            let guideInsets = Self.horizontalGuideInsets(in: view)
+            left = guideInsets.left + Self.embeddedRestStateInnerInset(guideInset: guideInsets.left)
+            right = guideInsets.right + Self.embeddedRestStateInnerInset(guideInset: guideInsets.right)
+            bottom = bounds.maxY - Self.floatingEmbeddedConcentricInset
         } else {
             let insets = currentBarOuterInsets
             left = insets.left
@@ -945,14 +940,14 @@ final class BrowserToolbarView: UIView {
         chromeContainer.transform = CGAffineTransform(translationX: 0, y: floatingBottomOffset + standaloneHideTranslation)
     }
 
-    /// On iOS 26 the host pins this bar to the concentric vertical guide. Split (standalone) chrome
-    /// stays there. Combined bottom chrome is shifted down to keep the same physical inset on every
-    /// edge. Below iOS 26 the layout slot sits on the safe area and the glass is shifted down toward
-    /// the device bottom, leaving `floatingBottomMargin`.
+    /// On iOS 26 the host pins this bar to the concentric vertical guide and the glass is shifted
+    /// so it keeps the same physical inset on every edge, for both the combined bottom chrome and
+    /// the standalone pill. Below iOS 26 the layout slot sits on the safe area and the glass is
+    /// shifted down toward the device bottom, leaving `floatingBottomMargin`.
     private func updateFloatingBottomOffset() {
         let target: CGFloat
         if #available(iOS 26.0, *), isFloatingStyleEnabled {
-            if usesCombinedBottomChromeGeometry, let host = superview, host.bounds.height > 0 {
+            if let host = superview, host.bounds.height > 0 {
                 let guideBottomGap = Self.verticalGuideBottomInset(in: host)
                 target = Self.embeddedRestStateBottomOffset(guideBottomGap: guideBottomGap)
             } else {

--- a/iOS/DuckDuckGo/BrowserToolbarView.swift
+++ b/iOS/DuckDuckGo/BrowserToolbarView.swift
@@ -124,7 +124,14 @@ final class BrowserToolbarView: UIView {
     private static let floatingUICornerRadius: CGFloat = 40
 
     static let floatingEmbeddedHorizontalInset: CGFloat = 16
+    /// Fallback physical inset for floating chrome on iOS 26, used only until the host's concentric
+    /// safe-area guide has resolved (it reports an empty frame outside a window). Once resolved,
+    /// the guide's own inset is used so the pill follows the system's concentric geometry.
     static let floatingEmbeddedConcentricInset: CGFloat = 20
+    /// Pulls floating chrome in from the system's corner-adapted guide. The guide alone leaves the
+    /// pill reading a touch too close to the display corners, so every edge tucks in by this much
+    /// on top of the device-specific guide inset.
+    static let floatingConcentricTuck: CGFloat = 4
     /// Outer side inset of the standalone top-address-bar toolbar.
     static let floatingStandaloneHorizontalInset: CGFloat = 24
     /// Physical inset of every floating pill on iOS 26. Both the combined bottom chrome and the
@@ -148,11 +155,20 @@ final class BrowserToolbarView: UIView {
         return addressBarPosition.isBottom ? floatingEmbeddedHorizontalInset : floatingStandaloneHorizontalInset
     }
 
-    /// Extra inset inside the corner-adapted guide so combined bottom chrome sits
-    /// `floatingEmbeddedConcentricInset` from the physical screen edges. Zero when the guide is
-    /// already larger (landscape Dynamic Island) so the glass never leaves the toolbar.
-    static func embeddedRestStateInnerInset(guideInset: CGFloat) -> CGFloat {
-        max(0, floatingEmbeddedConcentricInset - max(0, guideInset))
+    /// Physical inset floating chrome keeps from the screen edges: the system's concentric
+    /// safe-area inset plus `floatingConcentricTuck` where the guide has resolved, otherwise
+    /// `floatingEmbeddedConcentricInset`. In landscape the Dynamic Island widens one guide, so the
+    /// narrower side sets the inset and the wider side simply stays at its guide.
+    static func floatingPhysicalInset(guideInsets: (left: CGFloat, right: CGFloat)) -> CGFloat {
+        let resolved = min(max(0, guideInsets.left), max(0, guideInsets.right))
+        return resolved > 0 ? resolved + floatingConcentricTuck : floatingEmbeddedConcentricInset
+    }
+
+    /// Extra inset inside the corner-adapted guide so floating chrome sits `physicalInset` from the
+    /// physical screen edge. Zero when the guide is already at or beyond that inset (the resolved
+    /// portrait guide, or a landscape Dynamic Island) so the glass never leaves the toolbar.
+    static func embeddedRestStateInnerInset(guideInset: CGFloat, physicalInset: CGFloat = floatingEmbeddedConcentricInset) -> CGFloat {
+        max(0, physicalInset - max(0, guideInset))
     }
 
     static func floatingBottomMargin(for addressBarPosition: AddressBarPosition) -> CGFloat {
@@ -323,11 +339,12 @@ final class BrowserToolbarView: UIView {
                 right: Self.floatingEmbeddedConcentricInset)
         }
         let guideInsets = Self.horizontalGuideInsets(in: host)
+        let physicalInset = Self.floatingPhysicalInset(guideInsets: guideInsets)
         return UIEdgeInsets(
             top: 0,
-            left: Self.embeddedRestStateInnerInset(guideInset: guideInsets.left),
+            left: Self.embeddedRestStateInnerInset(guideInset: guideInsets.left, physicalInset: physicalInset),
             bottom: 0,
-            right: Self.embeddedRestStateInnerInset(guideInset: guideInsets.right))
+            right: Self.embeddedRestStateInnerInset(guideInset: guideInsets.right, physicalInset: physicalInset))
     }
 
     /// Distance from the physical bottom edge of `view` to its corner-adapted safe area guide.
@@ -339,12 +356,19 @@ final class BrowserToolbarView: UIView {
         return max(0, view.bounds.maxY - layoutFrame.maxY)
     }
 
-    /// Shift that puts combined bottom chrome `floatingEmbeddedConcentricInset` from the physical
-    /// bottom. The layout slot's bottom sits on the guide, so a guide gap wider than the inset
+    /// Shift that puts floating chrome `physicalInset` from the physical bottom, matching its side
+    /// insets. The layout slot's bottom sits on the guide, so a guide gap wider than the inset
     /// shifts the glass down and a narrower one shifts it up; it is not clamped to a downward
     /// shift, or the glass would sit flush on devices whose guide already reaches the bottom.
-    static func embeddedRestStateBottomOffset(guideBottomGap: CGFloat) -> CGFloat {
-        guideBottomGap - floatingEmbeddedConcentricInset
+    static func embeddedRestStateBottomOffset(guideBottomGap: CGFloat, physicalInset: CGFloat = floatingEmbeddedConcentricInset) -> CGFloat {
+        guideBottomGap - physicalInset
+    }
+
+    /// Physical inset the glass keeps from every screen edge, from the host's resolved guides.
+    @available(iOS 26.0, *)
+    private var floatingPhysicalInset: CGFloat {
+        guard let host = superview, host.bounds.width > 0 else { return Self.floatingEmbeddedConcentricInset }
+        return Self.floatingPhysicalInset(guideInsets: Self.horizontalGuideInsets(in: host))
     }
 
     /// Distance from each physical edge of `view` to its corner-adapted safe area guide.
@@ -858,7 +882,7 @@ final class BrowserToolbarView: UIView {
 
     var floatingBottomMargin: CGFloat {
         if #available(iOS 26.0, *) {
-            return Self.floatingEmbeddedConcentricInset
+            return floatingPhysicalInset
         }
         return hasEmbeddedOmnibar ? Self.floatingEmbeddedBottomMargin : Self.floatingStandaloneBottomMargin
     }
@@ -882,9 +906,10 @@ final class BrowserToolbarView: UIView {
         let bottom: CGFloat
         if #available(iOS 26.0, *) {
             let guideInsets = Self.horizontalGuideInsets(in: view)
-            left = guideInsets.left + Self.embeddedRestStateInnerInset(guideInset: guideInsets.left)
-            right = guideInsets.right + Self.embeddedRestStateInnerInset(guideInset: guideInsets.right)
-            bottom = bounds.maxY - Self.floatingEmbeddedConcentricInset
+            let physicalInset = Self.floatingPhysicalInset(guideInsets: guideInsets)
+            left = guideInsets.left + Self.embeddedRestStateInnerInset(guideInset: guideInsets.left, physicalInset: physicalInset)
+            right = guideInsets.right + Self.embeddedRestStateInnerInset(guideInset: guideInsets.right, physicalInset: physicalInset)
+            bottom = bounds.maxY - physicalInset
         } else {
             let insets = currentBarOuterInsets
             left = insets.left
@@ -949,7 +974,7 @@ final class BrowserToolbarView: UIView {
         if #available(iOS 26.0, *), isFloatingStyleEnabled {
             if let host = superview, host.bounds.height > 0 {
                 let guideBottomGap = Self.verticalGuideBottomInset(in: host)
-                target = Self.embeddedRestStateBottomOffset(guideBottomGap: guideBottomGap)
+                target = Self.embeddedRestStateBottomOffset(guideBottomGap: guideBottomGap, physicalInset: floatingPhysicalInset)
             } else {
                 target = 0
             }

--- a/iOS/DuckDuckGo/DefaultOmniBarView.swift
+++ b/iOS/DuckDuckGo/DefaultOmniBarView.swift
@@ -767,12 +767,18 @@ final class DefaultOmniBarView: UIView, OmniBarView, ExpandableOmniBarView {
         var view = UIVisualEffectView()
         UITraitCollection(userInterfaceStyle: configuration.interfaceStyle).performAsCurrent {
             if #available(iOS 26.0, *) {
-                // The embedded field carries the same material blur as the rest of the chrome.
-                let effect = UIGlassEffect(style: .regular)
-                if configuration.fireMode {
-                    effect.tintColor = UIColor(singleUseColor: .fireModeBackground)
+                if configuration.kind == .embedded {
+                    // The embedded field already sits on the chrome's glass, so it takes a flat fill
+                    // rather than a second layer of glass with its own highlights.
+                    view = UIVisualEffectView(effect: nil)
+                    view.backgroundColor = UIColor(singleUseColor: .floatingEmbeddedAddressBarBackground)
+                } else {
+                    let effect = UIGlassEffect(style: .regular)
+                    if configuration.fireMode {
+                        effect.tintColor = UIColor(singleUseColor: .fireModeBackground)
+                    }
+                    view = UIVisualEffectView(effect: effect)
                 }
-                view = UIVisualEffectView(effect: effect)
                 view.cornerConfiguration = .capsule()
             }
         }

--- a/iOS/DuckDuckGo/DefaultOmniBarView.swift
+++ b/iOS/DuckDuckGo/DefaultOmniBarView.swift
@@ -768,8 +768,7 @@ final class DefaultOmniBarView: UIView, OmniBarView, ExpandableOmniBarView {
         UITraitCollection(userInterfaceStyle: configuration.interfaceStyle).performAsCurrent {
             if #available(iOS 26.0, *) {
                 if configuration.kind == .embedded {
-                    // The embedded field already sits on the chrome's glass, so it takes a flat fill
-                    // rather than a second layer of glass with its own highlights.
+                    // Flat fill: the chrome underneath is already glass.
                     view = UIVisualEffectView(effect: nil)
                     view.backgroundColor = UIColor(singleUseColor: .floatingEmbeddedAddressBarBackground)
                 } else {

--- a/iOS/DuckDuckGoTests/BrowserToolbarViewTests.swift
+++ b/iOS/DuckDuckGoTests/BrowserToolbarViewTests.swift
@@ -209,8 +209,7 @@ final class BrowserToolbarViewTests: XCTestCase {
         let frame = sut.restingCapsuleFrame(in: container)
 
         if #available(iOS 26.0, *) {
-            // The standalone pill shares the combined bottom chrome's physical inset on every edge,
-            // so the two line up when the layout switches between them.
+            // Standalone shares the combined chrome's physical inset, so the two line up.
             XCTAssertEqual(frame.minX, BrowserToolbarView.floatingEmbeddedConcentricInset, accuracy: 0.01)
             XCTAssertEqual(container.bounds.width - frame.maxX, BrowserToolbarView.floatingEmbeddedConcentricInset, accuracy: 0.01)
             XCTAssertEqual(container.bounds.maxY - frame.maxY, BrowserToolbarView.floatingEmbeddedConcentricInset, accuracy: 0.01)
@@ -231,8 +230,7 @@ final class BrowserToolbarViewTests: XCTestCase {
         let frame = sut.restingCapsuleFrame(in: container)
 
         if #available(iOS 26.0, *) {
-            // Every edge follows the system's concentric guide (plus the tuck), so the inset is
-            // device-specific but equal all round.
+            // Device-specific inset (guide + tuck), equal on every edge.
             let physical = BrowserToolbarView.floatingPhysicalInset(guideInsets: BrowserToolbarView.horizontalGuideInsets(in: container))
             XCTAssertEqual(frame.minX, physical, accuracy: 0.01)
             XCTAssertEqual(container.bounds.width - frame.maxX, physical, accuracy: 0.01)
@@ -280,8 +278,7 @@ final class BrowserToolbarViewTests: XCTestCase {
     }
 
     func testWhenConcentricGuideHasResolvedThenThePillTucksInFromTheGuide() {
-        // The system's concentric inset wins over the fallback once the guide reports a value on
-        // both sides; the narrower side sets the inset when a Dynamic Island widens the other.
+        // Resolved guide wins over the fallback; the narrower side wins under a Dynamic Island.
         let tuck = BrowserToolbarView.floatingConcentricTuck
         XCTAssertEqual(BrowserToolbarView.floatingPhysicalInset(guideInsets: (left: 18, right: 18)), 18 + tuck, accuracy: 0.01)
         XCTAssertEqual(BrowserToolbarView.floatingPhysicalInset(guideInsets: (left: 57, right: 18)), 18 + tuck, accuracy: 0.01)
@@ -348,8 +345,7 @@ final class BrowserToolbarViewTests: XCTestCase {
         let frame = sut.restingCapsuleFrame(in: container)
 
         if #available(iOS 26.0, *) {
-            // Every edge follows the system's concentric guide (plus the tuck), so the inset is
-            // device-specific but equal all round.
+            // Device-specific inset (guide + tuck), equal on every edge.
             let physical = BrowserToolbarView.floatingPhysicalInset(guideInsets: BrowserToolbarView.horizontalGuideInsets(in: container))
             XCTAssertEqual(frame.minX, physical, accuracy: 0.01)
             XCTAssertEqual(container.bounds.width - frame.maxX, physical, accuracy: 0.01)
@@ -452,8 +448,7 @@ final class BrowserToolbarViewTests: XCTestCase {
         let last = try XCTUnwrap(centers.last)
         let capsule = sut.restingCapsuleFrame(in: window)
 
-        // The split pill's outer buttons land exactly where the combined bottom chrome's icons do,
-        // so switching address bar position doesn't move them.
+        // Outer buttons land where the combined chrome's icons do.
         let expectedInset = BrowserToolbarView.floatingEmbeddedAddressBarIconInset
         XCTAssertEqual(first - capsule.minX, expectedInset, accuracy: 0.5)
         XCTAssertEqual(capsule.maxX - last, expectedInset, accuracy: 0.5)

--- a/iOS/DuckDuckGoTests/BrowserToolbarViewTests.swift
+++ b/iOS/DuckDuckGoTests/BrowserToolbarViewTests.swift
@@ -231,9 +231,12 @@ final class BrowserToolbarViewTests: XCTestCase {
         let frame = sut.restingCapsuleFrame(in: container)
 
         if #available(iOS 26.0, *) {
-            XCTAssertEqual(frame.minX, BrowserToolbarView.floatingEmbeddedConcentricInset, accuracy: 0.01)
-            XCTAssertEqual(container.bounds.width - frame.maxX, BrowserToolbarView.floatingEmbeddedConcentricInset, accuracy: 0.01)
-            XCTAssertEqual(container.bounds.maxY - frame.maxY, BrowserToolbarView.floatingEmbeddedConcentricInset, accuracy: 0.01)
+            // Every edge follows the system's concentric guide (plus the tuck), so the inset is
+            // device-specific but equal all round.
+            let physical = BrowserToolbarView.floatingPhysicalInset(guideInsets: BrowserToolbarView.horizontalGuideInsets(in: container))
+            XCTAssertEqual(frame.minX, physical, accuracy: 0.01)
+            XCTAssertEqual(container.bounds.width - frame.maxX, physical, accuracy: 0.01)
+            XCTAssertEqual(container.bounds.maxY - frame.maxY, physical, accuracy: 0.01)
         } else {
             XCTAssertEqual(BrowserToolbarView.floatingEmbeddedHorizontalInset, 16)
             XCTAssertEqual(frame.minX, 16, accuracy: 0.01)
@@ -267,12 +270,29 @@ final class BrowserToolbarViewTests: XCTestCase {
 
         let frame = sut.restingCapsuleFrame(in: container)
         let guideInsets = BrowserToolbarView.horizontalGuideInsets(in: container)
+        let physical = BrowserToolbarView.floatingPhysicalInset(guideInsets: guideInsets)
 
-        // Each edge sits at its own guide, or at the concentric inset when the guide is smaller.
-        XCTAssertEqual(frame.minX, max(guideInsets.left, concentric), accuracy: 0.01)
-        XCTAssertEqual(container.bounds.width - frame.maxX, max(guideInsets.right, concentric), accuracy: 0.01)
-        // The wide leading guide must not pull the opposite edge inside the concentric inset.
-        XCTAssertGreaterThanOrEqual(container.bounds.width - frame.maxX, concentric - 0.01)
+        // Each edge sits at its own guide, or at the physical inset when the guide is smaller.
+        XCTAssertEqual(frame.minX, max(guideInsets.left, physical), accuracy: 0.01)
+        XCTAssertEqual(container.bounds.width - frame.maxX, max(guideInsets.right, physical), accuracy: 0.01)
+        // The wide leading guide must not pull the opposite edge inside the physical inset.
+        XCTAssertGreaterThanOrEqual(container.bounds.width - frame.maxX, physical - 0.01)
+    }
+
+    func testWhenConcentricGuideHasResolvedThenThePillTucksInFromTheGuide() {
+        // The system's concentric inset wins over the fallback once the guide reports a value on
+        // both sides; the narrower side sets the inset when a Dynamic Island widens the other.
+        let tuck = BrowserToolbarView.floatingConcentricTuck
+        XCTAssertEqual(BrowserToolbarView.floatingPhysicalInset(guideInsets: (left: 18, right: 18)), 18 + tuck, accuracy: 0.01)
+        XCTAssertEqual(BrowserToolbarView.floatingPhysicalInset(guideInsets: (left: 57, right: 18)), 18 + tuck, accuracy: 0.01)
+        XCTAssertEqual(BrowserToolbarView.embeddedRestStateInnerInset(guideInset: 18, physicalInset: 18 + tuck), tuck, accuracy: 0.01)
+        XCTAssertEqual(BrowserToolbarView.embeddedRestStateBottomOffset(guideBottomGap: 34, physicalInset: 18 + tuck), 34 - 18 - tuck, accuracy: 0.01)
+    }
+
+    func testWhenConcentricGuideIsUnresolvedThenTheFallbackInsetIsUsed() {
+        let concentric = BrowserToolbarView.floatingEmbeddedConcentricInset
+        XCTAssertEqual(BrowserToolbarView.floatingPhysicalInset(guideInsets: (left: 0, right: 0)), concentric, accuracy: 0.01)
+        XCTAssertEqual(BrowserToolbarView.floatingPhysicalInset(guideInsets: (left: 57, right: 0)), concentric, accuracy: 0.01)
     }
 
     func testWhenGuideGapExceedsConcentricInsetThenGlassShiftsDown() {
@@ -328,9 +348,12 @@ final class BrowserToolbarViewTests: XCTestCase {
         let frame = sut.restingCapsuleFrame(in: container)
 
         if #available(iOS 26.0, *) {
-            XCTAssertEqual(frame.minX, BrowserToolbarView.floatingEmbeddedConcentricInset, accuracy: 0.01)
-            XCTAssertEqual(container.bounds.width - frame.maxX, BrowserToolbarView.floatingEmbeddedConcentricInset, accuracy: 0.01)
-            XCTAssertEqual(container.bounds.maxY - frame.maxY, BrowserToolbarView.floatingEmbeddedConcentricInset, accuracy: 0.01)
+            // Every edge follows the system's concentric guide (plus the tuck), so the inset is
+            // device-specific but equal all round.
+            let physical = BrowserToolbarView.floatingPhysicalInset(guideInsets: BrowserToolbarView.horizontalGuideInsets(in: container))
+            XCTAssertEqual(frame.minX, physical, accuracy: 0.01)
+            XCTAssertEqual(container.bounds.width - frame.maxX, physical, accuracy: 0.01)
+            XCTAssertEqual(container.bounds.maxY - frame.maxY, physical, accuracy: 0.01)
         }
     }
 

--- a/iOS/DuckDuckGoTests/BrowserToolbarViewTests.swift
+++ b/iOS/DuckDuckGoTests/BrowserToolbarViewTests.swift
@@ -208,13 +208,14 @@ final class BrowserToolbarViewTests: XCTestCase {
 
         let frame = sut.restingCapsuleFrame(in: container)
 
-        XCTAssertEqual(BrowserToolbarView.floatingStandaloneButtonRowHorizontalPadding, 16)
         if #available(iOS 26.0, *) {
-            let guide = container.layoutGuide(for: .safeArea(cornerAdaptation: .horizontal))
-            let expected = guide.layoutFrame.minX + BrowserToolbarView.floatingConcentricGlassInset
-            XCTAssertEqual(frame.minX, expected, accuracy: 0.01)
-            XCTAssertEqual(container.bounds.width - frame.maxX, expected, accuracy: 0.01)
+            // The standalone pill shares the combined bottom chrome's physical inset on every edge,
+            // so the two line up when the layout switches between them.
+            XCTAssertEqual(frame.minX, BrowserToolbarView.floatingEmbeddedConcentricInset, accuracy: 0.01)
+            XCTAssertEqual(container.bounds.width - frame.maxX, BrowserToolbarView.floatingEmbeddedConcentricInset, accuracy: 0.01)
+            XCTAssertEqual(container.bounds.maxY - frame.maxY, BrowserToolbarView.floatingEmbeddedConcentricInset, accuracy: 0.01)
         } else {
+            XCTAssertEqual(BrowserToolbarView.floatingStandaloneButtonRowHorizontalPadding, 16)
             XCTAssertEqual(BrowserToolbarView.floatingStandaloneHorizontalInset, 24)
             XCTAssertEqual(frame.minX, 24, accuracy: 0.01)
             XCTAssertEqual(container.bounds.width - frame.maxX, 24, accuracy: 0.01)
@@ -333,13 +334,19 @@ final class BrowserToolbarViewTests: XCTestCase {
         }
     }
 
-    func testWhenStandaloneFloatingThenBottomMarginIsTwentyOnePoints() {
+    func testWhenStandaloneFloatingThenBottomMarginMatchesCombinedChrome() {
         let sut = makeSUT(embeddedOmnibar: false)
 
-        XCTAssertEqual(BrowserToolbarView.floatingStandaloneBottomMargin, 21)
-        XCTAssertEqual(sut.floatingBottomMargin, 21, accuracy: 0.01)
-        XCTAssertEqual(BrowserToolbarView.floatingOuterHorizontalInset(for: .top), 24)
-        XCTAssertEqual(BrowserToolbarView.floatingBottomMargin(for: .top), 21)
+        if #available(iOS 26.0, *) {
+            XCTAssertEqual(sut.floatingBottomMargin, BrowserToolbarView.floatingEmbeddedConcentricInset, accuracy: 0.01)
+            XCTAssertEqual(BrowserToolbarView.floatingOuterHorizontalInset(for: .top), BrowserToolbarView.floatingEmbeddedConcentricInset)
+            XCTAssertEqual(BrowserToolbarView.floatingBottomMargin(for: .top), BrowserToolbarView.floatingEmbeddedConcentricInset)
+        } else {
+            XCTAssertEqual(BrowserToolbarView.floatingStandaloneBottomMargin, 21)
+            XCTAssertEqual(sut.floatingBottomMargin, 21, accuracy: 0.01)
+            XCTAssertEqual(BrowserToolbarView.floatingOuterHorizontalInset(for: .top), 24)
+            XCTAssertEqual(BrowserToolbarView.floatingBottomMargin(for: .top), 21)
+        }
     }
 
     func testWhenEmbeddedFloatingThenBottomMarginMatchesPlatformGeometry() {
@@ -387,6 +394,43 @@ final class BrowserToolbarViewTests: XCTestCase {
 
         // Both rows carry 44pt controls, so aligned centres mean the same distance from the glass
         // edge as the address field's icons: its 16pt text-area padding plus half a control.
+        let expectedInset = BrowserToolbarView.floatingEmbeddedAddressBarIconInset
+        XCTAssertEqual(first - capsule.minX, expectedInset, accuracy: 0.5)
+        XCTAssertEqual(capsule.maxX - last, expectedInset, accuracy: 0.5)
+    }
+
+    func testWhenStandaloneFloatingThenOuterButtonsSitWhereTheCombinedChromeIconsDo() throws {
+        guard #available(iOS 26.0, *) else { throw XCTSkip("Floating UI is iOS 26+") }
+        let sut = makeSUT(embeddedOmnibar: false)
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 800))
+        sut.translatesAutoresizingMaskIntoConstraints = false
+        window.addSubview(sut)
+        window.makeKeyAndVisible()
+        let horizontalGuide = window.layoutGuide(for: .safeArea(cornerAdaptation: .horizontal))
+        NSLayoutConstraint.activate([
+            sut.leadingAnchor.constraint(equalTo: horizontalGuide.leadingAnchor),
+            sut.trailingAnchor.constraint(equalTo: horizontalGuide.trailingAnchor),
+            sut.bottomAnchor.constraint(equalTo: window.bottomAnchor),
+            sut.heightAnchor.constraint(equalToConstant: 62)
+        ])
+        sut.setToolbarButtons([
+            makeToolbarButton(identifier: "back", width: 44),
+            makeToolbarButton(identifier: "forward", width: 44),
+            makeToolbarButton(identifier: "fire", width: 44),
+            makeToolbarButton(identifier: "tabs", width: 44),
+            makeToolbarButton(identifier: "menu", width: 44)
+        ])
+        window.layoutIfNeeded()
+
+        let centers = sut.arrangedToolbarButtonViews.map { view in
+            window.convert(view.center, from: view.superview).x
+        }
+        let first = try XCTUnwrap(centers.first)
+        let last = try XCTUnwrap(centers.last)
+        let capsule = sut.restingCapsuleFrame(in: window)
+
+        // The split pill's outer buttons land exactly where the combined bottom chrome's icons do,
+        // so switching address bar position doesn't move them.
         let expectedInset = BrowserToolbarView.floatingEmbeddedAddressBarIconInset
         XCTAssertEqual(first - capsule.minX, expectedInset, accuracy: 0.5)
         XCTAssertEqual(capsule.maxX - last, expectedInset, accuracy: 0.5)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414235014887631/task/1216033800174500
Tech Design URL: N/A
CC: N/A

Stacked on https://github.com/duckduckgo/apple-browsers/pull/6673.

### Description
- Lays out the split (top-address-bar) toolbar pill with the same geometry as the combined bottom chrome: same edge inset on every side, same button-row padding, so its outer buttons land exactly where the bottom chrome's icons do.
- Derives that edge inset from the system's corner-adapted safe-area guide plus a 4pt tuck, instead of a fixed 20pt. On iPhone 17 that's 22pt, matching the system tab bar, and it adapts per device. The fixed value remains only as a fallback while the guide is unresolved.
- Gives the address field embedded in the bottom chrome a flat, bright fill instead of a second layer of glass with its own highlights. The top-placement and minimal-chrome fields keep their glass.

### Testing Steps
1. Enable the floating UI on an iPhone running iOS 26.
2. Set the address bar to the bottom and load a page → the address field is a flat white fill inside the chrome, with no glass highlights.
3. Scroll the page so the chrome collapses to the button row → note the pill's edges and button positions.
4. Switch the address bar to the top → the standalone toolbar pill has the same edges and button positions as in step 3, sitting about 22pt from the screen edges.
5. Compare against a system tab bar (e.g. any first-party app) → the side inset matches.

### Impact
Low: visual layout change to the floating chrome.

#### What could go wrong?
- The corner-adapted guide reports an empty frame before the view is in a window → the previous fixed 20pt inset is used until it resolves, covered by unit tests.
- Landscape with the Dynamic Island widens one guide → the narrower side sets the inset and the wider side stays on its guide, covered by the asymmetric-guide test.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual and layout-only changes to iOS 26 floating toolbar/omnibar; pre-iOS 26 paths are largely preserved and behavior is covered by updated unit tests.
> 
> **Overview**
> Aligns **iOS 26 floating chrome** so the split (top address bar) toolbar pill uses the same layout as the combined bottom bar: shared button-row padding, content insets, and capsule framing via one `floatingRestStateOuterInsets` path instead of separate standalone vs embedded geometry.
> 
> **Edge inset** is no longer a fixed 20pt on iOS 26. It comes from the corner-adapted safe-area guide plus a **4pt tuck** (`floatingPhysicalInset`), with the previous concentric value as fallback when the guide is unresolved. Bottom glass offset and `restingCapsuleFrame` use that same physical inset on every edge.
> 
> Adds **`floatingEmbeddedAddressBarBackground`** and changes the **bottom embedded omnibar** on iOS 26 to a flat fill (no second `UIGlassEffect` layer); top and minimal-chrome fields still use glass.
> 
> Unit tests are updated for the new inset math and to assert standalone outer buttons line up with combined chrome.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2338098237e2308b821643480d767bd5d951ed06. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->