### PR TITLE
iOS: Expand contextual input for selected text

### DIFF
--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetCoordinator.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualSheetCoordinator.swift
@@ -551,6 +551,9 @@ final class AIChatContextualSheetCoordinator {
             await presentFloatingInput(from: presentingViewController, skippingAutoAttach: true)
         } else {
             await presentSheet(from: presentingViewController, restoreURL: restoreURL, skippingAutoAttach: true)
+            if action.attachesSelection {
+                persistentUTIHost?.activateInput()
+            }
         }
         refreshSelectionChips()
 

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualUTIHost.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/AIChatContextualUTIHost.swift
@@ -400,6 +400,10 @@ final class AIChatContextualUTIHost: UnifiedToggleInputDelegate, AIChatContextua
         coordinator.viewController.isInputFirstResponder
     }
 
+    var isInputCollapsed: Bool {
+        coordinator.isContextualChatCollapsed
+    }
+
     /// A finished transcript belongs in the input, focused so the user can edit or send it.
     func applyDictatedQuery(_ query: String) {
         setText(query)

--- a/iOS/DuckDuckGoTests/AIChat/AIChatContextualSheetCoordinatorTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/AIChatContextualSheetCoordinatorTests.swift
@@ -360,6 +360,32 @@ final class AIChatContextualSheetCoordinatorTests: XCTestCase {
         XCTAssertEqual(sut.sessionState.contextualChatURL, restoreURL)
     }
 
+    @MainActor
+    func testAttachSelectionExpandsInputForExistingChat() async throws {
+        mockFloatingInputFeature.isAvailable = true
+        mockUnifiedToggleInputFeature.isAvailable = true
+        mockFeatureFlagger.enabledFeatureFlags = [.aiChatContextualUnifiedToggleInput]
+        sut.sessionState.handlePromptSubmission("Previous prompt")
+
+        await sut.handleSelectionAction(.ask, selection: .init(text: "selected text", url: nil, faviconBase64: nil), from: mockPresentingVC)
+
+        let host = try XCTUnwrap(sut.persistentUTIHost)
+        XCTAssertFalse(host.isInputCollapsed)
+    }
+
+    @MainActor
+    func testPresentingExistingChatWithoutSelectionKeepsInputCollapsed() async throws {
+        mockFloatingInputFeature.isAvailable = true
+        mockUnifiedToggleInputFeature.isAvailable = true
+        mockFeatureFlagger.enabledFeatureFlags = [.aiChatContextualUnifiedToggleInput]
+        sut.sessionState.handlePromptSubmission("Previous prompt")
+
+        await sut.presentSheet(from: mockPresentingVC)
+
+        let host = try XCTUnwrap(sut.persistentUTIHost)
+        XCTAssertTrue(host.isInputCollapsed)
+    }
+
     /// The signals-only payload is content-free and marked unattached, so pushing it while a page is
     /// attached would clear that page on the frontend while the chip still shows it.
     @MainActor


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206488453854252/task/1218165388444063

### Description

Expands the unified input when selected text is attached to an existing contextual chat, making the attachment immediately visible. Reopening the chat normally remains collapsed.

### Testing Steps

1. Start a contextual Duck.ai chat, submit a prompt, then dismiss the sheet.
2. Select more text on the page and choose Ask Duck.ai → the sheet opens with the input expanded and the selected-text attachment visible.

### Impact

Low: Focused contextual-input presentation fix.

#### What could go wrong?

Existing chats could expand when reopened normally → covered by regression tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Focused UI presentation change in contextual chat input; regression tests guard against expanding on ordinary sheet reopen.
> 
> **Overview**
> When users attach page text to an **existing** contextual Duck.ai chat (sheet path), the unified toggle input now **expands** via `persistentUTIHost?.activateInput()` after the sheet is presented, so selection chips are visible right away. Reopening the same chat without a new selection still uses the collapsed start state.
> 
> `AIChatContextualUTIHost` exposes **`isInputCollapsed`** for tests and callers. Unit tests cover expand-on-attach vs. collapsed-on-normal reopen.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fad9813b0224bab3bbf0b196f9a908080391d342. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->