### PR TITLE
macOS: New Create Image flow telemetry

### DIFF
--- a/macOS/DuckDuckGo/AIChat/AIChatOmnibarContainerViewController.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatOmnibarContainerViewController.swift
@@ -1198,6 +1198,7 @@ final class AIChatOmnibarContainerViewController: NSViewController {
             // Ahead of the pixel: this card is not a usage message, so closing it must not report
             // a dismissal against whichever usage exposure happens to be open.
             if createImageModelSwitchNotice != nil {
+                omnibarController.pixelHandler.fire(.createImageModelSwitchNoticeDismissed)
                 clearCreateImageModelSwitchNotice()
                 return
             }

--- a/macOS/DuckDuckGo/AIChat/AIChatOmnibarController.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatOmnibarController.swift
@@ -868,13 +868,23 @@ final class AIChatOmnibarController {
     private func switchToImageGenerationModelIfNeeded() -> AIChatCreateImageModelSwitchNotice? {
         guard isUpdatedCreateImageEnabled,
               let previousModel = selectedModel,
-              !previousModel.supportsTool(.imageGeneration),
-              let fallbackModel = imageGenerationModel else {
+              !previousModel.supportsTool(.imageGeneration) else {
+            return nil
+        }
+
+        guard let fallbackModel = imageGenerationModel else {
+            pixelHandler.fire(.createImageUnavailable)
             return nil
         }
 
         updateSelectedModel(fallbackModel.id)
-        return AIChatCreateImageModelSwitchNotice(previousModel: previousModel, newModel: fallbackModel)
+        let notice = AIChatCreateImageModelSwitchNotice(previousModel: previousModel, newModel: fallbackModel)
+        pixelHandler.fire(.createImageModelSwitched(
+            fromModelId: previousModel.id,
+            toModelId: fallbackModel.id,
+            fromModelPrivacyPreserving: notice.previousModelHasExtraPrivacyProtections
+        ))
+        return notice
     }
 
     /// The model ID to use for the current submission. In image-generation mode an
@@ -1370,6 +1380,9 @@ final class AIChatOmnibarController {
         usageWarningMeasurement.promptSubmitted()
 
         if isImageGenerationMode {
+            if !selectedModelSupportsImageGeneration {
+                pixelHandler.fire(.createImageSubmittedWithUnsupportedModel)
+            }
             pixelHandler.fire(.imageGenerationSubmitted)
         } else if isWebSearchMode {
             pixelHandler.fire(.webSearchSubmitted)

--- a/macOS/DuckDuckGo/AIChat/AIChatOmnibarController.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatOmnibarController.swift
@@ -1375,18 +1375,9 @@ final class AIChatOmnibarController {
             return
         }
 
-        pixelHandler.fire(.promptSubmitted)
+        firePromptSubmissionPixels()
         // After the URL branch: navigating away is not a prompt spent against the allowance.
         usageWarningMeasurement.promptSubmitted()
-
-        if isImageGenerationMode {
-            if !selectedModelSupportsImageGeneration {
-                pixelHandler.fire(.createImageSubmittedWithUnsupportedModel)
-            }
-            pixelHandler.fire(.imageGenerationSubmitted)
-        } else if isWebSearchMode {
-            pixelHandler.fire(.webSearchSubmitted)
-        }
 
         // Snapshot everything that could change between now and when the async submit Task
         // resumes. `await waitForAttachmentsReady?()` can take seconds for large images, and
@@ -1516,6 +1507,22 @@ final class AIChatOmnibarController {
         }
 
         currentText = ""
+    }
+
+    private func firePromptSubmissionPixels() {
+        pixelHandler.fire(.promptSubmitted)
+
+        switch activeToolMode {
+        case .imageGeneration:
+            if !selectedModelSupportsImageGeneration {
+                pixelHandler.fire(.createImageSubmittedWithUnsupportedModel)
+            }
+            pixelHandler.fire(.imageGenerationSubmitted)
+        case .webSearch:
+            pixelHandler.fire(.webSearchSubmitted)
+        case nil:
+            break
+        }
     }
 
     /// Eagerly extracts the page context for each omnibar-attached tab, returning a

--- a/macOS/DuckDuckGo/AIChat/AIChatPixel.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatPixel.swift
@@ -365,6 +365,18 @@ enum AIChatPixel: PixelKit.Event {
     /// Event Trigger: User submits a prompt while image generation mode is active
     case aiChatAddressBarImageGenerationSubmitted
 
+    /// Event Trigger: Selecting Create Image switches an unsupported model to an image-capable model.
+    case aiChatAddressBarCreateImageModelSwitched(fromModelId: String, toModelId: String, fromModelPrivacyPreserving: Bool)
+
+    /// Event Trigger: User dismisses the model-switch notice shown after selecting Create Image.
+    case aiChatAddressBarCreateImageModelSwitchNoticeDismissed
+
+    /// Event Trigger: Create Image cannot find an accessible image-capable model.
+    case aiChatAddressBarCreateImageUnavailable
+
+    /// Error monitor: a Create Image prompt is submitted while the selected model is known not to support image generation.
+    case aiChatAddressBarCreateImageSubmittedWithUnsupportedModel
+
     // MARK: - Web Search Mode
 
     /// Event Trigger: User activates web search mode via the Tools menu
@@ -754,6 +766,14 @@ enum AIChatPixel: PixelKit.Event {
             return "aichat_addressbar_image_generation_deactivated"
         case .aiChatAddressBarImageGenerationSubmitted:
             return "aichat_addressbar_image_generation_submitted"
+        case .aiChatAddressBarCreateImageModelSwitched:
+            return "aichat_addressbar_create_image_model_switched"
+        case .aiChatAddressBarCreateImageModelSwitchNoticeDismissed:
+            return "aichat_addressbar_create_image_model_switch_notice_dismissed"
+        case .aiChatAddressBarCreateImageUnavailable:
+            return "aichat_addressbar_create_image_unavailable"
+        case .aiChatAddressBarCreateImageSubmittedWithUnsupportedModel:
+            return "aichat_addressbar_create_image_submitted_with_unsupported_model"
         case .aiChatAddressBarWebSearchActivated:
             return "aichat_addressbar_web_search_activated"
         case .aiChatAddressBarWebSearchDeactivated:
@@ -921,6 +941,9 @@ enum AIChatPixel: PixelKit.Event {
                 .aiChatAddressBarImageGenerationActivated,
                 .aiChatAddressBarImageGenerationDeactivated,
                 .aiChatAddressBarImageGenerationSubmitted,
+                .aiChatAddressBarCreateImageModelSwitchNoticeDismissed,
+                .aiChatAddressBarCreateImageUnavailable,
+                .aiChatAddressBarCreateImageSubmittedWithUnsupportedModel,
                 .aiChatAddressBarWebSearchActivated,
                 .aiChatAddressBarWebSearchDeactivated,
                 .aiChatAddressBarWebSearchSubmitted,
@@ -972,6 +995,13 @@ enum AIChatPixel: PixelKit.Event {
             ]
         case .aiChatAddressBarSubscriptionUpsellTriggered(let currentTier, let requiredTier, let flowType, let origin):
             return ["current_tier": currentTier, "required_tier": requiredTier, "flow_type": flowType, "origin": origin]
+        case .aiChatAddressBarCreateImageModelSwitched(let fromModelId, let toModelId, let fromModelPrivacyPreserving):
+            return [
+                "from_model_id": fromModelId,
+                "to_model_id": toModelId,
+                "from_model_privacy_preserving": String(fromModelPrivacyPreserving),
+                "entry_point": "tools_menu"
+            ]
         case .aiChatAddressBarSubscriptionUpsellShown(let origin),
                 .aiChatNtpSubscriptionUpsellShown(let origin):
             return ["origin": origin]
@@ -1194,6 +1224,10 @@ enum AIChatPixel: PixelKit.Event {
                 .aiChatAddressBarImageGenerationActivated,
                 .aiChatAddressBarImageGenerationDeactivated,
                 .aiChatAddressBarImageGenerationSubmitted,
+                .aiChatAddressBarCreateImageModelSwitched,
+                .aiChatAddressBarCreateImageModelSwitchNoticeDismissed,
+                .aiChatAddressBarCreateImageUnavailable,
+                .aiChatAddressBarCreateImageSubmittedWithUnsupportedModel,
                 .aiChatAddressBarWebSearchActivated,
                 .aiChatAddressBarWebSearchDeactivated,
                 .aiChatAddressBarWebSearchSubmitted,

--- a/macOS/DuckDuckGo/AIChat/PromptInput/DuckAIPromptPixelFiring.swift
+++ b/macOS/DuckDuckGo/AIChat/PromptInput/DuckAIPromptPixelFiring.swift
@@ -48,6 +48,10 @@ enum DuckAIPromptPixelEvent: Equatable {
     /// its own origin, so the event itself carries none.
     case modelPickerShown
     case reasoningPickerShown
+    case createImageModelSwitched(fromModelId: String, toModelId: String, fromModelPrivacyPreserving: Bool)
+    case createImageModelSwitchNoticeDismissed
+    case createImageUnavailable
+    case createImageSubmittedWithUnsupportedModel
     /// The native upsell dialog was shown after a gated pick. Carries the origin because it varies
     /// per picker within a surface.
     case subscriptionUpsellShown(origin: String)
@@ -64,10 +68,23 @@ struct AddressBarPromptPixelHandler: DuckAIPromptPixelFiring {
     func fire(_ event: DuckAIPromptPixelEvent) {
         switch event {
         case .voiceChatOpened:
-            PixelKit.fire(AIChatPixel.aiChatNewVoiceChatOmnibarNative, frequency: .dailyAndStandard, includeAppVersionParameter: true)
+            PixelKit.fire(AIChatPixel.aiChatNewVoiceChatOmnibarNative,
+                          frequency: Self.frequency(for: event),
+                          includeAppVersionParameter: true)
         default:
             guard let pixel = Self.addressBarPixel(for: event) else { return }
-            PixelKit.fire(pixel, frequency: .dailyAndCount, includeAppVersionParameter: true)
+            PixelKit.fire(pixel, frequency: Self.frequency(for: event), includeAppVersionParameter: true)
+        }
+    }
+
+    static func frequency(for event: DuckAIPromptPixelEvent) -> PixelKit.Frequency {
+        switch event {
+        case .voiceChatOpened:
+            return .dailyAndStandard
+        case .createImageUnavailable:
+            return .daily
+        default:
+            return .dailyAndCount
         }
     }
 
@@ -100,6 +117,16 @@ struct AddressBarPromptPixelHandler: DuckAIPromptPixelFiring {
             .aiChatAddressBarModelPickerShown(origin: SubscriptionFunnelOrigin.addressBarModelPicker.rawValue)
         case .reasoningPickerShown:
             .aiChatAddressBarReasoningPickerShown(origin: SubscriptionFunnelOrigin.addressBarReasoningDropdown.rawValue)
+        case .createImageModelSwitched(let fromModelId, let toModelId, let fromModelPrivacyPreserving):
+            .aiChatAddressBarCreateImageModelSwitched(fromModelId: fromModelId,
+                                                      toModelId: toModelId,
+                                                      fromModelPrivacyPreserving: fromModelPrivacyPreserving)
+        case .createImageModelSwitchNoticeDismissed:
+            .aiChatAddressBarCreateImageModelSwitchNoticeDismissed
+        case .createImageUnavailable:
+            .aiChatAddressBarCreateImageUnavailable
+        case .createImageSubmittedWithUnsupportedModel:
+            .aiChatAddressBarCreateImageSubmittedWithUnsupportedModel
         case .subscriptionUpsellShown(let origin):
             .aiChatAddressBarSubscriptionUpsellShown(origin: origin)
         case .subscriptionUpsellTriggered(let currentTier, let requiredTier, let flowType, let origin):

--- a/macOS/DuckDuckGo/PromptBar/Model/PromptBarPixel.swift
+++ b/macOS/DuckDuckGo/PromptBar/Model/PromptBarPixel.swift
@@ -65,6 +65,18 @@ enum PromptBarPixel: PixelKit.Event {
     /// Event Trigger: User submits a prompt while image generation mode is active
     case imageGenerationSubmitted
 
+    /// Event Trigger: Selecting Create Image switches an unsupported model to an image-capable model.
+    case createImageModelSwitched(fromModelId: String, toModelId: String, fromModelPrivacyPreserving: Bool)
+
+    /// Event Trigger: User dismisses the model-switch notice shown after selecting Create Image.
+    case createImageModelSwitchNoticeDismissed
+
+    /// Event Trigger: Create Image cannot find an accessible image-capable model.
+    case createImageUnavailable
+
+    /// Error monitor: a Create Image prompt is submitted while the selected model is known not to support image generation.
+    case createImageSubmittedWithUnsupportedModel
+
     /// Event Trigger: User activates web search mode via the Tools menu
     case webSearchActivated
 
@@ -149,6 +161,14 @@ enum PromptBarPixel: PixelKit.Event {
             return "aichat_promptbar_image_generation_deactivated"
         case .imageGenerationSubmitted:
             return "aichat_promptbar_image_generation_submitted"
+        case .createImageModelSwitched:
+            return "aichat_promptbar_create_image_model_switched"
+        case .createImageModelSwitchNoticeDismissed:
+            return "aichat_promptbar_create_image_model_switch_notice_dismissed"
+        case .createImageUnavailable:
+            return "aichat_promptbar_create_image_unavailable"
+        case .createImageSubmittedWithUnsupportedModel:
+            return "aichat_promptbar_create_image_submitted_with_unsupported_model"
         case .webSearchActivated:
             return "aichat_promptbar_web_search_activated"
         case .webSearchDeactivated:
@@ -197,6 +217,9 @@ enum PromptBarPixel: PixelKit.Event {
                 .imageGenerationActivated,
                 .imageGenerationDeactivated,
                 .imageGenerationSubmitted,
+                .createImageModelSwitchNoticeDismissed,
+                .createImageUnavailable,
+                .createImageSubmittedWithUnsupportedModel,
                 .webSearchActivated,
                 .webSearchDeactivated,
                 .webSearchSubmitted,
@@ -217,6 +240,13 @@ enum PromptBarPixel: PixelKit.Event {
             return ["fileCount": String(fileCount)]
         case .fileValidationFailed(let reason):
             return ["reason": reason]
+        case .createImageModelSwitched(let fromModelId, let toModelId, let fromModelPrivacyPreserving):
+            return [
+                "from_model_id": fromModelId,
+                "to_model_id": toModelId,
+                "from_model_privacy_preserving": String(fromModelPrivacyPreserving),
+                "entry_point": "tools_menu"
+            ]
         case .dismissedWithoutSubmission(let reason, let hadText):
             return ["reason": reason.rawValue, "had_text": String(hadText)]
         case .state(let shortcutEnabled, let menuBarIconEnabled):

--- a/macOS/DuckDuckGo/PromptBar/Model/PromptBarPixelHandler.swift
+++ b/macOS/DuckDuckGo/PromptBar/Model/PromptBarPixelHandler.swift
@@ -66,6 +66,10 @@ struct PromptBarPixelHandler: DuckAIPromptPixelFiring {
                 .tabChosen,
                 .tabPickerCanceled,
                 .customizeResponsesOpened,
+                .createImageModelSwitched,
+                .createImageModelSwitchNoticeDismissed,
+                .createImageUnavailable,
+                .createImageSubmittedWithUnsupportedModel,
                 .subscriptionUpsellShown,
                 .subscriptionUpsellTriggered:
             nil

--- a/macOS/DuckDuckGo/PromptBar/Model/PromptBarPixelHandler.swift
+++ b/macOS/DuckDuckGo/PromptBar/Model/PromptBarPixelHandler.swift
@@ -25,13 +25,17 @@ struct PromptBarPixelHandler: DuckAIPromptPixelFiring {
 
     func fire(_ event: DuckAIPromptPixelEvent) {
         guard let pixel = Self.promptBarPixel(for: event) else { return }
+        PixelKit.fire(pixel, frequency: Self.frequency(for: event), includeAppVersionParameter: true)
+    }
 
-        switch pixel {
-        case .newVoiceChat:
-            // The frequency its address bar counterpart uses.
-            PixelKit.fire(pixel, frequency: .dailyAndStandard, includeAppVersionParameter: true)
+    static func frequency(for event: DuckAIPromptPixelEvent) -> PixelKit.Frequency {
+        switch event {
+        case .voiceChatOpened:
+            return .dailyAndStandard
+        case .createImageUnavailable:
+            return .daily
         default:
-            PixelKit.fire(pixel, frequency: .dailyAndCount, includeAppVersionParameter: true)
+            return .dailyAndCount
         }
     }
 
@@ -60,16 +64,19 @@ struct PromptBarPixelHandler: DuckAIPromptPixelFiring {
         case .modelPickerShown: .modelPickerShown(origin: SubscriptionFunnelOrigin.promptBarModelPicker.rawValue)
         case .reasoningPickerShown: .reasoningPickerShown(origin: SubscriptionFunnelOrigin.promptBarReasoningDropdown.rawValue)
         case .voiceChatOpened: .newVoiceChat
+        case .createImageModelSwitched(let fromModelId, let toModelId, let fromModelPrivacyPreserving):
+            .createImageModelSwitched(fromModelId: fromModelId,
+                                      toModelId: toModelId,
+                                      fromModelPrivacyPreserving: fromModelPrivacyPreserving)
+        case .createImageModelSwitchNoticeDismissed: .createImageModelSwitchNoticeDismissed
+        case .createImageUnavailable: .createImageUnavailable
+        case .createImageSubmittedWithUnsupportedModel: .createImageSubmittedWithUnsupportedModel
         case .submittedWithTabs,
                 .tabAttachmentRemoved,
                 .tabPickerShown,
                 .tabChosen,
                 .tabPickerCanceled,
                 .customizeResponsesOpened,
-                .createImageModelSwitched,
-                .createImageModelSwitchNoticeDismissed,
-                .createImageUnavailable,
-                .createImageSubmittedWithUnsupportedModel,
                 .subscriptionUpsellShown,
                 .subscriptionUpsellTriggered:
             nil

--- a/macOS/PixelDefinitions/pixels/definitions/aichat_addressbar_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/aichat_addressbar_pixels.json5
@@ -369,6 +369,59 @@
         "suffixes": ["daily_count"],
         "parameters": ["appVersion", "pixelSource", "channel"]
     },
+    "m_mac_aichat_addressbar_create_image_model_switched": {
+        "description": "Fired when selecting Create Image switches an unsupported model to an accessible image-capable model",
+        "owners": ["jotaemepereira"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count"],
+        "parameters": [
+            "appVersion",
+            "pixelSource",
+            "channel",
+            {
+                "key": "from_model_id",
+                "type": "string",
+                "description": "Identifier of the unsupported model selected before the switch"
+            },
+            {
+                "key": "to_model_id",
+                "type": "string",
+                "description": "Identifier of the image-capable model selected automatically"
+            },
+            {
+                "key": "from_model_privacy_preserving",
+                "type": "boolean",
+                "description": "Whether the model selected before the switch had extra privacy protections"
+            },
+            {
+                "key": "entry_point",
+                "type": "string",
+                "enum": ["tools_menu"],
+                "description": "Where the user selected Create Image"
+            }
+        ]
+    },
+    "m_mac_aichat_addressbar_create_image_model_switch_notice_dismissed": {
+        "description": "Fired when the user dismisses the notice shown after Create Image switches models",
+        "owners": ["jotaemepereira"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count"],
+        "parameters": ["appVersion", "pixelSource", "channel"]
+    },
+    "m_mac_aichat_addressbar_create_image_unavailable": {
+        "description": "Fired when Create Image cannot find an accessible image-capable model",
+        "owners": ["jotaemepereira"],
+        "triggers": ["other"],
+        "suffixes": ["daily"],
+        "parameters": ["appVersion", "pixelSource", "channel"]
+    },
+    "m_mac_aichat_addressbar_create_image_submitted_with_unsupported_model": {
+        "description": "Error monitor fired when a Create Image prompt is submitted while the selected model is known not to support image generation",
+        "owners": ["jotaemepereira"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count"],
+        "parameters": ["appVersion", "pixelSource", "channel"]
+    },
     "m_mac_aichat_addressbar_web_search_activated": {
         "description": "Fired when user selects the Web Search tool to enter web search mode",
         "owners": ["tomasstrba"],

--- a/macOS/PixelDefinitions/pixels/definitions/aichat_promptbar_pixels.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/aichat_promptbar_pixels.json5
@@ -118,6 +118,59 @@
         "suffixes": ["daily_count"],
         "parameters": ["appVersion", "pixelSource", "channel"]
     },
+    "m_mac_aichat_promptbar_create_image_model_switched": {
+        "description": "Fired when selecting Create Image in the Prompt Bar switches an unsupported model to an accessible image-capable model",
+        "owners": ["jotaemepereira"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count"],
+        "parameters": [
+            "appVersion",
+            "pixelSource",
+            "channel",
+            {
+                "key": "from_model_id",
+                "type": "string",
+                "description": "Identifier of the unsupported model selected before the switch"
+            },
+            {
+                "key": "to_model_id",
+                "type": "string",
+                "description": "Identifier of the image-capable model selected automatically"
+            },
+            {
+                "key": "from_model_privacy_preserving",
+                "type": "boolean",
+                "description": "Whether the model selected before the switch had extra privacy protections"
+            },
+            {
+                "key": "entry_point",
+                "type": "string",
+                "enum": ["tools_menu"],
+                "description": "Where the user selected Create Image"
+            }
+        ]
+    },
+    "m_mac_aichat_promptbar_create_image_model_switch_notice_dismissed": {
+        "description": "Fired when the user dismisses the model-switch notice shown after selecting Create Image in the Prompt Bar",
+        "owners": ["jotaemepereira"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count"],
+        "parameters": ["appVersion", "pixelSource", "channel"]
+    },
+    "m_mac_aichat_promptbar_create_image_unavailable": {
+        "description": "Fired when Create Image in the Prompt Bar cannot find an accessible image-capable model",
+        "owners": ["jotaemepereira"],
+        "triggers": ["other"],
+        "suffixes": ["daily"],
+        "parameters": ["appVersion", "pixelSource", "channel"]
+    },
+    "m_mac_aichat_promptbar_create_image_submitted_with_unsupported_model": {
+        "description": "Error monitor fired when a Create Image prompt is submitted from the Prompt Bar while the selected model is known not to support image generation",
+        "owners": ["jotaemepereira"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count"],
+        "parameters": ["appVersion", "pixelSource", "channel"]
+    },
     "m_mac_aichat_promptbar_web_search_activated": {
         "description": "Fired when user selects the Web Search tool in the Prompt Bar to enter web search mode",
         "owners": ["Bunn"],

--- a/macOS/UnitTests/AIChat/AIChatOmnibarControllerTests.swift
+++ b/macOS/UnitTests/AIChat/AIChatOmnibarControllerTests.swift
@@ -38,6 +38,7 @@ final class AIChatOmnibarControllerTests: XCTestCase {
     private var mockSubscriptionManager: SubscriptionManagerMock!
     private var mockSubscriptionUpsellPresenter: MockAIChatOmnibarSubscriptionUpselling!
     private var tabCollectionViewModel: TabCollectionViewModel!
+    private var pixelHandler: CapturingDuckAIPromptPixelHandler!
 
     override func setUp() {
         super.setUp()
@@ -56,6 +57,7 @@ final class AIChatOmnibarControllerTests: XCTestCase {
         mockModelsService = MockAIChatModelsProviding()
         mockSubscriptionManager = SubscriptionManagerMock()
         mockSubscriptionUpsellPresenter = MockAIChatOmnibarSubscriptionUpselling()
+        pixelHandler = CapturingDuckAIPromptPixelHandler()
         // Injected (rather than the real UserDefaults-backed default) so the impression cap is
         // controllable and no test leaks state into the shared standard defaults.
         tabCollectionViewModel = TabCollectionViewModel(isPopup: false)
@@ -65,7 +67,7 @@ final class AIChatOmnibarControllerTests: XCTestCase {
             surface: .addressBar,
             draftSource: TabPromptDraftSource(tabCollectionViewModel: tabCollectionViewModel),
             origin: WindowPromptOrigin(tabCollectionViewModel: tabCollectionViewModel),
-            pixelHandler: AddressBarPromptPixelHandler(),
+            pixelHandler: pixelHandler,
             featureFlagger: featureFlagger,
             searchPreferencesPersistor: searchPreferencesPersistor,
             preferences: mockPreferences,
@@ -87,6 +89,7 @@ final class AIChatOmnibarControllerTests: XCTestCase {
         mockSubscriptionManager = nil
         mockSubscriptionUpsellPresenter = nil
         tabCollectionViewModel = nil
+        pixelHandler = nil
         super.tearDown()
     }
 
@@ -1344,6 +1347,11 @@ final class AIChatOmnibarControllerTests: XCTestCase {
         XCTAssertEqual(notice?.previousModelShortName, "Mistral Small")
         XCTAssertEqual(notice?.newModelShortName, "GPT-5.4 mini")
         XCTAssertEqual(notice?.previousModelHasExtraPrivacyProtections, false)
+        XCTAssertTrue(pixelHandler.events.contains(.createImageModelSwitched(
+            fromModelId: "mistral",
+            toModelId: "suggested",
+            fromModelPrivacyPreserving: false
+        )))
     }
 
     func testWhenUpdatedCreateImageSwitchesFromOSSModel_ThenNoticeMentionsExtraPrivacyProtections() async {
@@ -1365,6 +1373,11 @@ final class AIChatOmnibarControllerTests: XCTestCase {
         XCTAssertEqual(notice?.previousModelShortName, "GPT-OSS")
         XCTAssertEqual(notice?.newModelShortName, "GPT-5.4")
         XCTAssertEqual(notice?.previousModelHasExtraPrivacyProtections, true)
+        XCTAssertTrue(pixelHandler.events.contains(.createImageModelSwitched(
+            fromModelId: "gpt-oss-120b",
+            toModelId: "image-model",
+            fromModelPrivacyPreserving: true
+        )))
     }
 
     func testWhenSelectedModelAlreadySupportsImageGeneration_ThenModelIsNotChangedAndNoticeIsNotReturned() async {
@@ -1384,6 +1397,10 @@ final class AIChatOmnibarControllerTests: XCTestCase {
         // Then
         XCTAssertEqual(mockPreferences.selectedModelId, "selected")
         XCTAssertNil(notice)
+        XCTAssertFalse(pixelHandler.events.contains { event in
+            if case .createImageModelSwitched = event { return true }
+            return false
+        })
     }
 
     func testWhenUpdatedCreateImageIsDisabled_ThenUnsupportedSelectedModelIsNotChanged() async {
@@ -1426,6 +1443,7 @@ final class AIChatOmnibarControllerTests: XCTestCase {
         XCTAssertNil(controller.effectiveModelId)
         XCTAssertNil(controller.effectiveToolChoice)
         XCTAssertEqual(controller.effectiveMode, AIChatNativePrompt.imageGenerationMode)
+        XCTAssertTrue(pixelHandler.events.contains(.createImageUnavailable))
     }
 
     func testWhenUpdatedCreateImageIsActivatedBeforeModelsLoad_ThenModelSwitchesAfterFetchAndModeStaysActive() async {
@@ -1604,6 +1622,27 @@ final class AIChatOmnibarControllerTests: XCTestCase {
         XCTAssertEqual(query.modelId, "img-model")
         XCTAssertEqual(query.toolChoice, [AIChatRAGTool.imageGeneration.rawValue])
         XCTAssertNil(query.mode)
+        XCTAssertFalse(pixelHandler.events.contains(.createImageSubmittedWithUnsupportedModel))
+    }
+
+    func testWhenImageGenerationIsSubmittedWithKnownUnsupportedSelectedModel_ThenErrorPixelFires() async {
+        // Given
+        featureFlagger.featuresStub[FeatureFlag.updatedCreateImage.rawValue] = false
+        mockModelsService.modelsToReturn = [
+            makeRemoteModel(id: "unsupported", supportedTools: []),
+            makeRemoteModel(id: "fallback", supportedTools: ["GenerateImage"])
+        ]
+        mockPreferences.selectedModelId = "unsupported"
+        controller.onOmnibarActivated()
+        await waitForModels()
+        controller.toggleImageGenerationMode()
+        controller.updateText("draw a lighthouse")
+
+        // When
+        controller.submit()
+
+        // Then
+        XCTAssertTrue(pixelHandler.events.contains(.createImageSubmittedWithUnsupportedModel))
     }
 
     // MARK: - Reasoning Effort Tests
@@ -3000,6 +3039,14 @@ private class MockAIChatOmnibarControllerDelegate: AIChatOmnibarControllerDelega
 
 private class AIChatMockSearchPreferencesPersistor: SearchPreferencesPersistor {
     var showAutocompleteSuggestions: Bool = true
+}
+
+private final class CapturingDuckAIPromptPixelHandler: DuckAIPromptPixelFiring {
+    private(set) var events: [DuckAIPromptPixelEvent] = []
+
+    func fire(_ event: DuckAIPromptPixelEvent) {
+        events.append(event)
+    }
 }
 
 // MARK: - Mock AI Chat Preferences

--- a/macOS/UnitTests/AIChat/AIChatOmnibarControllerTests.swift
+++ b/macOS/UnitTests/AIChat/AIChatOmnibarControllerTests.swift
@@ -1625,9 +1625,38 @@ final class AIChatOmnibarControllerTests: XCTestCase {
         XCTAssertFalse(pixelHandler.events.contains(.createImageSubmittedWithUnsupportedModel))
     }
 
-    func testWhenImageGenerationIsSubmittedWithKnownUnsupportedSelectedModel_ThenErrorPixelFires() async {
+    func testWhenImageGenerationIsSubmittedWithoutAccessibleImageModel_ThenErrorPixelFiresAndLegacyModeIsUsed() async {
         // Given
-        featureFlagger.featuresStub[FeatureFlag.updatedCreateImage.rawValue] = false
+        featureFlagger.featuresStub[FeatureFlag.updatedCreateImage.rawValue] = true
+        mockModelsService.modelsToReturn = [
+            makeRemoteModel(id: "unsupported", supportedTools: [])
+        ]
+        mockPreferences.selectedModelId = "unsupported"
+        controller.onOmnibarActivated()
+        await waitForModels()
+        controller.toggleImageGenerationMode()
+        controller.updateText("draw a lighthouse")
+
+        // When
+        controller.submit()
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        // Then
+        XCTAssertTrue(pixelHandler.events.contains(.createImageUnavailable))
+        XCTAssertTrue(pixelHandler.events.contains(.createImageSubmittedWithUnsupportedModel))
+        let prompt = AIChatPromptHandler.shared.consumeData()
+        guard case .query(let query) = prompt?.tool else {
+            XCTFail("Expected a `.query` tool in the submitted prompt")
+            return
+        }
+        XCTAssertNil(query.modelId)
+        XCTAssertNil(query.toolChoice)
+        XCTAssertEqual(query.mode, AIChatNativePrompt.imageGenerationMode)
+    }
+
+    func testWhenImageGenerationSwitchesToFallbackBeforeSubmission_ThenErrorPixelDoesNotFire() async {
+        // Given
+        featureFlagger.featuresStub[FeatureFlag.updatedCreateImage.rawValue] = true
         mockModelsService.modelsToReturn = [
             makeRemoteModel(id: "unsupported", supportedTools: []),
             makeRemoteModel(id: "fallback", supportedTools: ["GenerateImage"])
@@ -1640,9 +1669,18 @@ final class AIChatOmnibarControllerTests: XCTestCase {
 
         // When
         controller.submit()
+        try? await Task.sleep(nanoseconds: 100_000_000)
 
         // Then
-        XCTAssertTrue(pixelHandler.events.contains(.createImageSubmittedWithUnsupportedModel))
+        XCTAssertFalse(pixelHandler.events.contains(.createImageSubmittedWithUnsupportedModel))
+        let prompt = AIChatPromptHandler.shared.consumeData()
+        guard case .query(let query) = prompt?.tool else {
+            XCTFail("Expected a `.query` tool in the submitted prompt")
+            return
+        }
+        XCTAssertEqual(query.modelId, "fallback")
+        XCTAssertEqual(query.toolChoice, [AIChatRAGTool.imageGeneration.rawValue])
+        XCTAssertNil(query.mode)
     }
 
     // MARK: - Reasoning Effort Tests

--- a/macOS/UnitTests/AIChat/DuckAIPromptPixelFiringTests.swift
+++ b/macOS/UnitTests/AIChat/DuckAIPromptPixelFiringTests.swift
@@ -50,6 +50,15 @@ final class DuckAIPromptPixelFiringTests: XCTestCase {
         (.reasoningEffortSelected, .aiChatAddressBarReasoningEffortSelected),
         (.modelPickerShown, .aiChatAddressBarModelPickerShown(origin: "funnel_addressbar_macos__modelpicker")),
         (.reasoningPickerShown, .aiChatAddressBarReasoningPickerShown(origin: "funnel_addressbar_macos__reasoningdropdown")),
+        (.createImageModelSwitched(fromModelId: "gpt-oss-120b",
+                                   toModelId: "gpt-5.4",
+                                   fromModelPrivacyPreserving: true),
+         .aiChatAddressBarCreateImageModelSwitched(fromModelId: "gpt-oss-120b",
+                                                   toModelId: "gpt-5.4",
+                                                   fromModelPrivacyPreserving: true)),
+        (.createImageModelSwitchNoticeDismissed, .aiChatAddressBarCreateImageModelSwitchNoticeDismissed),
+        (.createImageUnavailable, .aiChatAddressBarCreateImageUnavailable),
+        (.createImageSubmittedWithUnsupportedModel, .aiChatAddressBarCreateImageSubmittedWithUnsupportedModel),
         (.subscriptionUpsellShown(origin: "funnel_addressbar_macos__modelpicker"),
          .aiChatAddressBarSubscriptionUpsellShown(origin: "funnel_addressbar_macos__modelpicker")),
         (.subscriptionUpsellTriggered(currentTier: "free", requiredTier: "plus", flowType: "modal", origin: "funnel_addressbar_macos__modelpicker"),
@@ -86,6 +95,12 @@ final class DuckAIPromptPixelFiringTests: XCTestCase {
         (.reasoningEffortSelected, .reasoningEffortSelected),
         (.modelPickerShown, .modelPickerShown(origin: "funnel_promptbar_macos__modelpicker")),
         (.reasoningPickerShown, .reasoningPickerShown(origin: "funnel_promptbar_macos__reasoningdropdown")),
+        (.createImageModelSwitched(fromModelId: "gpt-oss-120b",
+                                   toModelId: "gpt-5.4",
+                                   fromModelPrivacyPreserving: true), nil),
+        (.createImageModelSwitchNoticeDismissed, nil),
+        (.createImageUnavailable, nil),
+        (.createImageSubmittedWithUnsupportedModel, nil),
         (.subscriptionUpsellShown(origin: "x"), nil),
         (.subscriptionUpsellTriggered(currentTier: "free", requiredTier: "plus", flowType: "modal", origin: "x"), nil),
         (.voiceChatOpened, .newVoiceChat)
@@ -105,6 +120,42 @@ final class DuckAIPromptPixelFiringTests: XCTestCase {
         XCTAssertEqual(PromptBarPixel.modelPickerShown(origin: "x").name, "aichat_promptbar_model_picker_shown")
         XCTAssertEqual(PromptBarPixel.reasoningPickerShown(origin: "x").name, "aichat_promptbar_reasoning_picker_shown")
         XCTAssertEqual(PromptBarPixel.modelPickerShown(origin: "x").parameters, ["origin": "x"])
+    }
+
+    func testWhenCreateImagePixelsAreMappedThenNamesAndParametersMatchDefinitions() {
+        let modelSwitched = AIChatPixel.aiChatAddressBarCreateImageModelSwitched(
+            fromModelId: "gpt-oss-120b",
+            toModelId: "gpt-5.4",
+            fromModelPrivacyPreserving: true
+        )
+
+        XCTAssertEqual(modelSwitched.name, "aichat_addressbar_create_image_model_switched")
+        XCTAssertEqual(modelSwitched.parameters, [
+            "from_model_id": "gpt-oss-120b",
+            "to_model_id": "gpt-5.4",
+            "from_model_privacy_preserving": "true",
+            "entry_point": "tools_menu"
+        ])
+        XCTAssertEqual(AIChatPixel.aiChatAddressBarCreateImageModelSwitchNoticeDismissed.name,
+                       "aichat_addressbar_create_image_model_switch_notice_dismissed")
+        XCTAssertNil(AIChatPixel.aiChatAddressBarCreateImageModelSwitchNoticeDismissed.parameters)
+        XCTAssertEqual(AIChatPixel.aiChatAddressBarCreateImageUnavailable.name,
+                       "aichat_addressbar_create_image_unavailable")
+        XCTAssertNil(AIChatPixel.aiChatAddressBarCreateImageUnavailable.parameters)
+        XCTAssertEqual(AIChatPixel.aiChatAddressBarCreateImageSubmittedWithUnsupportedModel.name,
+                       "aichat_addressbar_create_image_submitted_with_unsupported_model")
+        XCTAssertNil(AIChatPixel.aiChatAddressBarCreateImageSubmittedWithUnsupportedModel.parameters)
+    }
+
+    func testWhenCreateImagePixelsAreFiredThenFrequenciesMirrorIOS() {
+        XCTAssertEqual(AddressBarPromptPixelHandler.frequency(for: .createImageModelSwitched(
+            fromModelId: "from",
+            toModelId: "to",
+            fromModelPrivacyPreserving: false
+        )), .dailyAndCount)
+        XCTAssertEqual(AddressBarPromptPixelHandler.frequency(for: .createImageModelSwitchNoticeDismissed), .dailyAndCount)
+        XCTAssertEqual(AddressBarPromptPixelHandler.frequency(for: .createImageUnavailable), .daily)
+        XCTAssertEqual(AddressBarPromptPixelHandler.frequency(for: .createImageSubmittedWithUnsupportedModel), .dailyAndCount)
     }
 
     func testWhenAddressBarHandlerMapsAnEvent_ThenItKeepsThePixelItFiredBefore() {

--- a/macOS/UnitTests/AIChat/DuckAIPromptPixelFiringTests.swift
+++ b/macOS/UnitTests/AIChat/DuckAIPromptPixelFiringTests.swift
@@ -97,10 +97,13 @@ final class DuckAIPromptPixelFiringTests: XCTestCase {
         (.reasoningPickerShown, .reasoningPickerShown(origin: "funnel_promptbar_macos__reasoningdropdown")),
         (.createImageModelSwitched(fromModelId: "gpt-oss-120b",
                                    toModelId: "gpt-5.4",
-                                   fromModelPrivacyPreserving: true), nil),
-        (.createImageModelSwitchNoticeDismissed, nil),
-        (.createImageUnavailable, nil),
-        (.createImageSubmittedWithUnsupportedModel, nil),
+                                   fromModelPrivacyPreserving: true),
+         .createImageModelSwitched(fromModelId: "gpt-oss-120b",
+                                   toModelId: "gpt-5.4",
+                                   fromModelPrivacyPreserving: true)),
+        (.createImageModelSwitchNoticeDismissed, .createImageModelSwitchNoticeDismissed),
+        (.createImageUnavailable, .createImageUnavailable),
+        (.createImageSubmittedWithUnsupportedModel, .createImageSubmittedWithUnsupportedModel),
         (.subscriptionUpsellShown(origin: "x"), nil),
         (.subscriptionUpsellTriggered(currentTier: "free", requiredTier: "plus", flowType: "modal", origin: "x"), nil),
         (.voiceChatOpened, .newVoiceChat)
@@ -156,6 +159,39 @@ final class DuckAIPromptPixelFiringTests: XCTestCase {
         XCTAssertEqual(AddressBarPromptPixelHandler.frequency(for: .createImageModelSwitchNoticeDismissed), .dailyAndCount)
         XCTAssertEqual(AddressBarPromptPixelHandler.frequency(for: .createImageUnavailable), .daily)
         XCTAssertEqual(AddressBarPromptPixelHandler.frequency(for: .createImageSubmittedWithUnsupportedModel), .dailyAndCount)
+        XCTAssertEqual(PromptBarPixelHandler.frequency(for: .createImageModelSwitched(
+            fromModelId: "from",
+            toModelId: "to",
+            fromModelPrivacyPreserving: false
+        )), .dailyAndCount)
+        XCTAssertEqual(PromptBarPixelHandler.frequency(for: .createImageModelSwitchNoticeDismissed), .dailyAndCount)
+        XCTAssertEqual(PromptBarPixelHandler.frequency(for: .createImageUnavailable), .daily)
+        XCTAssertEqual(PromptBarPixelHandler.frequency(for: .createImageSubmittedWithUnsupportedModel), .dailyAndCount)
+    }
+
+    func testWhenPromptBarCreateImagePixelsAreMappedThenNamesAndParametersMatchDefinitions() {
+        let modelSwitched = PromptBarPixel.createImageModelSwitched(
+            fromModelId: "gpt-oss-120b",
+            toModelId: "gpt-5.4",
+            fromModelPrivacyPreserving: true
+        )
+
+        XCTAssertEqual(modelSwitched.name, "aichat_promptbar_create_image_model_switched")
+        XCTAssertEqual(modelSwitched.parameters, [
+            "from_model_id": "gpt-oss-120b",
+            "to_model_id": "gpt-5.4",
+            "from_model_privacy_preserving": "true",
+            "entry_point": "tools_menu"
+        ])
+        XCTAssertEqual(PromptBarPixel.createImageModelSwitchNoticeDismissed.name,
+                       "aichat_promptbar_create_image_model_switch_notice_dismissed")
+        XCTAssertNil(PromptBarPixel.createImageModelSwitchNoticeDismissed.parameters)
+        XCTAssertEqual(PromptBarPixel.createImageUnavailable.name,
+                       "aichat_promptbar_create_image_unavailable")
+        XCTAssertNil(PromptBarPixel.createImageUnavailable.parameters)
+        XCTAssertEqual(PromptBarPixel.createImageSubmittedWithUnsupportedModel.name,
+                       "aichat_promptbar_create_image_submitted_with_unsupported_model")
+        XCTAssertNil(PromptBarPixel.createImageSubmittedWithUnsupportedModel.parameters)
     }
 
     func testWhenAddressBarHandlerMapsAnEvent_ThenItKeepsThePixelItFiredBefore() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204006570077678/task/1218029146860297?focus=true
Tech Design URL:
CC:

### Description
Adds pixels for the new Create Image flow to mimic iOS.

### Testing Steps
Use a macOS debug build with `updatedCreateImage` enabled and inspect outgoing PixelKit events.

1. Select a model without image-generation support, then choose Tools → Create Image → `m_mac_aichat_addressbar_create_image_model_switched` fires with the previous/new model IDs, privacy flag, and `entry_point=tools_menu`.
2. Dismiss the resulting model-switch notice → `m_mac_aichat_addressbar_create_image_model_switch_notice_dismissed` fires.
3. Stub `/models` with an unsupported selected model and no accessible image-capable model, then choose Create Image → `m_mac_aichat_addressbar_create_image_unavailable` fires.
4. Keep Create Image active while stubbing the selected model as unsupported, then submit a prompt → `m_mac_aichat_addressbar_create_image_submitted_with_unsupported_model` fires.

### Impact
Low. Telemetry-only changes behind the existing Create Image flow.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Telemetry-only changes on the existing Create Image path; no auth, data handling, or submission logic beyond firing pixels.
> 
> **Overview**
> Adds **macOS analytics for the updated Create Image flow**, aligned with iOS, for both the AI chat address bar and the Prompt Bar.
> 
> **Instrumentation:** Fires when Create Image auto-switches from an unsupported model (with `from_model_id`, `to_model_id`, privacy flag, `entry_point=tools_menu`), when the user dismisses the model-switch notice, when no image-capable model is available, and as an error monitor when a Create Image prompt is submitted while the selected model does not support image generation. Submit-time image/web-search pixels are centralized in `firePromptSubmissionPixels()` on `activeToolMode`.
> 
> **Plumbing:** New `DuckAIPromptPixelEvent` cases map through `AddressBarPromptPixelHandler` and `PromptBarPixelHandler` to `AIChatPixel` / `PromptBarPixel`, with `create_image_unavailable` using **daily** frequency (others **daily_count**). JSON pixel definitions and unit tests cover mappings, parameters, and controller behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c99728bd8f143518e849066466d538e0d9e1c53. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



