### PR TITLE
iOS: Keep deleted Duck.ai chats deleted after reinstall

### DIFF
--- a/SharedPackages/AIChat/Package.resolved
+++ b/SharedPackages/AIChat/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "d61e9ef500900a5d720f556507bc377c5db9d8c657dbfb0d578f7c3233fcced1",
+  "originHash" : "8ec7a7948f4320f24c9b3ccca107b34bd425edcbfd3f0e6d48521dd5cfea73bf",
   "pins" : [
     {
       "identity" : "content-scope-scripts",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/duckduckgo/content-scope-scripts.git",
       "state" : {
-        "revision" : "21aec4d902338cb10c422e091eb6a8c9f38a9be1",
-        "version" : "16.9.0"
+        "revision" : "e27d61495b3e8793e507a483d885b758e75c0732",
+        "version" : "17.0.0"
       }
     },
     {

--- a/SharedPackages/AIChat/Sources/AIChat/Shared/Sync/AIChatSyncHandler.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/Sync/AIChatSyncHandler.swift
@@ -85,8 +85,22 @@ public class AIChatSyncHandler: AIChatSyncHandling {
         }
     }
 
+    /// The account backing a live sync session, or `nil` when sync is off.
+    ///
+    /// Deliberately not a plain `account != nil` check: the account lives in the keychain, which
+    /// survives app deletion, and `syncAutoRestore` preserves it while leaving `authState` as
+    /// `.inactive`.
+    private var activeSyncAccount: SyncAccount? {
+        switch sync.authState {
+        case .active, .addingNewDevice:
+            return sync.account
+        case .initializing, .inactive:
+            return nil
+        }
+    }
+
     public func isSyncTurnedOn() -> Bool {
-        sync.authState != .initializing && sync.account != nil
+        activeSyncAccount != nil
     }
 
     public var authStatePublisher: AnyPublisher<SyncAuthState, Never> {
@@ -104,7 +118,9 @@ public class AIChatSyncHandler: AIChatSyncHandling {
 
         try validateSetup()
 
-        guard let account = sync.account else {
+        // Sync off reports the feature as available but signed out rather than throwing — the
+        // web app treats an error as a transient failure and retries.
+        guard let account = activeSyncAccount else {
             return SyncStatus(syncAvailable: true,
                               userId: nil,
                               deviceId: nil,
@@ -121,6 +137,11 @@ public class AIChatSyncHandler: AIChatSyncHandling {
 
     public func getScopedToken() async throws -> SyncToken {
         try validateSetup()
+
+        // `accountNotFound` is deliberate: the caller already maps it to "sync off".
+        guard activeSyncAccount != nil else {
+            throw SyncError.accountNotFound
+        }
 
         do {
             guard let token = try await sync.mainTokenRescope(to: "ai_chats"),

--- a/SharedPackages/AIChat/Tests/AIChatTests/AIChatSyncHandlerTests.swift
+++ b/SharedPackages/AIChat/Tests/AIChatTests/AIChatSyncHandlerTests.swift
@@ -81,7 +81,11 @@ final class AIChatSyncHandlerTests: XCTestCase {
         XCTAssertTrue(result, "Should return true when auth state is active and account exists")
     }
 
-    func testGivenAuthStateInactiveWithAccount_WhenIsSyncTurnedOn_ThenReturnsTrue() {
+    /// The preserved-account state: `syncAutoRestore` keeps the keychain account after sync is
+    /// disabled or the app is reinstalled. Chat sync must be off here — `AIChatSyncCleaner` cannot
+    /// delete chats server-side while inactive, so allowing reads would let the web app restore
+    /// chats the user deleted locally.
+    func testGivenAuthStateInactiveWithPreservedAccount_WhenIsSyncTurnedOn_ThenReturnsFalse() {
         // Given
         mockSync.authState = .inactive
         mockSync.account = MockSyncAccount.valid
@@ -91,7 +95,20 @@ final class AIChatSyncHandlerTests: XCTestCase {
         let result = sut.isSyncTurnedOn()
 
         // Then
-        XCTAssertTrue(result, "Should return true when auth state is not initializing and account exists")
+        XCTAssertFalse(result, "Sync is off when inactive, even though the keychain account survives")
+    }
+
+    func testGivenAuthStateAddingNewDeviceWithAccount_WhenIsSyncTurnedOn_ThenReturnsTrue() {
+        // Given
+        mockSync.authState = .addingNewDevice
+        mockSync.account = MockSyncAccount.valid
+        sut = makeSUT()
+
+        // When
+        let result = sut.isSyncTurnedOn()
+
+        // Then
+        XCTAssertTrue(result, "Mid-pairing is a live session, chat sync should keep working")
     }
 
     // MARK: - getSyncStatus Tests
@@ -177,6 +194,7 @@ final class AIChatSyncHandlerTests: XCTestCase {
     func testGivenRescopeReturnsNil_WhenGetScopedToken_ThenThrowsEmptyResponse() async {
         // Given
         mockSync.authState = .active
+        mockSync.account = MockSyncAccount.valid
         mockSync.mainTokenRescopeResult = nil
         sut = makeSUT()
 
@@ -192,6 +210,7 @@ final class AIChatSyncHandlerTests: XCTestCase {
     func testGivenRescopeReturnsEmptyString_WhenGetScopedToken_ThenThrowsEmptyResponse() async {
         // Given
         mockSync.authState = .active
+        mockSync.account = MockSyncAccount.valid
         mockSync.mainTokenRescopeResult = ""
         sut = makeSUT()
 
@@ -207,6 +226,7 @@ final class AIChatSyncHandlerTests: XCTestCase {
     func testGivenRescopeReturnsToken_WhenGetScopedToken_ThenReturnsToken() async throws {
         // Given
         mockSync.authState = .active
+        mockSync.account = MockSyncAccount.valid
         mockSync.mainTokenRescopeResult = "scoped-token-abc123"
         sut = makeSUT()
 
@@ -216,6 +236,54 @@ final class AIChatSyncHandlerTests: XCTestCase {
         // Then
         XCTAssertEqual(result.token, "scoped-token-abc123")
         XCTAssertEqual(mockSync.mainTokenRescopeScope, "ai_chats")
+    }
+
+    func testGivenAuthStateInactiveWithPreservedAccount_WhenGetScopedToken_ThenThrowsAccountNotFound() async {
+        // Given
+        mockSync.authState = .inactive
+        mockSync.account = MockSyncAccount.valid
+        mockSync.mainTokenRescopeResult = "scoped-token-abc123"
+        sut = makeSUT()
+
+        // When/Then
+        do {
+            _ = try await sut.getScopedToken()
+            XCTFail("Expected accountNotFound to be thrown")
+        } catch {
+            XCTAssertEqual(error as? SyncError, .accountNotFound)
+        }
+        XCTAssertNil(mockSync.mainTokenRescopeScope, "No token should be minted while sync is off")
+    }
+
+    func testGivenAuthStateAddingNewDeviceWithAccount_WhenGetScopedToken_ThenReturnsToken() async throws {
+        // Given
+        mockSync.authState = .addingNewDevice
+        mockSync.account = MockSyncAccount.valid
+        mockSync.mainTokenRescopeResult = "scoped-token-abc123"
+        sut = makeSUT()
+
+        // When
+        let result = try await sut.getScopedToken()
+
+        // Then
+        XCTAssertEqual(result.token, "scoped-token-abc123")
+    }
+
+    func testGivenAuthStateInactiveWithPreservedAccount_WhenGetSyncStatus_ThenReportsAvailableButSignedOut() throws {
+        // Given
+        mockSync.authState = .inactive
+        mockSync.account = MockSyncAccount.valid
+        sut = makeSUT()
+
+        // When
+        let status = try sut.getSyncStatus(featureAvailable: true)
+
+        // Then — available but signed out, so the web app does not treat it as a transient error
+        XCTAssertTrue(status.syncAvailable)
+        XCTAssertNil(status.userId, "Must not expose a userId while sync is off")
+        XCTAssertNil(status.deviceId)
+        XCTAssertNil(status.deviceName)
+        XCTAssertNil(status.deviceType)
     }
 
     // MARK: - encrypt Tests


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414709148257752/task/1218160695252279?focus=true

### Description

Duck.ai chats that a user deleted could come back after the app was reinstalled, including chats deleted with the Fire Button.

The sync account is stored in the keychain, which survives app deletion, and auto-restore keeps it on purpose so a user can restore sync without their recovery code. In that state sync is off but an account still exists, and the read and delete paths treated it differently. Duck.ai could still read chat history from the sync server, while the app was not allowed to delete chats from it, so every local deletion came back the next time Duck.ai loaded.

The app now reads and writes chat history on the sync server only when there is a live sync session. That is the same condition already used for server-side deletion.

Nothing changes when sync is on, or when there is no account. Users with a preserved account will no longer see server-side chats pulled into Duck.ai until they restore sync. macOS does not enable auto-restore, so it never reaches this state and is not affected.

### Testing Steps

**Set up the affected state**

1. On a device running the current App Store build, set up Sync (Settings → Sync & Backup). Completing setup also opts you into auto-restore.
2. Open Duck.ai and start two or three chats so there is history on the server.
3. Delete the DuckDuckGo app from the device. The sync account stays in the keychain.
4. Install the build from this branch.
5. Launch the app and skip the prompt to restore sync → sync is now off, but the old account is still in the keychain.

**Verify the fix**

6. Open Duck.ai → the chat list is empty. The chats from step 2 are not pulled down from the server. (Before this change they would appear.)
7. Start a new chat, then delete it from the recent chats list → it disappears from the list.
8. Force quit, relaunch, and open Duck.ai → the deleted chat does not come back.
9. Start another chat and burn it with the Fire Button → the chat is cleared.
10. Force quit, relaunch, and open Duck.ai → the burned chat does not come back.

**Check sync still works**

11. Go to Settings → Sync & Backup and restore or enable sync.
12. Open Duck.ai → chat history from the server appears as normal.
13. Delete a chat, then check a second synced device → the chat is gone there too.

### Impact and Risks

**Medium.**

This changes when Duck.ai is allowed to talk to the sync server. If the new condition were too strict, chat history sync could stop working for users who do have sync on. The condition covers both an active session and the mid-pairing state, and the unit tests cover each auth state, so that is unlikely.

The change lives in a shared package, so macOS compiles it too. macOS does not enable auto-restore, so it never reaches the affected state and behaviour there is unchanged.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when Duck.ai may read from the sync server and mint tokens; overly strict gating could break chat sync for users with sync on, though active and adding-new-device paths are explicitly preserved and tested.
> 
> **Overview**
> Fixes Duck.ai chat history reappearing after reinstall or when sync is off but a **keychain-preserved** sync account still exists (`authState` `.inactive`).
> 
> **`AIChatSyncHandler`** now uses an `activeSyncAccount` helper that only treats `.active` and `.addingNewDevice` as a live session—not a bare `sync.account != nil`. **`isSyncTurnedOn()`**, **`getScopedToken()`**, and **`getSyncStatus()`** all follow that rule: inactive + preserved account reports sync off (no scoped token, no user/device IDs), while still advertising sync as available-but-signed-out so the web app does not retry on errors.
> 
> Unit tests cover inactive preserved account, mid-pairing **`.addingNewDevice`**, and the signed-out status shape. **`content-scope-scripts`** is bumped **16.9.0 → 17.0.0** in `Package.resolved`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit caca0bd14a2e56dc233d6aefb6dde6e3cd8f642a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->