### PR TITLE
[macOS] Fix stuck Duck.ai omnibar hover states

### DIFF
--- a/macOS/DuckDuckGo/AIChat/AIChatModelPickerButton.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatModelPickerButton.swift
@@ -350,7 +350,8 @@ final class AIChatModelPickerButton: NSView {
         refreshHoverState()
     }
 
-    /// For the cases where the tracking area can't be trusted — see `sendMenuOpeningAction`.
+    /// Re-derives hover from the pointer's real position when event ordering or modal menu
+    /// tracking makes the tracking-area callbacks unreliable.
     private func refreshHoverState() {
         guard isEnabled, !isReadOnly, let window else {
             isHovered = false
@@ -368,7 +369,7 @@ final class AIChatModelPickerButton: NSView {
     /// unconditionally would leave the hover fill visible until the pointer crosses the view again.
     private func updateHoverState(_ hovering: Bool, from event: NSEvent) {
         guard event.timestamp >= lastHoverEventTimestamp else {
-            refreshHoverState()
+            resetTransientFillState()
             return
         }
         lastHoverEventTimestamp = event.timestamp

--- a/macOS/DuckDuckGo/AIChat/AIChatModelPickerButton.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatModelPickerButton.swift
@@ -350,8 +350,7 @@ final class AIChatModelPickerButton: NSView {
         refreshHoverState()
     }
 
-    /// Re-derives hover from the pointer's real position when event ordering or modal menu
-    /// tracking makes the tracking-area callbacks unreliable.
+    /// Re-derives hover from the pointer's real position when event ordering or modal menu tracking makes callbacks unreliable.
     private func refreshHoverState() {
         guard isEnabled, !isReadOnly, let window else {
             isHovered = false

--- a/macOS/DuckDuckGo/AIChat/AIChatModelPickerButton.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatModelPickerButton.swift
@@ -421,23 +421,6 @@ final class AIChatModelPickerButton: NSView {
         resetTransientFillState()
     }
 
-    private func trackMouseInteraction() {
-        while let event = window?.nextEvent(matching: [.leftMouseDragged, .leftMouseUp]) {
-            switch event.type {
-            case .leftMouseDragged:
-                mouseDragged(with: event)
-            case .leftMouseUp:
-                mouseUp(with: event)
-                return
-            default:
-                assertionFailure("Unexpected mouse tracking event")
-                resetTransientFillState()
-                return
-            }
-        }
-        resetTransientFillState()
-    }
-
     override func keyDown(with event: NSEvent) {
         guard !isReadOnly else {
             if event.keyCode == 48 {

--- a/macOS/DuckDuckGo/AIChat/AIChatModelPickerButton.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatModelPickerButton.swift
@@ -372,7 +372,8 @@ final class AIChatModelPickerButton: NSView {
             return
         }
         lastHoverEventTimestamp = event.timestamp
-        isHovered = hovering && isEnabled && !isReadOnly
+        let canShowHover = NSEvent.pressedMouseButtons == 0 || isMouseDown
+        isHovered = hovering && isEnabled && !isReadOnly && canShowHover
         if !hovering {
             isMouseDown = false
         }
@@ -384,8 +385,8 @@ final class AIChatModelPickerButton: NSView {
     }
 
     override func mouseMoved(with event: NSEvent) {
-        updateHoverState(true, from: event)
         isMouseDown = false
+        updateHoverState(true, from: event)
         NSCursor.arrow.set()
     }
 
@@ -416,7 +417,7 @@ final class AIChatModelPickerButton: NSView {
                 return
             }
         }
-        isMouseDown = false
+        resetTransientFillState()
     }
 
     override func keyDown(with event: NSEvent) {

--- a/macOS/DuckDuckGo/AIChat/AIChatModelPickerButton.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatModelPickerButton.swift
@@ -398,6 +398,7 @@ final class AIChatModelPickerButton: NSView {
         guard isEnabled, !isReadOnly else { return }
         wantsFocusRing = false
         isMouseDown = true
+        trackMouseInteraction()
     }
 
     override func mouseDragged(with event: NSEvent) {
@@ -414,6 +415,23 @@ final class AIChatModelPickerButton: NSView {
                 sendMenuOpeningAction {
                     NSApp.sendAction(action, to: target, from: self)
                 }
+                return
+            }
+        }
+        resetTransientFillState()
+    }
+
+    private func trackMouseInteraction() {
+        while let event = window?.nextEvent(matching: [.leftMouseDragged, .leftMouseUp]) {
+            switch event.type {
+            case .leftMouseDragged:
+                mouseDragged(with: event)
+            case .leftMouseUp:
+                mouseUp(with: event)
+                return
+            default:
+                assertionFailure("Unexpected mouse tracking event")
+                resetTransientFillState()
                 return
             }
         }

--- a/macOS/DuckDuckGo/AIChat/AIChatModelPickerButton.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatModelPickerButton.swift
@@ -324,6 +324,7 @@ final class AIChatModelPickerButton: NSView {
     // MARK: - Hover Tracking
 
     private var trackingArea: NSTrackingArea?
+    private var lastHoverEventTimestamp: TimeInterval = 0
 
     private func setupHoverTracking() {
         updateTrackingAreas()
@@ -338,7 +339,7 @@ final class AIChatModelPickerButton: NSView {
 
         let newTrackingArea = NSTrackingArea(
             rect: bounds,
-            options: [.mouseEnteredAndExited, .mouseMoved, .activeInKeyWindow],
+            options: [.mouseEnteredAndExited, .mouseMoved, .activeInKeyWindow, .inVisibleRect],
             owner: self,
             userInfo: nil
         )
@@ -347,19 +348,6 @@ final class AIChatModelPickerButton: NSView {
 
         // A new tracking area reports nothing about a pointer already outside it.
         refreshHoverState()
-    }
-
-    override func mouseEntered(with event: NSEvent) {
-        isHovered = isEnabled && !isReadOnly
-        NSCursor.arrow.set()
-    }
-
-    override func mouseMoved(with event: NSEvent) {
-        NSCursor.arrow.set()
-    }
-
-    override func mouseExited(with event: NSEvent) {
-        isHovered = false
     }
 
     /// For the cases where the tracking area can't be trusted — see `sendMenuOpeningAction`.
@@ -374,6 +362,35 @@ final class AIChatModelPickerButton: NSView {
     func resetTransientFillState() {
         isMouseDown = false
         refreshHoverState()
+    }
+
+    /// AppKit can deliver an older enter event after a newer exit event. Trusting that enter
+    /// unconditionally would leave the hover fill visible until the pointer crosses the view again.
+    private func updateHoverState(_ hovering: Bool, from event: NSEvent) {
+        guard event.timestamp >= lastHoverEventTimestamp else {
+            refreshHoverState()
+            return
+        }
+        lastHoverEventTimestamp = event.timestamp
+        isHovered = hovering && isEnabled && !isReadOnly
+        if !hovering {
+            isMouseDown = false
+        }
+    }
+
+    override func mouseEntered(with event: NSEvent) {
+        updateHoverState(true, from: event)
+        NSCursor.arrow.set()
+    }
+
+    override func mouseMoved(with event: NSEvent) {
+        updateHoverState(true, from: event)
+        isMouseDown = false
+        NSCursor.arrow.set()
+    }
+
+    override func mouseExited(with event: NSEvent) {
+        updateHoverState(false, from: event)
     }
 
     override func mouseDown(with event: NSEvent) {

--- a/macOS/DuckDuckGo/AIChat/AIChatOmnibarToolButton.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatOmnibarToolButton.swift
@@ -64,6 +64,22 @@ extension FocusRingControlling {
     }
 }
 
+extension FocusRingControlling where Self: NSView {
+
+    /// Tracks the full pointer sequence so NSWindow cannot redispatch drag events to every custom view under the cursor.
+    func trackMouseInteraction() {
+        while let event = window?.nextEvent(matching: [.leftMouseDragged, .leftMouseUp]) {
+            if event.type == .leftMouseDragged {
+                mouseDragged(with: event)
+                continue
+            }
+            mouseUp(with: event)
+            return
+        }
+        resetTransientFillState()
+    }
+}
+
 /// A reusable toolbar button for the AI Chat omnibar with circular hover background effect.
 final class AIChatOmnibarToolButton: NSView {
 
@@ -191,7 +207,6 @@ final class AIChatOmnibarToolButton: NSView {
 
     var isEnabled: Bool = true {
         didSet {
-            guard isEnabled != oldValue else { return }
             if !isEnabled {
                 isMouseDown = false
                 isHovered = false
@@ -535,6 +550,7 @@ final class AIChatOmnibarToolButton: NSView {
     }
 
     override func mouseDown(with event: NSEvent) {
+        guard isEnabled else { return }
         wantsFocusRing = false
         isMouseDown = true
         trackMouseInteraction()
@@ -555,23 +571,6 @@ final class AIChatOmnibarToolButton: NSView {
                 sendMenuOpeningAction {
                     NSApp.sendAction(action, to: target, from: self)
                 }
-                return
-            }
-        }
-        resetTransientFillState()
-    }
-
-    private func trackMouseInteraction() {
-        while let event = window?.nextEvent(matching: [.leftMouseDragged, .leftMouseUp]) {
-            switch event.type {
-            case .leftMouseDragged:
-                mouseDragged(with: event)
-            case .leftMouseUp:
-                mouseUp(with: event)
-                return
-            default:
-                assertionFailure("Unexpected mouse tracking event")
-                resetTransientFillState()
                 return
             }
         }

--- a/macOS/DuckDuckGo/AIChat/AIChatOmnibarToolButton.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatOmnibarToolButton.swift
@@ -537,6 +537,7 @@ final class AIChatOmnibarToolButton: NSView {
     override func mouseDown(with event: NSEvent) {
         wantsFocusRing = false
         isMouseDown = true
+        trackMouseInteraction()
     }
 
     override func mouseDragged(with event: NSEvent) {
@@ -554,6 +555,23 @@ final class AIChatOmnibarToolButton: NSView {
                 sendMenuOpeningAction {
                     NSApp.sendAction(action, to: target, from: self)
                 }
+                return
+            }
+        }
+        resetTransientFillState()
+    }
+
+    private func trackMouseInteraction() {
+        while let event = window?.nextEvent(matching: [.leftMouseDragged, .leftMouseUp]) {
+            switch event.type {
+            case .leftMouseDragged:
+                mouseDragged(with: event)
+            case .leftMouseUp:
+                mouseUp(with: event)
+                return
+            default:
+                assertionFailure("Unexpected mouse tracking event")
+                resetTransientFillState()
                 return
             }
         }

--- a/macOS/DuckDuckGo/AIChat/AIChatOmnibarToolButton.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatOmnibarToolButton.swift
@@ -512,7 +512,8 @@ final class AIChatOmnibarToolButton: NSView {
             return
         }
         lastHoverEventTimestamp = event.timestamp
-        isHovered = hovering && isEnabled
+        let canShowHover = NSEvent.pressedMouseButtons == 0 || isMouseDown
+        isHovered = hovering && isEnabled && canShowHover
         if !hovering {
             isMouseDown = false
         }
@@ -524,8 +525,8 @@ final class AIChatOmnibarToolButton: NSView {
     }
 
     override func mouseMoved(with event: NSEvent) {
-        updateHoverState(true, from: event)
         isMouseDown = false
+        updateHoverState(true, from: event)
         NSCursor.arrow.set()
     }
 
@@ -556,7 +557,7 @@ final class AIChatOmnibarToolButton: NSView {
                 return
             }
         }
-        isMouseDown = false
+        resetTransientFillState()
     }
 
     override func keyDown(with event: NSEvent) {

--- a/macOS/DuckDuckGo/AIChat/AIChatOmnibarToolButton.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatOmnibarToolButton.swift
@@ -490,8 +490,7 @@ final class AIChatOmnibarToolButton: NSView {
         refreshHoverState()
     }
 
-    /// Re-derives hover from the pointer's real position when event ordering or modal menu
-    /// tracking makes the tracking-area callbacks unreliable.
+    /// Re-derives hover from the pointer's real position when event ordering or modal menu tracking makes callbacks unreliable.
     private func refreshHoverState() {
         guard isEnabled, let window else {
             isHovered = false

--- a/macOS/DuckDuckGo/AIChat/AIChatOmnibarToolButton.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatOmnibarToolButton.swift
@@ -459,6 +459,7 @@ final class AIChatOmnibarToolButton: NSView {
     }
 
     private var trackingArea: NSTrackingArea?
+    private var lastHoverEventTimestamp: TimeInterval = 0
 
     private func setupHoverTracking() {
         updateTrackingAreas()
@@ -473,7 +474,7 @@ final class AIChatOmnibarToolButton: NSView {
 
         let newTrackingArea = NSTrackingArea(
             rect: bounds,
-            options: [.mouseEnteredAndExited, .mouseMoved, .activeInKeyWindow],
+            options: [.mouseEnteredAndExited, .mouseMoved, .activeInKeyWindow, .inVisibleRect],
             owner: self,
             userInfo: nil
         )
@@ -498,17 +499,33 @@ final class AIChatOmnibarToolButton: NSView {
         refreshHoverState()
     }
 
+    /// AppKit can deliver an older enter event after a newer exit event. Trusting that enter
+    /// unconditionally would leave the hover fill visible until the pointer crosses the view again.
+    private func updateHoverState(_ hovering: Bool, from event: NSEvent) {
+        guard event.timestamp >= lastHoverEventTimestamp else {
+            refreshHoverState()
+            return
+        }
+        lastHoverEventTimestamp = event.timestamp
+        isHovered = hovering
+        if !hovering {
+            isMouseDown = false
+        }
+    }
+
     override func mouseEntered(with event: NSEvent) {
-        isHovered = true
+        updateHoverState(true, from: event)
         NSCursor.arrow.set()
     }
 
     override func mouseMoved(with event: NSEvent) {
+        updateHoverState(true, from: event)
+        isMouseDown = false
         NSCursor.arrow.set()
     }
 
     override func mouseExited(with event: NSEvent) {
-        isHovered = false
+        updateHoverState(false, from: event)
     }
 
     override func mouseDown(with event: NSEvent) {

--- a/macOS/DuckDuckGo/AIChat/AIChatOmnibarToolButton.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatOmnibarToolButton.swift
@@ -191,6 +191,11 @@ final class AIChatOmnibarToolButton: NSView {
 
     var isEnabled: Bool = true {
         didSet {
+            guard isEnabled != oldValue else { return }
+            if !isEnabled {
+                isMouseDown = false
+                isHovered = false
+            }
             updateAppearance()
         }
     }
@@ -485,9 +490,10 @@ final class AIChatOmnibarToolButton: NSView {
         refreshHoverState()
     }
 
-    /// For the cases where the tracking area can't be trusted — see `sendMenuOpeningAction`.
+    /// Re-derives hover from the pointer's real position when event ordering or modal menu
+    /// tracking makes the tracking-area callbacks unreliable.
     private func refreshHoverState() {
-        guard let window else {
+        guard isEnabled, let window else {
             isHovered = false
             return
         }
@@ -503,11 +509,11 @@ final class AIChatOmnibarToolButton: NSView {
     /// unconditionally would leave the hover fill visible until the pointer crosses the view again.
     private func updateHoverState(_ hovering: Bool, from event: NSEvent) {
         guard event.timestamp >= lastHoverEventTimestamp else {
-            refreshHoverState()
+            resetTransientFillState()
             return
         }
         lastHoverEventTimestamp = event.timestamp
-        isHovered = hovering
+        isHovered = hovering && isEnabled
         if !hovering {
             isMouseDown = false
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204006570077678/task/1216334198180492?focus=true
Tech Design URL:
CC:

### Description

Fixes Duck.ai omnibar controls retaining hover or pressed fills after AppKit delivers pointer events out of order. Reconciles stale events with the cursor position and tracks the visible control bounds.

### Testing Steps

1. On macOS, focus the address bar and switch to Duck.ai.
2. Hover each tool and picker, then move away → its fill clears.
3. Open and dismiss both picker menus → transient fills clear.
4. Repeat in the Prompt Bar.

### Impact

Low. Limited to visual interaction state in Duck.ai controls.

#### What could go wrong?

Hover could clear while the pointer remains over a control → stale events re-check the current cursor position.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual interaction state only in Duck.ai omnibar controls; logic re-validates hover against the live cursor when events are stale.
> 
> **Overview**
> Fixes **Duck.ai omnibar** controls (`AIChatModelPickerButton`, `AIChatOmnibarToolButton`) that could keep hover or pressed background fills after pointer moves away or menus dismiss.
> 
> Hover handling now **ignores stale AppKit enter/exit events** via event timestamps, **re-checks the real cursor position** when tracking areas or menu tracking are unreliable, and adds **`.inVisibleRect`** on tracking areas. **`updateHoverState`** also suppresses hover while another button is held unless this control is the one pressed.
> 
> **`trackMouseInteraction()`** on `FocusRingControlling` views consumes the drag/up sequence after `mouseDown` so the window does not fan drag events to every control under the cursor. Clicks and failed actions end through **`resetTransientFillState()`**, which clears press state and refreshes hover. Disabling a tool button now clears transient hover/press immediately.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 674f09ec4f2f775c1a1b27ec3080da85ea5915d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->