### PR TITLE
Reactivate deprecated PIR profile queries

### DIFF
--- a/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/SecureVaultStorage/DataBrokerProtectionDatabase.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/SecureVaultStorage/DataBrokerProtectionDatabase.swift
@@ -703,13 +703,11 @@ extension DataBrokerProtectionDatabase {
 
         let databaseBrokerProfileQueryData = try fetchActiveBrokerProfileQueryData()
         let databaseProfileQueries = databaseBrokerProfileQueryData.map { $0.profileQuery }
-        let activeDatabaseProfileQueries = Set(databaseProfileQueries.filter { !$0.deprecated })
 
         // The queries we need to create are the one that exist on the new ones but not in the database
         let profileQueriesToCreate = Set(newProfileQueries).subtracting(Set(databaseProfileQueries))
 
         let profileQueriesToReactivate = Set(databaseProfileQueries.filter(\.deprecated))
-            .subtracting(activeDatabaseProfileQueries)
             .intersection(Set(newProfileQueries))
             .map { $0.with(deprecated: false) }
 

--- a/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/SecureVaultStorage/DataBrokerProtectionDatabase.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/SecureVaultStorage/DataBrokerProtectionDatabase.swift
@@ -795,13 +795,8 @@ extension DataBrokerProtectionDatabase {
                                                   profileId: profileID)
 
             if !profile.deprecated {
-                let preferredRunDate = Date()
-                for brokerID in brokerIDs {
-                    if try vault.fetchScan(brokerId: brokerID, profileQueryId: profileQueryID) != nil {
-                        try vault.updatePreferredRunDate(preferredRunDate, brokerId: brokerID, profileQueryId: profileQueryID)
-                    } else {
-                        try vault.save(brokerId: brokerID, profileQueryId: profileQueryID, lastRunDate: nil, preferredRunDate: preferredRunDate)
-                    }
+                for brokerID in brokerIDs where !profile.deprecated {
+                    try updatePreferredRunDate(Date(), brokerId: brokerID, profileQueryId: profileQueryID)
                 }
             }
         }

--- a/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/SecureVaultStorage/DataBrokerProtectionDatabase.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/SecureVaultStorage/DataBrokerProtectionDatabase.swift
@@ -703,9 +703,15 @@ extension DataBrokerProtectionDatabase {
 
         let databaseBrokerProfileQueryData = try fetchActiveBrokerProfileQueryData()
         let databaseProfileQueries = databaseBrokerProfileQueryData.map { $0.profileQuery }
+        let activeDatabaseProfileQueries = Set(databaseProfileQueries.filter { !$0.deprecated })
 
         // The queries we need to create are the one that exist on the new ones but not in the database
         let profileQueriesToCreate = Set(newProfileQueries).subtracting(Set(databaseProfileQueries))
+
+        let profileQueriesToReactivate = Set(databaseProfileQueries.filter(\.deprecated))
+            .subtracting(activeDatabaseProfileQueries)
+            .intersection(Set(newProfileQueries))
+            .map { $0.with(deprecated: false) }
 
         // Updated profile queries. This is only for use for deprecated matches.
         // We do not use it for updating a particular profile query. The reason is that
@@ -752,6 +758,14 @@ extension DataBrokerProtectionDatabase {
                                      vault: vault)
         }
 
+        // Reactivate
+        if !profileQueriesToReactivate.isEmpty {
+            try updateProfileQueries(profileQueriesToReactivate,
+                                     profileID: profileID,
+                                     brokerIDs: brokerIDs,
+                                     vault: vault)
+        }
+
         // Create
         if !profileQueriesToCreate.isEmpty {
             try initializeDatabaseForProfile(
@@ -783,8 +797,13 @@ extension DataBrokerProtectionDatabase {
                                                   profileId: profileID)
 
             if !profile.deprecated {
-                for brokerID in brokerIDs where !profile.deprecated {
-                    try updatePreferredRunDate(Date(), brokerId: brokerID, profileQueryId: profileQueryID)
+                let preferredRunDate = Date()
+                for brokerID in brokerIDs {
+                    if try vault.fetchScan(brokerId: brokerID, profileQueryId: profileQueryID) != nil {
+                        try vault.updatePreferredRunDate(preferredRunDate, brokerId: brokerID, profileQueryId: profileQueryID)
+                    } else {
+                        try vault.save(brokerId: brokerID, profileQueryId: profileQueryID, lastRunDate: nil, preferredRunDate: preferredRunDate)
+                    }
                 }
             }
         }

--- a/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCoreTestsUtils/Mocks.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCoreTestsUtils/Mocks.swift
@@ -688,6 +688,10 @@ public final class DataBrokerProtectionSecureVaultMock: DataBrokerProtectionSecu
     public var brokers = [DataBroker]()
     public var scanJobData = [ScanJobData]()
     public var optOutJobData = [OptOutJobData]()
+    public var fetchScanHandler: ((Int64, Int64) -> ScanJobData?)?
+    public var updatedProfileQueries = [ProfileQuery]()
+    public var savedScanJobs = [(brokerId: Int64, profileQueryId: Int64, lastRunDate: Date?, preferredRunDate: Date?)]()
+    public var updatedScanPreferredRunDates = [(date: Date?, brokerId: Int64, profileQueryId: Int64)]()
     public var lastPreferredRunDateOnScan: Date?
     public var lastPreferredRunDateOnOptOut: Date?
     public var lastSavedBrokerResource: BrokerResource?
@@ -722,6 +726,10 @@ public final class DataBrokerProtectionSecureVaultMock: DataBrokerProtectionSecu
         brokers.removeAll()
         scanJobData.removeAll()
         optOutJobData.removeAll()
+        fetchScanHandler = nil
+        updatedProfileQueries.removeAll()
+        savedScanJobs.removeAll()
+        updatedScanPreferredRunDates.removeAll()
         lastPreferredRunDateOnScan = nil
         lastPreferredRunDateOnOptOut = nil
         lastSavedBrokerResource = nil
@@ -822,9 +830,11 @@ public final class DataBrokerProtectionSecureVaultMock: DataBrokerProtectionSecu
 
     public func save(brokerId: Int64, profileQueryId: Int64, lastRunDate: Date?, preferredRunDate: Date?) throws {
         lastPreferredRunDateOnScan = preferredRunDate
+        savedScanJobs.append((brokerId, profileQueryId, lastRunDate, preferredRunDate))
     }
 
     public func updatePreferredRunDate(_ date: Date?, brokerId: Int64, profileQueryId: Int64) throws {
+        updatedScanPreferredRunDates.append((date, brokerId, profileQueryId))
     }
 
     public func updateLastRunDate(_ date: Date?, brokerId: Int64, profileQueryId: Int64) throws {
@@ -848,7 +858,10 @@ public final class DataBrokerProtectionSecureVaultMock: DataBrokerProtectionSecu
     }
 
     public func fetchScan(brokerId: Int64, profileQueryId: Int64) throws -> ScanJobData? {
-        scanJobData.first
+        if let fetchScanHandler {
+            return fetchScanHandler(brokerId, profileQueryId)
+        }
+        return scanJobData.first
     }
 
     public func fetchAllScans() throws -> [ScanJobData] {
@@ -953,6 +966,7 @@ public final class DataBrokerProtectionSecureVaultMock: DataBrokerProtectionSecu
 
     public func update(_ profileQuery: ProfileQuery, brokerIDs: [Int64], profileId: Int64) throws -> Int64 {
         wasUpdateProfileQueryCalled = true
+        updatedProfileQueries.append(profileQuery)
         return 1
     }
 

--- a/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCoreTestsUtils/Mocks.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCoreTestsUtils/Mocks.swift
@@ -688,10 +688,7 @@ public final class DataBrokerProtectionSecureVaultMock: DataBrokerProtectionSecu
     public var brokers = [DataBroker]()
     public var scanJobData = [ScanJobData]()
     public var optOutJobData = [OptOutJobData]()
-    public var fetchScanHandler: ((Int64, Int64) -> ScanJobData?)?
     public var updatedProfileQueries = [ProfileQuery]()
-    public var savedScanJobs = [(brokerId: Int64, profileQueryId: Int64, lastRunDate: Date?, preferredRunDate: Date?)]()
-    public var updatedScanPreferredRunDates = [(date: Date?, brokerId: Int64, profileQueryId: Int64)]()
     public var lastPreferredRunDateOnScan: Date?
     public var lastPreferredRunDateOnOptOut: Date?
     public var lastSavedBrokerResource: BrokerResource?
@@ -726,10 +723,7 @@ public final class DataBrokerProtectionSecureVaultMock: DataBrokerProtectionSecu
         brokers.removeAll()
         scanJobData.removeAll()
         optOutJobData.removeAll()
-        fetchScanHandler = nil
         updatedProfileQueries.removeAll()
-        savedScanJobs.removeAll()
-        updatedScanPreferredRunDates.removeAll()
         lastPreferredRunDateOnScan = nil
         lastPreferredRunDateOnOptOut = nil
         lastSavedBrokerResource = nil
@@ -830,11 +824,9 @@ public final class DataBrokerProtectionSecureVaultMock: DataBrokerProtectionSecu
 
     public func save(brokerId: Int64, profileQueryId: Int64, lastRunDate: Date?, preferredRunDate: Date?) throws {
         lastPreferredRunDateOnScan = preferredRunDate
-        savedScanJobs.append((brokerId, profileQueryId, lastRunDate, preferredRunDate))
     }
 
     public func updatePreferredRunDate(_ date: Date?, brokerId: Int64, profileQueryId: Int64) throws {
-        updatedScanPreferredRunDates.append((date, brokerId, profileQueryId))
     }
 
     public func updateLastRunDate(_ date: Date?, brokerId: Int64, profileQueryId: Int64) throws {
@@ -858,10 +850,7 @@ public final class DataBrokerProtectionSecureVaultMock: DataBrokerProtectionSecu
     }
 
     public func fetchScan(brokerId: Int64, profileQueryId: Int64) throws -> ScanJobData? {
-        if let fetchScanHandler {
-            return fetchScanHandler(brokerId, profileQueryId)
-        }
-        return scanJobData.first
+        scanJobData.first
     }
 
     public func fetchAllScans() throws -> [ScanJobData] {

--- a/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCoreTestsUtils/Mocks.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCoreTestsUtils/Mocks.swift
@@ -688,7 +688,6 @@ public final class DataBrokerProtectionSecureVaultMock: DataBrokerProtectionSecu
     public var brokers = [DataBroker]()
     public var scanJobData = [ScanJobData]()
     public var optOutJobData = [OptOutJobData]()
-    public var updatedProfileQueries = [ProfileQuery]()
     public var lastPreferredRunDateOnScan: Date?
     public var lastPreferredRunDateOnOptOut: Date?
     public var lastSavedBrokerResource: BrokerResource?
@@ -723,7 +722,6 @@ public final class DataBrokerProtectionSecureVaultMock: DataBrokerProtectionSecu
         brokers.removeAll()
         scanJobData.removeAll()
         optOutJobData.removeAll()
-        updatedProfileQueries.removeAll()
         lastPreferredRunDateOnScan = nil
         lastPreferredRunDateOnOptOut = nil
         lastSavedBrokerResource = nil
@@ -955,7 +953,6 @@ public final class DataBrokerProtectionSecureVaultMock: DataBrokerProtectionSecu
 
     public func update(_ profileQuery: ProfileQuery, brokerIDs: [Int64], profileId: Int64) throws -> Int64 {
         wasUpdateProfileQueryCalled = true
-        updatedProfileQueries.append(profileQuery)
         return 1
     }
 

--- a/SharedPackages/DataBrokerProtectionCore/Tests/DataBrokerProtectionCoreTests/DataBrokerProtectionProfileTests.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Tests/DataBrokerProtectionCoreTests/DataBrokerProtectionProfileTests.swift
@@ -19,7 +19,9 @@
 import XCTest
 @testable import DataBrokerProtectionCore
 import DataBrokerProtectionCoreTestsUtils
+import BrowserServicesKit
 import SecureStorage
+import SecureStorageTestsUtils
 
 final class DataBrokerProtectionProfileTests: XCTestCase {
     func testProfileQueriesWithSingleAddressMultipleNames() {
@@ -276,35 +278,72 @@ final class DataBrokerProtectionProfileTests: XCTestCase {
         XCTAssertTrue(vault.wasDeleteProfileQueryCalled)
     }
 
-    func testSaveProfileWithMatchingDeprecatedQuery_thenReactivatesQuery() async throws {
-        let vault: DataBrokerProtectionSecureVaultMock = try DataBrokerProtectionSecureVaultMock(providers:
-                                                            SecureStorageProviders(
-                                                                crypto: EmptySecureStorageCryptoProviderMock(),
-                                                                database: SecureStorageDatabaseProviderMock(),
-                                                                keystore: EmptySecureStorageKeyStoreProviderMock()))
+    func testChangingProfileThenChangingItBackReactivatesOriginalQuery() async throws {
+        let temporaryDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("DBPProfileTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: temporaryDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
+
+        let databaseProvider = try DefaultDataBrokerProtectionDatabaseProvider(
+            file: temporaryDirectory.appendingPathComponent("Vault.db"),
+            key: Data("key".utf8),
+            registerMigrationsHandler: DefaultDataBrokerProtectionDatabaseMigrationsProvider.v10Migrations
+        )
+        let keyStoreProvider = MockKeystoreProvider()
+        keyStoreProvider._encryptedL2Key = Data("encryptedL2".utf8)
+        keyStoreProvider._generatedPassword = Data("generatedPassword".utf8)
+        let vault = DefaultDataBrokerProtectionSecureVault(providers: SecureStorageProviders(
+            crypto: NoOpCryptoProvider(),
+            database: databaseProvider,
+            keystore: keyStoreProvider
+        ))
         let database = DataBrokerProtectionDatabase(fakeBrokerFlag: DataBrokerDebugFlagFakeBroker(),
                                                     pixelHandler: MockDataBrokerProtectionPixelsHandler(),
                                                     vault: vault,
                                                     localBrokerService: MockLocalBrokerJSONService())
-        let profile = DataBrokerProtectionProfile(
-            names: [.init(firstName: "First", lastName: "Last")],
-            addresses: [.init(city: "City", state: "State")],
-            phones: [],
-            birthYear: 1980
+
+        let brokerURL = try XCTUnwrap(Bundle.module.url(forResource: "valid-broker",
+                                                        withExtension: "json",
+                                                        subdirectory: "BundleResources"))
+        let brokerID = try database.saveBroker(brokerResource: DataBroker.initFromResource(brokerURL))
+        let originalProfile = DataBrokerProtectionProfile(names: [.init(firstName: "Alice", lastName: "Example")],
+                                                          addresses: [.init(city: "Testville", state: "CA")],
+                                                          phones: [],
+                                                          birthYear: 1980)
+        let changedProfile = DataBrokerProtectionProfile(names: originalProfile.names,
+                                                         addresses: originalProfile.addresses,
+                                                         phones: originalProfile.phones,
+                                                         birthYear: 1981)
+
+        try await database.save(originalProfile)
+        let originalQuery = try XCTUnwrap(vault.fetchAllProfileQueries(for: 1).first)
+        let originalQueryID = try XCTUnwrap(originalQuery.id)
+        try database.saveOptOutJob(
+            optOut: .mock(with: ExtractedProfile(),
+                          brokerId: brokerID,
+                          profileQueryId: originalQueryID,
+                          preferredRunDate: Date()),
+            extractedProfile: ExtractedProfile()
         )
-        let deprecatedProfileQuery = ProfileQuery.mock.with(deprecated: true)
 
-        vault.profile = profile
-        vault.profileQueries = [deprecatedProfileQuery]
-        vault.brokers = [.mock, .mockWithDefaults(id: 2, name: "Second broker")]
-        vault.scanJobData = [.mock]
+        try await database.save(changedProfile)
 
-        try await database.save(profile)
+        let changedQueries = try vault.fetchAllProfileQueries(for: 1)
+        XCTAssertTrue(try XCTUnwrap(changedQueries.first { $0.birthYear == 1980 }).deprecated)
+        XCTAssertFalse(try XCTUnwrap(changedQueries.first { $0.birthYear == 1981 }).deprecated)
 
-        XCTAssertFalse(vault.wasSaveProfileQueryCalled)
-        let updatedProfileQuery = try XCTUnwrap(vault.updatedProfileQueries.first)
-        XCTAssertEqual(updatedProfileQuery.id, deprecatedProfileQuery.id)
-        XCTAssertFalse(updatedProfileQuery.deprecated)
+        let beforeRevert = Date()
+        try await database.save(originalProfile)
+
+        let finalQueries = try vault.fetchAllProfileQueries(for: 1)
+        let reactivatedQuery = try XCTUnwrap(finalQueries.first { $0.birthYear == 1980 })
+        XCTAssertEqual(reactivatedQuery.id, originalQueryID)
+        XCTAssertFalse(reactivatedQuery.deprecated)
+        XCTAssertNil(finalQueries.first { $0.birthYear == 1981 })
+
+        let scan = try XCTUnwrap(vault.fetchScan(brokerId: brokerID, profileQueryId: originalQueryID))
+        XCTAssertGreaterThanOrEqual(try XCTUnwrap(scan.preferredRunDate), beforeRevert)
+        XCTAssertEqual(try vault.fetchOptOuts(brokerId: brokerID, profileQueryId: originalQueryID).count, 1)
     }
 }
 

--- a/SharedPackages/DataBrokerProtectionCore/Tests/DataBrokerProtectionCoreTests/DataBrokerProtectionProfileTests.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Tests/DataBrokerProtectionCoreTests/DataBrokerProtectionProfileTests.swift
@@ -276,7 +276,7 @@ final class DataBrokerProtectionProfileTests: XCTestCase {
         XCTAssertTrue(vault.wasDeleteProfileQueryCalled)
     }
 
-    func testSaveProfileWithMatchingDeprecatedQuery_thenReactivatesQueryAndSchedulesMissingBrokerScans() async throws {
+    func testSaveProfileWithMatchingDeprecatedQuery_thenReactivatesQuery() async throws {
         let vault: DataBrokerProtectionSecureVaultMock = try DataBrokerProtectionSecureVaultMock(providers:
                                                             SecureStorageProviders(
                                                                 crypto: EmptySecureStorageCryptoProviderMock(),
@@ -293,38 +293,18 @@ final class DataBrokerProtectionProfileTests: XCTestCase {
             birthYear: 1980
         )
         let deprecatedProfileQuery = ProfileQuery.mock.with(deprecated: true)
-        let existingScan = ScanJobData(
-            brokerId: 1,
-            profileQueryId: 1,
-            preferredRunDate: .distantFuture,
-            historyEvents: [.mock(type: .matchesFound(count: 1))]
-        )
 
         vault.profile = profile
         vault.profileQueries = [deprecatedProfileQuery]
         vault.brokers = [.mock, .mockWithDefaults(id: 2, name: "Second broker")]
-        vault.fetchScanHandler = { brokerId, profileQueryId in
-            brokerId == existingScan.brokerId && profileQueryId == existingScan.profileQueryId ? existingScan : nil
-        }
+        vault.scanJobData = [.mock]
 
-        let beforeSave = Date()
         try await database.save(profile)
 
         XCTAssertFalse(vault.wasSaveProfileQueryCalled)
-        XCTAssertEqual(vault.updatedProfileQueries.count, 1)
-        XCTAssertEqual(vault.updatedProfileQueries.first?.id, deprecatedProfileQuery.id)
-        XCTAssertEqual(vault.updatedProfileQueries.first?.deprecated, false)
-
-        XCTAssertEqual(vault.updatedScanPreferredRunDates.count, 1)
-        XCTAssertEqual(vault.updatedScanPreferredRunDates.first?.brokerId, 1)
-        XCTAssertEqual(vault.updatedScanPreferredRunDates.first?.profileQueryId, 1)
-        XCTAssertGreaterThanOrEqual(vault.updatedScanPreferredRunDates.first?.date ?? .distantPast, beforeSave)
-
-        XCTAssertEqual(vault.savedScanJobs.count, 1)
-        XCTAssertEqual(vault.savedScanJobs.first?.brokerId, 2)
-        XCTAssertEqual(vault.savedScanJobs.first?.profileQueryId, 1)
-        XCTAssertNil(vault.savedScanJobs.first?.lastRunDate)
-        XCTAssertGreaterThanOrEqual(vault.savedScanJobs.first?.preferredRunDate ?? .distantPast, beforeSave)
+        let updatedProfileQuery = try XCTUnwrap(vault.updatedProfileQueries.first)
+        XCTAssertEqual(updatedProfileQuery.id, deprecatedProfileQuery.id)
+        XCTAssertFalse(updatedProfileQuery.deprecated)
     }
 }
 

--- a/SharedPackages/DataBrokerProtectionCore/Tests/DataBrokerProtectionCoreTests/DataBrokerProtectionProfileTests.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Tests/DataBrokerProtectionCoreTests/DataBrokerProtectionProfileTests.swift
@@ -275,6 +275,57 @@ final class DataBrokerProtectionProfileTests: XCTestCase {
         XCTAssertFalse(vault.wasUpdateProfileQueryCalled)
         XCTAssertTrue(vault.wasDeleteProfileQueryCalled)
     }
+
+    func testSaveProfileWithMatchingDeprecatedQuery_thenReactivatesQueryAndSchedulesMissingBrokerScans() async throws {
+        let vault: DataBrokerProtectionSecureVaultMock = try DataBrokerProtectionSecureVaultMock(providers:
+                                                            SecureStorageProviders(
+                                                                crypto: EmptySecureStorageCryptoProviderMock(),
+                                                                database: SecureStorageDatabaseProviderMock(),
+                                                                keystore: EmptySecureStorageKeyStoreProviderMock()))
+        let database = DataBrokerProtectionDatabase(fakeBrokerFlag: DataBrokerDebugFlagFakeBroker(),
+                                                    pixelHandler: MockDataBrokerProtectionPixelsHandler(),
+                                                    vault: vault,
+                                                    localBrokerService: MockLocalBrokerJSONService())
+        let profile = DataBrokerProtectionProfile(
+            names: [.init(firstName: "First", lastName: "Last")],
+            addresses: [.init(city: "City", state: "State")],
+            phones: [],
+            birthYear: 1980
+        )
+        let deprecatedProfileQuery = ProfileQuery.mock.with(deprecated: true)
+        let existingScan = ScanJobData(
+            brokerId: 1,
+            profileQueryId: 1,
+            preferredRunDate: .distantFuture,
+            historyEvents: [.mock(type: .matchesFound(count: 1))]
+        )
+
+        vault.profile = profile
+        vault.profileQueries = [deprecatedProfileQuery]
+        vault.brokers = [.mock, .mockWithDefaults(id: 2, name: "Second broker")]
+        vault.fetchScanHandler = { brokerId, profileQueryId in
+            brokerId == existingScan.brokerId && profileQueryId == existingScan.profileQueryId ? existingScan : nil
+        }
+
+        let beforeSave = Date()
+        try await database.save(profile)
+
+        XCTAssertFalse(vault.wasSaveProfileQueryCalled)
+        XCTAssertEqual(vault.updatedProfileQueries.count, 1)
+        XCTAssertEqual(vault.updatedProfileQueries.first?.id, deprecatedProfileQuery.id)
+        XCTAssertEqual(vault.updatedProfileQueries.first?.deprecated, false)
+
+        XCTAssertEqual(vault.updatedScanPreferredRunDates.count, 1)
+        XCTAssertEqual(vault.updatedScanPreferredRunDates.first?.brokerId, 1)
+        XCTAssertEqual(vault.updatedScanPreferredRunDates.first?.profileQueryId, 1)
+        XCTAssertGreaterThanOrEqual(vault.updatedScanPreferredRunDates.first?.date ?? .distantPast, beforeSave)
+
+        XCTAssertEqual(vault.savedScanJobs.count, 1)
+        XCTAssertEqual(vault.savedScanJobs.first?.brokerId, 2)
+        XCTAssertEqual(vault.savedScanJobs.first?.profileQueryId, 1)
+        XCTAssertNil(vault.savedScanJobs.first?.lastRunDate)
+        XCTAssertGreaterThanOrEqual(vault.savedScanJobs.first?.preferredRunDate ?? .distantPast, beforeSave)
+    }
 }
 
 extension ProfileQuery: Comparable {


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ External contributors: file an issue before opening a PR.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1203581873609357/task/1216375796914597
Tech Design URL:
CC:

### Description

Fixes an issue where previously deprecated profile is forever prevented from trigger scans.

### Testing Steps
<!-- One action per step. Note expected outcome inline where relevant, e.g. "3. Tap Save → settings screen dismisses". Assume the reviewer is unfamiliar with this part of the app. -->
1. Set up PIR profile and start manual scans, wait for it to finish
2. Edit profile and change the birth year
3. Trigger manual scans again, grab a coffee, wait for it to finish
4. Edit profile again and change back to original birth year

In the prod version this would break the flow. The scan will not show progress and re-opening the dashboard would bring back the Edit Profile form.

With the fix you won't be stuck at the Edit Profile form any more.

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
8. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact

Minor.

#### What could go wrong?
<!-- Before submitting: identify realistic failure scenarios and check a mitigation exists in this diff (test, flag, guard). Only keep this section if the risk is non-obvious to a reviewer. Otherwise delete it. One line per scenario: "X could happen → mitigated by Y." -->

### Quality Considerations
<!-- Edge cases, performance, privacy/security impact — omit if not applicable -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches profile persistence and scan scheduling for deprecated queries with existing matches; behavior is covered by a new vault-backed test but affects core PIR job eligibility.
> 
> **Overview**
> Fixes PIR getting stuck on the Edit Profile flow when a user changes profile details (e.g. birth year) and later restores the original values.
> 
> **`updateProfile`** now finds profile queries that are still in the vault but marked **deprecated** and that match the newly saved profile, clears `deprecated`, and runs them through **`updateProfileQueries`** so scans can run again (including bumping **`preferredRunDate`**). Without this, a reverted query stayed deprecated and was never treated as new, so manual scans showed no progress.
> 
> An integration-style test saves a profile, changes birth year (deprecating the original query when it has opt-out/match data), then saves the original profile again and asserts the same query ID is reactivated, the temporary query is removed, and scan/opt-out jobs remain wired correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6480a0d003cfe0d01e30c1ca3a0b13df4c667c58. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->