### PR TITLE
macOS: Add a debug-menu override for the VPN endpoint port (PoC)

### DIFF
--- a/SharedPackages/VPN/Sources/VPN/Monitoring/TunnelMonitors.swift
+++ b/SharedPackages/VPN/Sources/VPN/Monitoring/TunnelMonitors.swift
@@ -163,7 +163,7 @@ final class TunnelMonitors: TunnelMonitoring {
                 excludeLocalNetworks: excludeLocalNetworks,
                 excludeCGNAT: self.settings.excludeCGNAT,
                 dnsSettings: self.settings.dnsSettings,
-                endpointPortOverride: self.settings.endpointPortOverride) { [weak self] generateConfigResult in
+                endpointPortOverride: self.settings.endpointPortOverride ?? VPNSettings.defaultEndpointPortOverride) { [weak self] generateConfigResult in
                 try await self?.onFailureRecoveryConfigUpdate(generateConfigResult)
             }
         }

--- a/SharedPackages/VPN/Sources/VPN/Monitoring/TunnelMonitors.swift
+++ b/SharedPackages/VPN/Sources/VPN/Monitoring/TunnelMonitors.swift
@@ -162,7 +162,8 @@ final class TunnelMonitors: TunnelMonitoring {
                 to: server,
                 excludeLocalNetworks: excludeLocalNetworks,
                 excludeCGNAT: self.settings.excludeCGNAT,
-                dnsSettings: self.settings.dnsSettings) { [weak self] generateConfigResult in
+                dnsSettings: self.settings.dnsSettings,
+                endpointPortOverride: self.settings.endpointPortOverride) { [weak self] generateConfigResult in
                 try await self?.onFailureRecoveryConfigUpdate(generateConfigResult)
             }
         }

--- a/SharedPackages/VPN/Sources/VPN/NetworkProtectionDeviceManager.swift
+++ b/SharedPackages/VPN/Sources/VPN/NetworkProtectionDeviceManager.swift
@@ -19,6 +19,7 @@
 import Foundation
 import Common
 import FoundationExtensions
+import Network
 import NetworkExtension
 import os.log
 import Subscription
@@ -70,6 +71,7 @@ public protocol NetworkProtectionDeviceManagement {
                                      excludeLocalNetworks: Bool,
                                      excludeCGNAT: Bool,
                                      dnsSettings: NetworkProtectionDNSSettings,
+                                     endpointPortOverride: UInt16?,
                                      regenerateKey: Bool) async throws -> GenerateTunnelConfigurationResult
 
 }
@@ -144,6 +146,7 @@ public actor NetworkProtectionDeviceManager: NetworkProtectionDeviceManagement {
                                             excludeLocalNetworks: Bool,
                                             excludeCGNAT: Bool,
                                             dnsSettings: NetworkProtectionDNSSettings,
+                                            endpointPortOverride: UInt16?,
                                             regenerateKey: Bool) async throws -> GenerateTunnelConfigurationResult {
         Logger.networkProtection.debug("Generating tunnel configuration")
         var keyPair: KeyPair
@@ -184,7 +187,8 @@ public actor NetworkProtectionDeviceManager: NetworkProtectionDeviceManagement {
                                                         server: selectedServer,
                                                         excludeLocalNetworks: excludeLocalNetworks,
                                                         excludeCGNAT: excludeCGNAT,
-                                                        dnsSettings: dnsSettings)
+                                                        dnsSettings: dnsSettings,
+                                                        endpointPortOverride: endpointPortOverride)
             return (configuration, selectedServer)
         } catch let error as NetworkProtectionError {
             errorEvents?.fire(error)
@@ -308,7 +312,8 @@ public actor NetworkProtectionDeviceManager: NetworkProtectionDeviceManagement {
                              server: NetworkProtectionServer,
                              excludeLocalNetworks: Bool,
                              excludeCGNAT: Bool,
-                             dnsSettings: NetworkProtectionDNSSettings) throws -> TunnelConfiguration {
+                             dnsSettings: NetworkProtectionDNSSettings,
+                             endpointPortOverride: UInt16? = nil) throws -> TunnelConfiguration {
 
         guard let allowedIPs = server.allowedIPs else {
             throw NetworkProtectionError.noServerRegistrationInfo
@@ -322,7 +327,15 @@ public actor NetworkProtectionDeviceManager: NetworkProtectionDeviceManagement {
             throw NetworkProtectionError.couldNotGetPeerHostName
         }
 
-        let peerConfiguration = peerConfiguration(serverPublicKey: serverPublicKey, serverEndpoint: serverEndpoint)
+        let effectiveEndpoint: Endpoint
+        if let endpointPortOverride {
+            effectiveEndpoint = Endpoint(host: serverEndpoint.host, port: NWEndpoint.Port(integerLiteral: endpointPortOverride))
+            Logger.networkProtection.log("Overriding endpoint port \(String(describing: serverEndpoint.port), privacy: .public) with \(endpointPortOverride, privacy: .public)")
+        } else {
+            effectiveEndpoint = serverEndpoint
+        }
+
+        let peerConfiguration = peerConfiguration(serverPublicKey: serverPublicKey, serverEndpoint: effectiveEndpoint)
 
         guard let closestIP = allowedIPs.first, let interfaceAddressRange = IPAddressRange(from: closestIP) else {
             throw NetworkProtectionError.couldNotGetInterfaceAddressRange

--- a/SharedPackages/VPN/Sources/VPN/PacketTunnelProvider.swift
+++ b/SharedPackages/VPN/Sources/VPN/PacketTunnelProvider.swift
@@ -1222,7 +1222,7 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
                 excludeLocalNetworks: settings.excludeLocalNetworks,
                 excludeCGNAT: settings.excludeCGNAT,
                 dnsSettings: dnsSettings,
-                endpointPortOverride: settings.endpointPortOverride,
+                endpointPortOverride: settings.endpointPortOverride ?? VPNSettings.defaultEndpointPortOverride,
                 regenerateKey: regenerateKey
             )
         } catch {

--- a/SharedPackages/VPN/Sources/VPN/PacketTunnelProvider.swift
+++ b/SharedPackages/VPN/Sources/VPN/PacketTunnelProvider.swift
@@ -1222,6 +1222,7 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
                 excludeLocalNetworks: settings.excludeLocalNetworks,
                 excludeCGNAT: settings.excludeCGNAT,
                 dnsSettings: dnsSettings,
+                endpointPortOverride: settings.endpointPortOverride,
                 regenerateKey: regenerateKey
             )
         } catch {
@@ -1291,6 +1292,10 @@ open class PacketTunnelProvider: NEPacketTunnelProvider {
                     updateMethod: .selectServer(serverSelectionMethod),
                     reassert: true,
                     attemptSource: .locationChange)
+            }
+        case .setEndpointPortOverride:
+            if case .connected = connectionStatus {
+                try? await handleRestartAdapter()
             }
         case .setConnectOnLogin,
                 .setDNSSettings,

--- a/SharedPackages/VPN/Sources/VPN/Recovery/FailureRecoveryHandler.swift
+++ b/SharedPackages/VPN/Sources/VPN/Recovery/FailureRecoveryHandler.swift
@@ -39,6 +39,7 @@ public protocol FailureRecoveryHandling {
         excludeLocalNetworks: Bool,
         excludeCGNAT: Bool,
         dnsSettings: NetworkProtectionDNSSettings,
+        endpointPortOverride: UInt16?,
         updateConfig: @escaping (NetworkProtectionDeviceManagement.GenerateTunnelConfigurationResult) async throws -> Void
     ) async
 
@@ -89,6 +90,7 @@ actor FailureRecoveryHandler: FailureRecoveryHandling {
         excludeLocalNetworks: Bool,
         excludeCGNAT: Bool = false,
         dnsSettings: NetworkProtectionDNSSettings,
+        endpointPortOverride: UInt16? = nil,
         updateConfig: @escaping (NetworkProtectionDeviceManagement.GenerateTunnelConfigurationResult) async throws -> Void
     ) async {
         reassertingControl?.startReasserting()
@@ -104,7 +106,8 @@ actor FailureRecoveryHandler: FailureRecoveryHandling {
                     to: lastConnectedServer,
                     excludeLocalNetworks: excludeLocalNetworks,
                     excludeCGNAT: excludeCGNAT,
-                    dnsSettings: dnsSettings)
+                    dnsSettings: dnsSettings,
+                    endpointPortOverride: endpointPortOverride)
                 try Task.checkCancellation()
                 switch result {
                 case .noRecoveryNecessary:
@@ -133,7 +136,8 @@ actor FailureRecoveryHandler: FailureRecoveryHandling {
         to lastConnectedServer: NetworkProtectionServer,
         excludeLocalNetworks: Bool,
         excludeCGNAT: Bool,
-        dnsSettings: NetworkProtectionDNSSettings) async throws -> FailureRecoveryResult {
+        dnsSettings: NetworkProtectionDNSSettings,
+        endpointPortOverride: UInt16?) async throws -> FailureRecoveryResult {
 
         let serverSelectionMethod: NetworkProtectionServerSelectionMethod = .failureRecovery(serverName: lastConnectedServer.serverName)
         let configurationResult: NetworkProtectionDeviceManagement.GenerateTunnelConfigurationResult
@@ -143,6 +147,7 @@ actor FailureRecoveryHandler: FailureRecoveryHandling {
             excludeLocalNetworks: excludeLocalNetworks,
             excludeCGNAT: excludeCGNAT,
             dnsSettings: dnsSettings,
+            endpointPortOverride: endpointPortOverride,
             regenerateKey: false
         )
         Logger.networkProtectionTunnelFailureMonitor.log("🟢 Failure recovery fetched new config.")

--- a/SharedPackages/VPN/Sources/VPN/Settings/Extensions/UserDefaults+endpointPortOverride.swift
+++ b/SharedPackages/VPN/Sources/VPN/Settings/Extensions/UserDefaults+endpointPortOverride.swift
@@ -1,0 +1,71 @@
+//
+//  UserDefaults+endpointPortOverride.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Combine
+import Foundation
+
+extension UserDefaults {
+    private var endpointPortOverrideKey: String {
+        "networkProtectionSettingEndpointPortOverrideRawValue"
+    }
+
+    @objc
+    dynamic var networkProtectionSettingEndpointPortOverrideRawValue: NSNumber? {
+        get {
+            value(forKey: endpointPortOverrideKey) as? NSNumber
+        }
+
+        set {
+            set(newValue, forKey: endpointPortOverrideKey)
+        }
+    }
+
+    private func endpointPortOverrideFromRawValue(_ rawValue: NSNumber?) -> UInt16? {
+        guard let intValue = rawValue?.intValue, (1...65535).contains(intValue) else {
+            return nil
+        }
+
+        return UInt16(intValue)
+    }
+
+    var networkProtectionSettingEndpointPortOverride: UInt16? {
+        get {
+            endpointPortOverrideFromRawValue(networkProtectionSettingEndpointPortOverrideRawValue)
+        }
+
+        set {
+            if let newValue {
+                networkProtectionSettingEndpointPortOverrideRawValue = NSNumber(value: newValue)
+            } else {
+                networkProtectionSettingEndpointPortOverrideRawValue = nil
+            }
+        }
+    }
+
+    var networkProtectionSettingEndpointPortOverridePublisher: AnyPublisher<UInt16?, Never> {
+        let endpointPortOverrideFromRawValue = self.endpointPortOverrideFromRawValue
+
+        return publisher(for: \.networkProtectionSettingEndpointPortOverrideRawValue).map { rawValue in
+            endpointPortOverrideFromRawValue(rawValue)
+        }.eraseToAnyPublisher()
+    }
+
+    func resetNetworkProtectionSettingEndpointPortOverride() {
+        networkProtectionSettingEndpointPortOverrideRawValue = nil
+    }
+}

--- a/SharedPackages/VPN/Sources/VPN/Settings/VPNSettings.swift
+++ b/SharedPackages/VPN/Sources/VPN/Settings/VPNSettings.swift
@@ -597,6 +597,9 @@ public final class VPNSettings {
 
     // MARK: - Endpoint Port Override
 
+    /// PoC: the endpoint port used when no override has been chosen. Replaces the server-provided port.
+    public static let defaultEndpointPortOverride: UInt16 = 51820
+
     public var endpointPortOverridePublisher: AnyPublisher<UInt16?, Never> {
         defaults.networkProtectionSettingEndpointPortOverridePublisher
     }

--- a/SharedPackages/VPN/Sources/VPN/Settings/VPNSettings.swift
+++ b/SharedPackages/VPN/Sources/VPN/Settings/VPNSettings.swift
@@ -45,6 +45,7 @@ public final class VPNSettings {
         case setDNSSettings(_ dnsSettings: NetworkProtectionDNSSettings)
         case setShowInMenuBar(_ showInMenuBar: Bool)
         case setDisableRekeying(_ disableRekeying: Bool)
+        case setEndpointPortOverride(_ port: UInt16?)
     }
 
     public enum RegistrationKeyValidity: Codable, Equatable {
@@ -215,6 +216,13 @@ public final class VPNSettings {
                 Change.setDisableRekeying(disableRekeying)
             }.eraseToAnyPublisher()
 
+        let endpointPortOverridePublisher = endpointPortOverridePublisher
+            .dropFirst()
+            .removeDuplicates()
+            .map { endpointPortOverride in
+                Change.setEndpointPortOverride(endpointPortOverride)
+            }.eraseToAnyPublisher()
+
         return Publishers.MergeMany(
             connectOnLoginPublisher,
             includeAllNetworksPublisher,
@@ -230,7 +238,8 @@ public final class VPNSettings {
             environmentChangePublisher,
             dnsSettingsChangePublisher,
             showInMenuBarPublisher,
-            disableRekeyingPublisher).eraseToAnyPublisher()
+            disableRekeyingPublisher,
+            endpointPortOverridePublisher).eraseToAnyPublisher()
     }()
 
     public init(defaults: UserDefaults) {
@@ -253,6 +262,7 @@ public final class VPNSettings {
         defaults.resetDNSSettings()
         defaults.resetNetworkProtectionSettingShowInMenuBar()
         defaults.resetVPNSettingEnforceRoutes()
+        defaults.resetNetworkProtectionSettingEndpointPortOverride()
     }
 
     public func resetTunnelFlagsToDefaults() {
@@ -301,6 +311,8 @@ public final class VPNSettings {
             self.showInMenuBar = showInMenuBar
         case .setDisableRekeying(let disableRekeying):
             self.disableRekeying = disableRekeying
+        case .setEndpointPortOverride(let port):
+            self.endpointPortOverride = port
         }
     }
 
@@ -580,6 +592,22 @@ public final class VPNSettings {
 
         set {
             defaults.networkProtectionSettingDisableRekeying = newValue
+        }
+    }
+
+    // MARK: - Endpoint Port Override
+
+    public var endpointPortOverridePublisher: AnyPublisher<UInt16?, Never> {
+        defaults.networkProtectionSettingEndpointPortOverridePublisher
+    }
+
+    public var endpointPortOverride: UInt16? {
+        get {
+            defaults.networkProtectionSettingEndpointPortOverride
+        }
+
+        set {
+            defaults.networkProtectionSettingEndpointPortOverride = newValue
         }
     }
 

--- a/SharedPackages/VPN/Sources/VPN/StartupOptions.swift
+++ b/SharedPackages/VPN/Sources/VPN/StartupOptions.swift
@@ -33,6 +33,7 @@ public struct VPNSettingsSnapshot: Codable, Equatable {
     let excludeLocalNetworks: Bool
     let excludeCGNAT: Bool
     let enforceRoutes: Bool
+    let endpointPortOverride: UInt16?
 
     enum CodingKeys: String, CodingKey {
         case registrationKeyValidity
@@ -43,6 +44,7 @@ public struct VPNSettingsSnapshot: Codable, Equatable {
         case excludeLocalNetworks
         case excludeCGNAT
         case enforceRoutes
+        case endpointPortOverride
     }
 
     /// Create a snapshot of the current VPN settings
@@ -55,6 +57,7 @@ public struct VPNSettingsSnapshot: Codable, Equatable {
         self.excludeLocalNetworks = settings.excludeLocalNetworks
         self.excludeCGNAT = settings.excludeCGNAT
         self.enforceRoutes = settings.enforceRoutes
+        self.endpointPortOverride = settings.endpointPortOverride
     }
 
     /// Create a snapshot with explicit values
@@ -65,7 +68,8 @@ public struct VPNSettingsSnapshot: Codable, Equatable {
                 dnsSettings: NetworkProtectionDNSSettings,
                 excludeLocalNetworks: Bool,
                 excludeCGNAT: Bool = UserDefaults.excludeCGNATDefaultValue,
-                enforceRoutes: Bool = UserDefaults.enforceRoutesDefaultValue) {
+                enforceRoutes: Bool = UserDefaults.enforceRoutesDefaultValue,
+                endpointPortOverride: UInt16? = nil) {
         self.registrationKeyValidity = registrationKeyValidity
         self.selectedEnvironment = selectedEnvironment
         self.selectedServer = selectedServer
@@ -74,6 +78,7 @@ public struct VPNSettingsSnapshot: Codable, Equatable {
         self.excludeLocalNetworks = excludeLocalNetworks
         self.excludeCGNAT = excludeCGNAT
         self.enforceRoutes = enforceRoutes
+        self.endpointPortOverride = endpointPortOverride
     }
 
     /// Custom decoding so snapshots persisted by older versions still decode, falling back to default
@@ -88,6 +93,7 @@ public struct VPNSettingsSnapshot: Codable, Equatable {
         excludeLocalNetworks = try container.decode(Bool.self, forKey: .excludeLocalNetworks)
         excludeCGNAT = try container.decodeIfPresent(Bool.self, forKey: .excludeCGNAT) ?? UserDefaults.excludeCGNATDefaultValue
         enforceRoutes = try container.decodeIfPresent(Bool.self, forKey: .enforceRoutes) ?? UserDefaults.enforceRoutesDefaultValue
+        endpointPortOverride = try container.decodeIfPresent(UInt16.self, forKey: .endpointPortOverride)
     }
 
     /// Apply these settings to a VPNSettings instance
@@ -100,6 +106,7 @@ public struct VPNSettingsSnapshot: Codable, Equatable {
         settings.excludeLocalNetworks = excludeLocalNetworks
         settings.excludeCGNAT = excludeCGNAT
         settings.enforceRoutes = enforceRoutes
+        settings.endpointPortOverride = endpointPortOverride
     }
 }
 

--- a/SharedPackages/VPN/Sources/VPNTestUtils/MockNetworkProtectionDeviceManagement.swift
+++ b/SharedPackages/VPN/Sources/VPNTestUtils/MockNetworkProtectionDeviceManagement.swift
@@ -30,6 +30,7 @@ public final class MockNetworkProtectionDeviceManagement: NetworkProtectionDevic
         public let excludeLocalNetworks: Bool
         public let excludeCGNAT: Bool
         public let dnsSettings: NetworkProtectionDNSSettings
+        public let endpointPortOverride: UInt16?
         public let regenerateKey: Bool
     }
 
@@ -49,12 +50,14 @@ public final class MockNetworkProtectionDeviceManagement: NetworkProtectionDevic
         excludeLocalNetworks: Bool,
         excludeCGNAT: Bool = false,
         dnsSettings: NetworkProtectionDNSSettings,
+        endpointPortOverride: UInt16? = nil,
         regenerateKey: Bool) async throws -> (tunnelConfiguration: VPN.TunnelConfiguration, server: VPN.NetworkProtectionServer) {
             spyGenerateTunnelConfiguration = GenerateTunnelConfigurationCall(
                 selectionMethod: resolvedSelectionMethod,
                 excludeLocalNetworks: excludeLocalNetworks,
                 excludeCGNAT: excludeCGNAT,
                 dnsSettings: dnsSettings,
+                endpointPortOverride: endpointPortOverride,
                 regenerateKey: regenerateKey
             )
             if let stubGenerateTunnelConfiguration {

--- a/SharedPackages/VPN/Tests/VPNTests/Monitoring/TunnelMonitorsTests.swift
+++ b/SharedPackages/VPN/Tests/VPNTests/Monitoring/TunnelMonitorsTests.swift
@@ -327,6 +327,7 @@ final class TunnelMonitorsTests: XCTestCase {
 
         XCTAssertEqual(failureRecoveryHandler.attemptCount, 1)
         XCTAssertEqual(failureRecoveryHandler.lastExcludeLocalNetworks, false)
+        XCTAssertNil(failureRecoveryHandler.lastEndpointPortOverride)
     }
 
     func testTunnelFailureCallback_failureDetected_appliesRecoveryConfig() async throws {
@@ -671,6 +672,7 @@ private final class MockFailureRecoveryHandler: FailureRecoveryHandling, @unchec
     var lastExcludeLocalNetworks: Bool?
     var lastExcludeCGNAT: Bool?
     var lastDNSSettings: NetworkProtectionDNSSettings?
+    var lastEndpointPortOverride: UInt16?
     var configResultToUpdate: NetworkProtectionDeviceManagement.GenerateTunnelConfigurationResult?
     var afterSuccessfulConfigUpdate: (@MainActor () -> Void)?
 
@@ -679,6 +681,7 @@ private final class MockFailureRecoveryHandler: FailureRecoveryHandling, @unchec
         excludeLocalNetworks: Bool,
         excludeCGNAT: Bool,
         dnsSettings: NetworkProtectionDNSSettings,
+        endpointPortOverride: UInt16?,
         updateConfig: @escaping (NetworkProtectionDeviceManagement.GenerateTunnelConfigurationResult) async throws -> Void
     ) async {
         attemptCount += 1
@@ -686,6 +689,7 @@ private final class MockFailureRecoveryHandler: FailureRecoveryHandling, @unchec
         lastExcludeLocalNetworks = excludeLocalNetworks
         lastExcludeCGNAT = excludeCGNAT
         lastDNSSettings = dnsSettings
+        lastEndpointPortOverride = endpointPortOverride
 
         if let configResultToUpdate {
             do {

--- a/SharedPackages/VPN/Tests/VPNTests/NetworkProtectionDeviceManagerTests.swift
+++ b/SharedPackages/VPN/Tests/VPNTests/NetworkProtectionDeviceManagerTests.swift
@@ -224,6 +224,50 @@ final class NetworkProtectionDeviceManagerTests: XCTestCase {
         // THEN
         XCTAssertEqual(configuration.0.interface.dns.first?.address.rawValue, expectedIPAddress.rawValue)
     }
+
+    func testTunnelConfiguration_WithEndpointPortOverride_UsesOverridePortAndKeepsHost() async throws {
+        // GIVEN
+        let server = NetworkProtectionServer.mockRegisteredServer
+        let serverEndpoint = try XCTUnwrap(server.serverInfo.endpoint)
+        let privateKey = keyStore.newKeyPair().privateKey
+
+        // WHEN
+        let tunnelConfiguration = try await manager.tunnelConfiguration(
+            interfacePrivateKey: privateKey,
+            server: server,
+            excludeLocalNetworks: false,
+            excludeCGNAT: false,
+            dnsSettings: .ddg(blockRiskyDomains: false),
+            endpointPortOverride: 51820
+        )
+
+        // THEN
+        let peerEndpoint = try XCTUnwrap(tunnelConfiguration.peers.first?.endpoint)
+        XCTAssertEqual(peerEndpoint.port, 51820)
+        XCTAssertEqual(peerEndpoint.host, serverEndpoint.host)
+    }
+
+    func testTunnelConfiguration_WithoutEndpointPortOverride_UsesServerPort() async throws {
+        // GIVEN
+        let server = NetworkProtectionServer.mockRegisteredServer
+        let serverEndpoint = try XCTUnwrap(server.serverInfo.endpoint)
+        let privateKey = keyStore.newKeyPair().privateKey
+
+        // WHEN
+        let tunnelConfiguration = try await manager.tunnelConfiguration(
+            interfacePrivateKey: privateKey,
+            server: server,
+            excludeLocalNetworks: false,
+            excludeCGNAT: false,
+            dnsSettings: .ddg(blockRiskyDomains: false),
+            endpointPortOverride: nil
+        )
+
+        // THEN
+        let peerEndpoint = try XCTUnwrap(tunnelConfiguration.peers.first?.endpoint)
+        XCTAssertEqual(peerEndpoint.port, serverEndpoint.port)
+        XCTAssertEqual(peerEndpoint.host, serverEndpoint.host)
+    }
 }
 
 extension NetworkProtectionDeviceManager {
@@ -235,6 +279,7 @@ extension NetworkProtectionDeviceManager {
             excludeLocalNetworks: false,
             excludeCGNAT: false,
             dnsSettings: .ddg(blockRiskyDomains: protectionActive),
+            endpointPortOverride: nil,
             regenerateKey: regenerateKey
         )
     }

--- a/SharedPackages/VPN/Tests/VPNTests/Recovery/FailureRecoveryHandlerTests.swift
+++ b/SharedPackages/VPN/Tests/VPNTests/Recovery/FailureRecoveryHandlerTests.swift
@@ -435,6 +435,7 @@ private final class DeviceManagementSpy: NetworkProtectionDeviceManagement {
         excludeLocalNetworks: Bool,
         excludeCGNAT: Bool,
         dnsSettings: NetworkProtectionDNSSettings,
+        endpointPortOverride: UInt16?,
         regenerateKey: Bool
     ) async throws -> NetworkProtectionDeviceManagement.GenerateTunnelConfigurationResult {
         await beforeReturningResult?()

--- a/SharedPackages/VPN/Tests/VPNTests/Settings/VPNSettingsEndpointPortOverrideTests.swift
+++ b/SharedPackages/VPN/Tests/VPNTests/Settings/VPNSettingsEndpointPortOverrideTests.swift
@@ -1,0 +1,118 @@
+//
+//  VPNSettingsEndpointPortOverrideTests.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Combine
+import Foundation
+import XCTest
+@testable import VPN
+
+final class VPNSettingsEndpointPortOverrideTests: XCTestCase {
+
+    private var suiteName: String!
+    private var defaults: UserDefaults!
+    private var settings: VPNSettings!
+    private var cancellables: Set<AnyCancellable>!
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "test-\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)!
+        settings = VPNSettings(defaults: defaults)
+        cancellables = []
+    }
+
+    override func tearDown() {
+        cancellables = nil
+        defaults.removePersistentDomain(forName: suiteName)
+        settings = nil
+        defaults = nil
+        suiteName = nil
+        super.tearDown()
+    }
+
+    func testDefaultsToNilWhenUserHasNotChosen() {
+        XCTAssertNil(settings.endpointPortOverride, "The endpoint port override must default to nil when the user hasn't chosen a value")
+    }
+
+    func testSettingValuePersists() {
+        settings.endpointPortOverride = 51820
+
+        XCTAssertEqual(settings.endpointPortOverride, 51820)
+    }
+
+    func testPublisherEmitsWhenValueChanges() {
+        let expectation = expectation(description: "publisher emits the updated value")
+        var received: UInt16??
+
+        settings.endpointPortOverridePublisher
+            .dropFirst() // Ignore the value emitted on subscription.
+            .sink { value in
+                received = value
+                expectation.fulfill()
+            }
+            .store(in: &cancellables)
+
+        settings.endpointPortOverride = 51820
+
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertEqual(received, 51820)
+    }
+
+    func testChangePublisherEmitsSetEndpointPortOverride() {
+        let expectation = expectation(description: "changePublisher emits the endpoint port override change")
+        var received: VPNSettings.Change?
+
+        settings.changePublisher
+            .sink { change in
+                guard case .setEndpointPortOverride = change else { return }
+                received = change
+                expectation.fulfill()
+            }
+            .store(in: &cancellables)
+
+        settings.endpointPortOverride = 51820
+
+        wait(for: [expectation], timeout: 1.0)
+        guard case .setEndpointPortOverride(let port)? = received else {
+            return XCTFail("Expected .setEndpointPortOverride, got \(String(describing: received))")
+        }
+        XCTAssertEqual(port, 51820)
+    }
+
+    func testApplyingChangeUpdatesValue() {
+        settings.apply(change: .setEndpointPortOverride(51820))
+
+        XCTAssertEqual(settings.endpointPortOverride, 51820)
+    }
+
+    func testApplyingChangeWithNilClearsValue() {
+        settings.endpointPortOverride = 51820
+
+        settings.apply(change: .setEndpointPortOverride(nil))
+
+        XCTAssertNil(settings.endpointPortOverride)
+    }
+
+    func testResetToDefaultsClearsValue() {
+        settings.endpointPortOverride = 51820
+
+        settings.resetToDefaults()
+
+        XCTAssertNil(settings.endpointPortOverride)
+    }
+}

--- a/SharedPackages/VPN/Tests/VPNTests/StartupOptionTests.swift
+++ b/SharedPackages/VPN/Tests/VPNTests/StartupOptionTests.swift
@@ -219,6 +219,43 @@ final class StartupOptionsTests: XCTestCase {
         XCTAssertFalse(other.enforceRoutes)
     }
 
+    func testVPNSettingsSnapshotRoundTripsEndpointPortOverride() throws {
+        let snapshot = VPNSettingsSnapshot(
+            registrationKeyValidity: .custom(3600),
+            selectedEnvironment: .production,
+            selectedServer: .automatic,
+            selectedLocation: .nearest,
+            dnsSettings: .ddg(blockRiskyDomains: true),
+            excludeLocalNetworks: false,
+            endpointPortOverride: 51820
+        )
+
+        let decoded = try JSONDecoder().decode(VPNSettingsSnapshot.self, from: JSONEncoder().encode(snapshot))
+
+        XCTAssertEqual(decoded.endpointPortOverride, 51820)
+    }
+
+    func testVPNSettingsSnapshotDefaultsEndpointPortOverrideToNilWhenMissingFromPayload() throws {
+        // Simulate a snapshot persisted by an older version that predates carrying the override.
+        let snapshot = VPNSettingsSnapshot(
+            registrationKeyValidity: .custom(3600),
+            selectedEnvironment: .production,
+            selectedServer: .automatic,
+            selectedLocation: .nearest,
+            dnsSettings: .ddg(blockRiskyDomains: true),
+            excludeLocalNetworks: false,
+            endpointPortOverride: 51820
+        )
+        let encoded = try JSONEncoder().encode(snapshot)
+        var json = try XCTUnwrap(JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+        json.removeValue(forKey: "endpointPortOverride")
+        let legacyData = try JSONSerialization.data(withJSONObject: json)
+
+        let decoded = try JSONDecoder().decode(VPNSettingsSnapshot.self, from: legacyData)
+
+        XCTAssertNil(decoded.endpointPortOverride)
+    }
+
     func testCorruptedVPNSettingsResultInResetOption() {
         let corruptedData = "invalid json data".data(using: .utf8)!
 

--- a/iOS/DuckDuckGo/NetworkProtectionTunnelController.swift
+++ b/iOS/DuckDuckGo/NetworkProtectionTunnelController.swift
@@ -551,7 +551,8 @@ final class NetworkProtectionTunnelController: VPNConnectionContextProvidingTunn
                 .setSelectedLocation,
                 .setDNSSettings,
                 .setShowInMenuBar,
-                .setDisableRekeying:
+                .setDisableRekeying,
+                .setEndpointPortOverride:
             // Intentional no-op as this is handled by the extension or applied on the next connect
             break
         }

--- a/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/NetworkProtectionDebugMenu.swift
+++ b/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/NetworkProtectionDebugMenu.swift
@@ -45,6 +45,10 @@ final class NetworkProtectionDebugMenu: NSMenu {
     private let registrationKeyValidityMenu: NSMenu
     private let registrationKeyValidityAutomaticItem = NSMenuItem(title: "Automatic", action: #selector(NetworkProtectionDebugMenu.setRegistrationKeyValidity))
 
+    private let wireGuardPortMenu = NSMenu()
+    private let wireGuardPortServerDefaultItem = NSMenuItem(title: "Server Default", action: #selector(NetworkProtectionDebugMenu.setWireGuardPortOverride))
+    private let wireGuardPortCustomItem = NSMenuItem(title: "Custom…", action: #selector(NetworkProtectionDebugMenu.setCustomWireGuardPortOverride))
+
     private let resetToDefaults = NSMenuItem(title: "Reset Settings to defaults", action: #selector(NetworkProtectionDebugMenu.resetSettings))
 
     private let excludeDDGBrowserTrafficFromVPN = NSMenuItem(title: "DDG Browser", action: #selector(toggleExcludeDDGBrowser))
@@ -186,6 +190,9 @@ final class NetworkProtectionDebugMenu: NSMenu {
                 disableRekeyingMenuItem
                     .targetting(self)
 
+                NSMenuItem.separator()
+                NSMenuItem(title: "WireGuard Port").submenu(wireGuardPortMenu)
+
 #if DEBUG
                 NSMenuItem.separator()
                 NSMenuItem(title: "Validity").submenu(registrationKeyValidityMenu)
@@ -214,6 +221,7 @@ final class NetworkProtectionDebugMenu: NSMenu {
             try? await populateNetworkProtectionServerListMenuItems()
         }
         populateNetworkProtectionRegistrationKeyValidityMenuItems()
+        populateWireGuardPortMenuItems()
     }
 
     required init(coder: NSCoder) {
@@ -415,6 +423,45 @@ final class NetworkProtectionDebugMenu: NSMenu {
         settings.registrationKeyValidity = .custom(timeInterval)
     }
 
+    /// Sets the WireGuard endpoint port override to "Server Default" or one of the presets.
+    ///
+    @objc func setWireGuardPortOverride(_ menuItem: NSMenuItem) {
+        settings.endpointPortOverride = menuItem.representedObject as? UInt16
+    }
+
+    /// Prompts for a custom WireGuard endpoint port override.
+    ///
+    @objc func setCustomWireGuardPortOverride(_ sender: Any?) {
+        Task { @MainActor in
+            let alert = NSAlert()
+            alert.messageText = "Custom WireGuard Port"
+            alert.informativeText = "Enter a UDP port number (1-65535)."
+            alert.addButton(withTitle: "Set")
+            alert.addButton(withTitle: "Cancel")
+
+            let textField = NSTextField(frame: NSRect(x: 0, y: 0, width: 200, height: 24))
+            if let currentPort = settings.endpointPortOverride {
+                textField.stringValue = String(currentPort)
+            }
+            alert.accessoryView = textField
+
+            guard await alert.runModal() == .alertFirstButtonReturn else { return }
+
+            let text = textField.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+
+            guard let port = UInt16(text), (1...65535).contains(port) else {
+                let errorAlert = NSAlert()
+                errorAlert.messageText = "Invalid Port"
+                errorAlert.informativeText = "Please enter a number between 1 and 65535."
+                errorAlert.addButton(withTitle: "OK")
+                await errorAlert.runModal()
+                return
+            }
+
+            settings.endpointPortOverride = port
+        }
+    }
+
     @objc func toggleEnforceRoutesAction(_ sender: Any?) {
         settings.enforceRoutes.toggle()
 
@@ -574,6 +621,27 @@ final class NetworkProtectionDebugMenu: NSMenu {
 #endif
     }
 
+    private static let wireGuardPortPresets: [UInt16] = [443, 51820]
+
+    private func populateWireGuardPortMenuItems() {
+        wireGuardPortServerDefaultItem.target = self
+        wireGuardPortCustomItem.target = self
+
+        let presetItems = Self.wireGuardPortPresets.map { port in
+            let menuItem = NSMenuItem(title: "\(port)",
+                                      action: #selector(setWireGuardPortOverride(_:)),
+                                      target: self,
+                                      keyEquivalent: "")
+
+            menuItem.representedObject = port
+            return menuItem
+        }
+
+        wireGuardPortMenu.items = [wireGuardPortServerDefaultItem, NSMenuItem.separator()]
+            + presetItems
+            + [NSMenuItem.separator(), wireGuardPortCustomItem]
+    }
+
     func menuItem(title: String, action: Selector, representedObject: Any?) -> NSMenuItem {
         let menuItem = NSMenuItem(title: title, action: action, keyEquivalent: "")
         menuItem.target = self
@@ -588,6 +656,7 @@ final class NetworkProtectionDebugMenu: NSMenu {
         updateExclusionsMenu()
         updatePreferredServerMenu()
         updateRekeyValidityMenu()
+        updateWireGuardPortMenu()
         updateNetworkProtectionMenuItemsState()
         updateUpsellMenuToggleTitle()
     }
@@ -641,6 +710,35 @@ final class NetworkProtectionDebugMenu: NSMenu {
                     item.state = .off
                 }
             }
+        }
+    }
+
+    private func updateWireGuardPortMenu() {
+        let currentPort = settings.endpointPortOverride
+        var matchedPreset = false
+
+        for item in wireGuardPortMenu.items {
+            if item === wireGuardPortServerDefaultItem {
+                item.state = currentPort == nil ? .on : .off
+                continue
+            }
+
+            guard let presetPort = item.representedObject as? UInt16 else { continue }
+
+            if presetPort == currentPort {
+                item.state = .on
+                matchedPreset = true
+            } else {
+                item.state = .off
+            }
+        }
+
+        if let currentPort, !matchedPreset {
+            wireGuardPortCustomItem.state = .on
+            wireGuardPortCustomItem.title = "Custom… (\(currentPort))"
+        } else {
+            wireGuardPortCustomItem.state = .off
+            wireGuardPortCustomItem.title = "Custom…"
         }
     }
 

--- a/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/NetworkProtectionTunnelController.swift
+++ b/macOS/DuckDuckGo/NetworkProtection/AppTargets/BothAppTargets/NetworkProtectionTunnelController.swift
@@ -296,7 +296,8 @@ final class NetworkProtectionTunnelController: TunnelController, TunnelSessionPr
                 .setSelectedLocation,
                 .setDNSSettings,
                 .setShowInMenuBar,
-                .setDisableRekeying:
+                .setDisableRekeying,
+                .setEndpointPortOverride:
             // Intentional no-op as this is handled by the extension or the agent's app delegate
             break
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1218147754476618?focus=true

### Description
Proof of concept: a debug-menu override for the VPN endpoint UDP port,
so we can test whether an alternate port gets through on networks that
drop WireGuard traffic to the default one. Unset means the server's
port is used and nothing changes.

### Testing Steps
TBD

### Impact
Low. Debug menu only, defaults to off.

#### What could go wrong?
An internal user could set a port the server does not accept and forget
about it → "Server Default" and "Reset Settings to defaults" both clear
it, and the extension logs the override on every connection.

### Quality Considerations
With the override unset, tunnel configuration is unchanged. Tests cover
the setting's default, persistence, change publication, snapshot
encoding with and without the key, and the endpoint port substitution.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)
