### PR TITLE
[iOS] Add support for performance optimized paywalls

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/Subscription/PerformanceOptimizedPaywallsProvider.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/Subscription/PerformanceOptimizedPaywallsProvider.swift
@@ -29,6 +29,11 @@ public protocol PerformanceOptimizedPaywallsProviding {
     var paths: SubscriptionURL.PerformanceOptimizedPaywallPaths { get }
 }
 
+/// Provides the rollout state for performance-optimized paywalls.
+public protocol PerformanceOptimizedPaywallsFeatureFlagging {
+    var isPerformanceOptimizedPaywallsEnabled: Bool { get }
+}
+
 /// Default implementation of `PerformanceOptimizedPaywallsProviding`.
 ///
 /// The paths come from the subfeature's settings so the frontend can move the pages without an app
@@ -36,19 +41,19 @@ public protocol PerformanceOptimizedPaywallsProviding {
 public struct DefaultPerformanceOptimizedPaywallsProvider: PerformanceOptimizedPaywallsProviding {
 
     private let privacyConfigurationManager: PrivacyConfigurationManaging
-    private let isFeatureEnabled: () -> Bool
+    private let featureFlagger: any PerformanceOptimizedPaywallsFeatureFlagging
     private let fallbackPaths: SubscriptionURL.PerformanceOptimizedPaywallPaths
 
     public init(privacyConfigurationManager: PrivacyConfigurationManaging,
-                isFeatureEnabled: @escaping () -> Bool,
+                featureFlagger: any PerformanceOptimizedPaywallsFeatureFlagging,
                 fallbackPaths: SubscriptionURL.PerformanceOptimizedPaywallPaths = .default) {
         self.privacyConfigurationManager = privacyConfigurationManager
-        self.isFeatureEnabled = isFeatureEnabled
+        self.featureFlagger = featureFlagger
         self.fallbackPaths = fallbackPaths
     }
 
     public var isEnabled: Bool {
-        isFeatureEnabled()
+        featureFlagger.isPerformanceOptimizedPaywallsEnabled
     }
 
     public var paths: SubscriptionURL.PerformanceOptimizedPaywallPaths {

--- a/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/Subscription/PerformanceOptimizedPaywallsProvider.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/Subscription/PerformanceOptimizedPaywallsProvider.swift
@@ -60,7 +60,8 @@ public struct DefaultPerformanceOptimizedPaywallsProvider: PerformanceOptimizedP
 
         return SubscriptionURL.PerformanceOptimizedPaywallPaths(
             vpn: settings.entryPoints?.vpn?.path ?? fallbackPaths.vpn,
-            duckai: settings.entryPoints?.duckai?.path ?? fallbackPaths.duckai
+            duckai: settings.entryPoints?.duckai?.path ?? fallbackPaths.duckai,
+            pir: settings.entryPoints?.pir?.path ?? fallbackPaths.pir
         )
     }
 
@@ -73,6 +74,7 @@ public struct DefaultPerformanceOptimizedPaywallsProvider: PerformanceOptimizedP
         struct EntryPoints: Decodable {
             let vpn: EntryPoint?
             let duckai: EntryPoint?
+            let pir: EntryPoint?
         }
 
         let entryPoints: EntryPoints?

--- a/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/Subscription/PerformanceOptimizedPaywallsProvider.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/Subscription/PerformanceOptimizedPaywallsProvider.swift
@@ -1,0 +1,80 @@
+//
+//  PerformanceOptimizedPaywallsProvider.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import PrivacyConfig
+import Subscription
+
+/// Provides utilities to query the `performanceOptimizedPaywalls` subfeature.
+public protocol PerformanceOptimizedPaywallsProviding {
+    /// Indicates whether the pre-rendered paywalls should be used.
+    var isEnabled: Bool { get }
+
+    /// The paths of the pre-rendered paywall pages.
+    var paths: SubscriptionURL.PerformanceOptimizedPaywallPaths { get }
+}
+
+/// Default implementation of `PerformanceOptimizedPaywallsProviding`.
+///
+/// The paths come from the subfeature's settings so the frontend can move the pages without an app
+/// release. Each path falls back independently, so a config that carries only one of them still works.
+public struct DefaultPerformanceOptimizedPaywallsProvider: PerformanceOptimizedPaywallsProviding {
+
+    private let privacyConfigurationManager: PrivacyConfigurationManaging
+    private let isFeatureEnabled: () -> Bool
+    private let fallbackPaths: SubscriptionURL.PerformanceOptimizedPaywallPaths
+
+    public init(privacyConfigurationManager: PrivacyConfigurationManaging,
+                isFeatureEnabled: @escaping () -> Bool,
+                fallbackPaths: SubscriptionURL.PerformanceOptimizedPaywallPaths = .default) {
+        self.privacyConfigurationManager = privacyConfigurationManager
+        self.isFeatureEnabled = isFeatureEnabled
+        self.fallbackPaths = fallbackPaths
+    }
+
+    public var isEnabled: Bool {
+        isFeatureEnabled()
+    }
+
+    public var paths: SubscriptionURL.PerformanceOptimizedPaywallPaths {
+        guard let settingsString = privacyConfigurationManager.privacyConfig.settings(for: PrivacyProSubfeature.performanceOptimizedPaywalls),
+              let settingsData = settingsString.data(using: .utf8),
+              let settings = try? JSONDecoder().decode(Settings.self, from: settingsData) else {
+            return fallbackPaths
+        }
+
+        return SubscriptionURL.PerformanceOptimizedPaywallPaths(
+            vpn: settings.entryPoints?.vpn?.path ?? fallbackPaths.vpn,
+            duckai: settings.entryPoints?.duckai?.path ?? fallbackPaths.duckai
+        )
+    }
+
+    private struct Settings: Decodable {
+
+        struct EntryPoint: Decodable {
+            let path: String?
+        }
+
+        struct EntryPoints: Decodable {
+            let vpn: EntryPoint?
+            let duckai: EntryPoint?
+        }
+
+        let entryPoints: EntryPoints?
+    }
+}

--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -652,7 +652,7 @@ public enum PrivacyProSubfeature: String, Equatable, PrivacySubfeature {
     case subscriptionOnboardingPaidSubsSep2026
     case onboardingSubscriptionUpsellExperiment
 
-    /// Gates the server-rendered first paywall. Wired only — nothing reads it yet.
+    /// Gates the server-rendered first paywall.
     case performanceOptimizedPaywalls
 }
 

--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -651,6 +651,9 @@ public enum PrivacyProSubfeature: String, Equatable, PrivacySubfeature {
     case subscriptionOnboardingFreeTrialsSep2026
     case subscriptionOnboardingPaidSubsSep2026
     case onboardingSubscriptionUpsellExperiment
+
+    /// Gates the server-rendered first paywall. Wired only — nothing reads it yet.
+    case performanceOptimizedPaywalls
 }
 
 public enum DuckPlayerSubfeature: String, PrivacySubfeature {

--- a/SharedPackages/BrowserServicesKit/Sources/Subscription/SubscriptionURL+PerformanceOptimizedPaywall.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Subscription/SubscriptionURL+PerformanceOptimizedPaywall.swift
@@ -1,0 +1,100 @@
+//
+//  SubscriptionURL+PerformanceOptimizedPaywall.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+extension SubscriptionURL {
+
+    /// The paywall entry points that `performanceOptimizedPaywalls` serves from a pre-rendered page.
+    ///
+    /// The page is rendered ahead of time, so the decisions it used to make on load — which feature to
+    /// emphasise, whether to offer a trial, whether to list Personal Information Removal — have to be
+    /// stated in the URL before it opens.
+    public enum PerformanceOptimizedPaywallEntryPoint: String, CaseIterable {
+        case vpn
+        case duckai
+
+        /// Resolves the entry point a `featurePage` query item stands for, or `nil` when the pre-rendered
+        /// pages don't cover it (`winback`, say) and today's client-rendered paywall should be kept.
+        init?(featurePage: String?) {
+            guard let featurePage else {
+                self = .vpn
+                return
+            }
+            guard let entryPoint = Self(rawValue: featurePage) else { return nil }
+            self = entryPoint
+        }
+    }
+
+    /// Paths of the pre-rendered paywall pages.
+    ///
+    /// Remote config supplies these, so the frontend can move the pages without an app release. The
+    /// values in ``default`` are the fallback for when config carries no path.
+    public struct PerformanceOptimizedPaywallPaths: Equatable {
+
+        public static let `default` = PerformanceOptimizedPaywallPaths(vpn: "/subscriptions/new/mobile/vpn",
+                                                                      duckai: "/subscriptions/new/mobile/duckai")
+
+        public let vpn: String
+        public let duckai: String
+
+        public init(vpn: String, duckai: String) {
+            self.vpn = vpn
+            self.duckai = duckai
+        }
+
+        public func path(for entryPoint: PerformanceOptimizedPaywallEntryPoint) -> String {
+            switch entryPoint {
+            case .vpn: vpn
+            case .duckai: duckai
+            }
+        }
+    }
+
+    /// Rewrites a first-paywall URL onto its pre-rendered page.
+    ///
+    /// Reads the entry point off the URL's `featurePage` query item, swaps in that page's path and states
+    /// `trial` and — when Personal Information Removal is missing from the offering — `pir`. Every other
+    /// query item, `origin` included, is carried over untouched. `featurePage` is dropped: the path now
+    /// carries the emphasis.
+    ///
+    /// - Returns: The rewritten URL, or `nil` when the pre-rendered pages don't cover this URL and the
+    ///   caller should keep the one it has.
+    public static func performanceOptimizedPaywallURL(basedOn url: URL,
+                                                      paths: PerformanceOptimizedPaywallPaths = .default,
+                                                      isTrialEligible: Bool,
+                                                      isPersonalInformationRemovalAvailable: Bool) -> URL? {
+        guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else { return nil }
+
+        let queryItems = components.queryItems ?? []
+        let featurePage = queryItems.first { $0.name == QueryParameter.featurePage }?.value
+
+        guard let entryPoint = PerformanceOptimizedPaywallEntryPoint(featurePage: featurePage) else { return nil }
+
+        components.path = paths.path(for: entryPoint)
+
+        var rewrittenQueryItems = queryItems.filter { $0.name != QueryParameter.featurePage }
+        rewrittenQueryItems.append(URLQueryItem(name: QueryParameter.trial, value: String(isTrialEligible)))
+        if !isPersonalInformationRemovalAvailable {
+            rewrittenQueryItems.append(URLQueryItem(name: QueryParameter.personalInformationRemoval, value: "false"))
+        }
+        components.queryItems = rewrittenQueryItems
+
+        return components.url
+    }
+}

--- a/SharedPackages/BrowserServicesKit/Sources/Subscription/SubscriptionURL+PerformanceOptimizedPaywall.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Subscription/SubscriptionURL+PerformanceOptimizedPaywall.swift
@@ -28,6 +28,7 @@ extension SubscriptionURL {
     public enum PerformanceOptimizedPaywallEntryPoint: String, CaseIterable {
         case vpn
         case duckai
+        case pir
 
         /// Resolves the entry point a `featurePage` query item stands for, or `nil` when the pre-rendered
         /// pages don't cover it (`winback`, say) and today's client-rendered paywall should be kept.
@@ -48,20 +49,24 @@ extension SubscriptionURL {
     public struct PerformanceOptimizedPaywallPaths: Equatable {
 
         public static let `default` = PerformanceOptimizedPaywallPaths(vpn: "/subscriptions/new/mobile/vpn",
-                                                                      duckai: "/subscriptions/new/mobile/duckai")
+                                                                      duckai: "/subscriptions/new/mobile/duckai",
+                                                                      pir: "/subscriptions/new/mobile/pir")
 
         public let vpn: String
         public let duckai: String
+        public let pir: String
 
-        public init(vpn: String, duckai: String) {
+        public init(vpn: String, duckai: String, pir: String) {
             self.vpn = vpn
             self.duckai = duckai
+            self.pir = pir
         }
 
         public func path(for entryPoint: PerformanceOptimizedPaywallEntryPoint) -> String {
             switch entryPoint {
             case .vpn: vpn
             case .duckai: duckai
+            case .pir: pir
             }
         }
     }
@@ -70,8 +75,8 @@ extension SubscriptionURL {
     ///
     /// Reads the entry point off the URL's `featurePage` query item, swaps in that page's path and states
     /// `trial` and — when Personal Information Removal is missing from the offering — `pir`. Every other
-    /// query item, `origin` included, is carried over untouched. `featurePage` is dropped: the path now
-    /// carries the emphasis.
+    /// query item, `origin` included, is carried over untouched, in its original order. `featurePage` is
+    /// dropped: the path now carries the emphasis.
     ///
     /// - Returns: The rewritten URL, or `nil` when the pre-rendered pages don't cover this URL and the
     ///   caller should keep the one it has.
@@ -88,7 +93,9 @@ extension SubscriptionURL {
 
         components.path = paths.path(for: entryPoint)
 
-        var rewrittenQueryItems = queryItems.filter { $0.name != QueryParameter.featurePage }
+        // Drops the three names this rewrite owns, so `trial` and `pir` are stated exactly once even if
+        // the URL arrived carrying them. Nothing else is removed.
+        var rewrittenQueryItems = queryItems.filter { !QueryParameter.rewritten.contains($0.name) }
         rewrittenQueryItems.append(URLQueryItem(name: QueryParameter.trial, value: String(isTrialEligible)))
         if !isPersonalInformationRemovalAvailable {
             rewrittenQueryItems.append(URLQueryItem(name: QueryParameter.personalInformationRemoval, value: "false"))

--- a/SharedPackages/BrowserServicesKit/Sources/Subscription/SubscriptionURL+PerformanceOptimizedPaywall.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Subscription/SubscriptionURL+PerformanceOptimizedPaywall.swift
@@ -69,6 +69,24 @@ extension SubscriptionURL {
             case .pir: pir
             }
         }
+
+        /// Converts a pre-rendered paywall URL into the canonical redirect understood by the native purchase flow.
+        public func purchaseRedirectComponents(from components: URLComponents) -> URLComponents? {
+            guard let entryPoint = entryPoint(for: components.path) else { return nil }
+
+            var redirectComponents = components
+            redirectComponents.path = SubscriptionPurchaseFlowPath.purchase.rawValue
+
+            var queryItems = redirectComponents.percentEncodedQueryItems ?? []
+            queryItems.removeAll { $0.name == QueryParameter.featurePage }
+            queryItems.append(URLQueryItem(name: QueryParameter.featurePage, value: entryPoint.rawValue))
+            redirectComponents.percentEncodedQueryItems = queryItems
+            return redirectComponents
+        }
+
+        private func entryPoint(for path: String) -> PerformanceOptimizedPaywallEntryPoint? {
+            PerformanceOptimizedPaywallEntryPoint.allCases.first { self.path(for: $0) == path }
+        }
     }
 
     /// Rewrites a first-paywall URL onto its pre-rendered page.

--- a/SharedPackages/BrowserServicesKit/Sources/Subscription/SubscriptionURL.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Subscription/SubscriptionURL.swift
@@ -212,6 +212,10 @@ extension SubscriptionURL {
         static let trial = "trial"
         /// Only ever `false`, and only when the offering excludes Personal Information Removal.
         static let personalInformationRemoval = "pir"
+
+        /// The names a pre-rendered paywall URL states for itself, and so drops from the URL it is
+        /// built from. Every other query item is carried over.
+        static let rewritten = [featurePage, trial, personalInformationRemoval]
     }
 }
 

--- a/SharedPackages/BrowserServicesKit/Sources/Subscription/SubscriptionURL.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/Subscription/SubscriptionURL.swift
@@ -158,7 +158,7 @@ extension SubscriptionURL {
             url = url.appendingParameter(name: AttributionParameter.origin, value: origin)
         }
         if let featurePage = featurePage {
-            url = url.appendingParameter(name: "featurePage", value: featurePage)
+            url = url.appendingParameter(name: QueryParameter.featurePage, value: featurePage)
         }
         return URLComponents(url: url, resolvingAgainstBaseURL: false)
     }
@@ -204,6 +204,15 @@ extension SubscriptionURL {
     public enum FeaturePage {
         public static let winback = "winback"
     }
+
+    /// Query item names the subscription pages read off the URL they are opened with.
+    enum QueryParameter {
+        static let featurePage = "featurePage"
+        /// Whether the user is eligible for a free trial. Always stated on a pre-rendered paywall.
+        static let trial = "trial"
+        /// Only ever `false`, and only when the offering excludes Personal Information Removal.
+        static let personalInformationRemoval = "pir"
+    }
 }
 
 fileprivate extension URL {
@@ -229,7 +238,14 @@ extension URL {
         if let queryItems = components.queryItems, !queryItems.isEmpty {
             // `experiment_mobileannualtrials2_ios` is the monthly free-trial experiment cohort param;
             // like `origin` it's appended to loaded URLs and must be ignored when matching screens.
-            components.queryItems = queryItems.filter { !["environment", "origin", "using", "experiment_mobileannualtrials2_ios"].contains($0.name) }
+            // `trial` and `pir` pick what a pre-rendered paywall reveals, not which page it is.
+            let ignoredNames = ["environment",
+                                "origin",
+                                "using",
+                                "experiment_mobileannualtrials2_ios",
+                                SubscriptionURL.QueryParameter.trial,
+                                SubscriptionURL.QueryParameter.personalInformationRemoval]
+            components.queryItems = queryItems.filter { !ignoredNames.contains($0.name) }
             if components.queryItems?.isEmpty ?? true {
                 components.queryItems = nil
             }

--- a/SharedPackages/BrowserServicesKit/Tests/BrowserServicesKitTests/Subscription/PerformanceOptimizedPaywallsProviderTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/BrowserServicesKitTests/Subscription/PerformanceOptimizedPaywallsProviderTests.swift
@@ -1,0 +1,126 @@
+//
+//  PerformanceOptimizedPaywallsProviderTests.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+import PrivacyConfig
+import PrivacyConfigTestsUtils
+import Subscription
+@testable import BrowserServicesKit
+
+final class PerformanceOptimizedPaywallsProviderTests: XCTestCase {
+
+    private var privacyConfig: MockPrivacyConfiguration!
+    private var privacyConfigurationManager: MockPrivacyConfigurationManager!
+
+    override func setUp() {
+        super.setUp()
+        privacyConfig = MockPrivacyConfiguration()
+        privacyConfigurationManager = MockPrivacyConfigurationManager(
+            privacyConfig: privacyConfig,
+            internalUserDecider: DefaultInternalUserDecider(store: MockInternalUserStoring())
+        )
+    }
+
+    override func tearDown() {
+        privacyConfig = nil
+        privacyConfigurationManager = nil
+        super.tearDown()
+    }
+
+    // MARK: - isEnabled
+
+    func testIsEnabledReflectsTheFeatureFlag() {
+        XCTAssertTrue(makeProvider(isFeatureEnabled: true).isEnabled)
+        XCTAssertFalse(makeProvider(isFeatureEnabled: false).isEnabled)
+    }
+
+    // MARK: - Paths
+
+    func testPathsComeFromSettings() {
+        // Given
+        privacyConfig.subfeatureSettings = """
+        {
+            "entryPoints": {
+                "vpn": { "path": "/subscriptions/new/mobile/vpn" },
+                "duckai": { "path": "/subscriptions/new/mobile/duckai" }
+            }
+        }
+        """
+
+        // When
+        let paths = makeProvider().paths
+
+        // Then
+        XCTAssertEqual(paths, SubscriptionURL.PerformanceOptimizedPaywallPaths(vpn: "/subscriptions/new/mobile/vpn",
+                                                                              duckai: "/subscriptions/new/mobile/duckai"))
+    }
+
+    func testPathsFallBackWhenSettingsAreAbsent() {
+        // Given
+        privacyConfig.subfeatureSettings = nil
+
+        // When
+        let paths = makeProvider().paths
+
+        // Then
+        XCTAssertEqual(paths, .default)
+    }
+
+    func testEachPathFallsBackIndependently() {
+        // Given
+        privacyConfig.subfeatureSettings = """
+        { "entryPoints": { "duckai": { "path": "/subscriptions/v2/duckai" } } }
+        """
+
+        // When
+        let paths = makeProvider().paths
+
+        // Then
+        XCTAssertEqual(paths.vpn, SubscriptionURL.PerformanceOptimizedPaywallPaths.default.vpn)
+        XCTAssertEqual(paths.duckai, "/subscriptions/v2/duckai")
+    }
+
+    func testPathsFallBackWhenSettingsAreNotValidJSON() {
+        // Given
+        privacyConfig.subfeatureSettings = "not json"
+
+        // When
+        let paths = makeProvider().paths
+
+        // Then
+        XCTAssertEqual(paths, .default)
+    }
+
+    func testPathsFallBackWhenSettingsCarryNoEntryPoints() {
+        // Given
+        privacyConfig.subfeatureSettings = "{}"
+
+        // When
+        let paths = makeProvider().paths
+
+        // Then
+        XCTAssertEqual(paths, .default)
+    }
+
+    // MARK: - Helpers
+
+    private func makeProvider(isFeatureEnabled: Bool = true) -> DefaultPerformanceOptimizedPaywallsProvider {
+        DefaultPerformanceOptimizedPaywallsProvider(privacyConfigurationManager: privacyConfigurationManager,
+                                                    isFeatureEnabled: { isFeatureEnabled })
+    }
+}

--- a/SharedPackages/BrowserServicesKit/Tests/BrowserServicesKitTests/Subscription/PerformanceOptimizedPaywallsProviderTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/BrowserServicesKitTests/Subscription/PerformanceOptimizedPaywallsProviderTests.swift
@@ -145,6 +145,14 @@ final class PerformanceOptimizedPaywallsProviderTests: XCTestCase {
 
     private func makeProvider(isFeatureEnabled: Bool = true) -> DefaultPerformanceOptimizedPaywallsProvider {
         DefaultPerformanceOptimizedPaywallsProvider(privacyConfigurationManager: privacyConfigurationManager,
-                                                    isFeatureEnabled: { isFeatureEnabled })
+                                                    featureFlagger: MockPerformanceOptimizedPaywallsFeatureFlagger(isEnabled: isFeatureEnabled))
+    }
+}
+
+private struct MockPerformanceOptimizedPaywallsFeatureFlagger: PerformanceOptimizedPaywallsFeatureFlagging {
+    let isPerformanceOptimizedPaywallsEnabled: Bool
+
+    init(isEnabled: Bool) {
+        isPerformanceOptimizedPaywallsEnabled = isEnabled
     }
 }

--- a/SharedPackages/BrowserServicesKit/Tests/BrowserServicesKitTests/Subscription/PerformanceOptimizedPaywallsProviderTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/BrowserServicesKitTests/Subscription/PerformanceOptimizedPaywallsProviderTests.swift
@@ -53,11 +53,13 @@ final class PerformanceOptimizedPaywallsProviderTests: XCTestCase {
 
     func testPathsComeFromSettings() {
         // Given
+        // The shape shipped in `privacyPro.performanceOptimizedPaywalls.settings`.
         privacyConfig.subfeatureSettings = """
         {
             "entryPoints": {
                 "vpn": { "path": "/subscriptions/new/mobile/vpn" },
-                "duckai": { "path": "/subscriptions/new/mobile/duckai" }
+                "duckai": { "path": "/subscriptions/new/mobile/duckai" },
+                "pir": { "path": "/subscriptions/new/mobile/pir" }
             }
         }
         """
@@ -67,7 +69,8 @@ final class PerformanceOptimizedPaywallsProviderTests: XCTestCase {
 
         // Then
         XCTAssertEqual(paths, SubscriptionURL.PerformanceOptimizedPaywallPaths(vpn: "/subscriptions/new/mobile/vpn",
-                                                                              duckai: "/subscriptions/new/mobile/duckai"))
+                                                                              duckai: "/subscriptions/new/mobile/duckai",
+                                                                              pir: "/subscriptions/new/mobile/pir"))
     }
 
     func testPathsFallBackWhenSettingsAreAbsent() {
@@ -93,6 +96,27 @@ final class PerformanceOptimizedPaywallsProviderTests: XCTestCase {
         // Then
         XCTAssertEqual(paths.vpn, SubscriptionURL.PerformanceOptimizedPaywallPaths.default.vpn)
         XCTAssertEqual(paths.duckai, "/subscriptions/v2/duckai")
+        XCTAssertEqual(paths.pir, SubscriptionURL.PerformanceOptimizedPaywallPaths.default.pir)
+    }
+
+    func testPirPathFallsBackWhileTheOthersAreConfigured() {
+        // Given
+        privacyConfig.subfeatureSettings = """
+        {
+            "entryPoints": {
+                "vpn": { "path": "/subscriptions/v2/vpn" },
+                "duckai": { "path": "/subscriptions/v2/duckai" }
+            }
+        }
+        """
+
+        // When
+        let paths = makeProvider().paths
+
+        // Then
+        XCTAssertEqual(paths.vpn, "/subscriptions/v2/vpn")
+        XCTAssertEqual(paths.duckai, "/subscriptions/v2/duckai")
+        XCTAssertEqual(paths.pir, SubscriptionURL.PerformanceOptimizedPaywallPaths.default.pir)
     }
 
     func testPathsFallBackWhenSettingsAreNotValidJSON() {

--- a/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/SubscriptionURLTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/SubscriptionURLTests.swift
@@ -377,7 +377,7 @@ final class SubscriptionURLTests: XCTestCase {
         XCTAssertEqual(components?.url, expectedURL)
     }
 
-    // MARK: - First paywall, performance-optimized (not implemented)
+    // MARK: - First paywall, performance-optimized
 
     // With `performanceOptimizedPaywalls` on, the two entry points this app opens itself become:
     //
@@ -390,33 +390,121 @@ final class SubscriptionURLTests: XCTestCase {
     //
     // Everything else keeps today's URL: other featurePages, intercepted `/pro` links, desktop.
 
-    /// Delete the `XCTSkipIf` and replace the `XCTFail` with assertions against whatever builds them.
     func testFirstPaywallURLsWhenPerformanceOptimizedPaywallsIsOn() throws {
-        try XCTSkipIf(true, "Pending: the server-rendered first paywall is not implemented")
+        // Given
+        let vpn = SubscriptionURL.purchase.subscriptionURL(environment: .production)
+        let duckai = try XCTUnwrap(SubscriptionURL.purchaseURLComponentsWithOriginAndFeaturePage(origin: nil,
+                                                                                                featurePage: "duckai",
+                                                                                                environment: .production)?.url)
 
-        let required = [
-            "https://duckduckgo.com/subscriptions/new/mobile/vpn?trial=false",
-            "https://duckduckgo.com/subscriptions/new/mobile/vpn?trial=true",
-            "https://duckduckgo.com/subscriptions/new/mobile/vpn?trial=false&pir=false",
-            "https://duckduckgo.com/subscriptions/new/mobile/vpn?trial=true&pir=false",
-            "https://duckduckgo.com/subscriptions/new/mobile/duckai?trial=false",
-            "https://duckduckgo.com/subscriptions/new/mobile/duckai?trial=true",
-            "https://duckduckgo.com/subscriptions/new/mobile/duckai?trial=false&pir=false",
-            "https://duckduckgo.com/subscriptions/new/mobile/duckai?trial=true&pir=false"
+        let cases: [(url: URL, isTrialEligible: Bool, isPIRAvailable: Bool, expected: String)] = [
+            (vpn, false, true, "https://duckduckgo.com/subscriptions/new/mobile/vpn?trial=false"),
+            (vpn, true, true, "https://duckduckgo.com/subscriptions/new/mobile/vpn?trial=true"),
+            (vpn, false, false, "https://duckduckgo.com/subscriptions/new/mobile/vpn?trial=false&pir=false"),
+            (vpn, true, false, "https://duckduckgo.com/subscriptions/new/mobile/vpn?trial=true&pir=false"),
+            (duckai, false, true, "https://duckduckgo.com/subscriptions/new/mobile/duckai?trial=false"),
+            (duckai, true, true, "https://duckduckgo.com/subscriptions/new/mobile/duckai?trial=true"),
+            (duckai, false, false, "https://duckduckgo.com/subscriptions/new/mobile/duckai?trial=false&pir=false"),
+            (duckai, true, false, "https://duckduckgo.com/subscriptions/new/mobile/duckai?trial=true&pir=false")
         ]
 
-        XCTFail("Nothing produces the server-rendered first paywall URLs yet: \(required.joined(separator: ", "))")
+        for testCase in cases {
+            // When
+            let url = SubscriptionURL.performanceOptimizedPaywallURL(basedOn: testCase.url,
+                                                                     isTrialEligible: testCase.isTrialEligible,
+                                                                     isPersonalInformationRemovalAvailable: testCase.isPIRAvailable)
+
+            // Then
+            XCTAssertEqual(url?.absoluteString, testCase.expected)
+        }
     }
 
     /// `trial` and `pir` pick what the page reveals, not which page it is, so screen matching has to
-    /// ignore them. Already a real assertion: delete the `XCTSkipIf` and it fails.
+    /// ignore them.
     func testForComparisonIgnoresFirstPaywallStateParameters() throws {
-        try XCTSkipIf(true, "Pending: forComparison() does not ignore trial and pir yet")
-
         let page = URL(string: "https://duckduckgo.com/subscriptions/new/mobile/vpn")!
         let pageWithState = URL(string: "https://duckduckgo.com/subscriptions/new/mobile/vpn?trial=true&pir=false")!
 
         XCTAssertEqual(pageWithState.forComparison(), page.forComparison())
+    }
+
+    func testFirstPaywallURLKeepsOriginAndDropsFeaturePage() throws {
+        // Given
+        let origin = "funnel_appsettings_ios"
+        let purchaseURL = try XCTUnwrap(SubscriptionURL.purchaseURLComponentsWithOriginAndFeaturePage(origin: origin,
+                                                                                                     featurePage: "duckai",
+                                                                                                     environment: .production)?.url)
+
+        // When
+        let url = SubscriptionURL.performanceOptimizedPaywallURL(basedOn: purchaseURL,
+                                                                 isTrialEligible: true,
+                                                                 isPersonalInformationRemovalAvailable: true)
+
+        // Then
+        XCTAssertEqual(url?.absoluteString,
+                       "https://duckduckgo.com/subscriptions/new/mobile/duckai?origin=funnel_appsettings_ios&trial=true")
+    }
+
+    func testFirstPaywallURLKeepsStagingEnvironment() throws {
+        // Given
+        let purchaseURL = SubscriptionURL.purchase.subscriptionURL(environment: .staging)
+
+        // When
+        let url = SubscriptionURL.performanceOptimizedPaywallURL(basedOn: purchaseURL,
+                                                                 isTrialEligible: false,
+                                                                 isPersonalInformationRemovalAvailable: true)
+
+        // Then
+        XCTAssertEqual(url?.absoluteString,
+                       "https://duckduckgo.com/subscriptions/new/mobile/vpn?environment=staging&trial=false")
+    }
+
+    func testFirstPaywallURLUsesCustomBaseURL() throws {
+        // Given
+        let customBaseURL = URL(string: "https://sdz0qh1x-80.eun1.devtunnels.ms/subscriptions")!
+        let purchaseURL = SubscriptionURL.purchase.subscriptionURL(withCustomBaseURL: customBaseURL, environment: .production)
+
+        // When
+        let url = SubscriptionURL.performanceOptimizedPaywallURL(basedOn: purchaseURL,
+                                                                 isTrialEligible: true,
+                                                                 isPersonalInformationRemovalAvailable: true)
+
+        // Then
+        XCTAssertEqual(url?.absoluteString,
+                       "https://sdz0qh1x-80.eun1.devtunnels.ms/subscriptions/new/mobile/vpn?trial=true")
+    }
+
+    func testFirstPaywallURLUsesConfiguredPaths() throws {
+        // Given
+        let paths = SubscriptionURL.PerformanceOptimizedPaywallPaths(vpn: "/subscriptions/v2/vpn",
+                                                                    duckai: "/subscriptions/v2/duckai")
+        let purchaseURL = SubscriptionURL.purchase.subscriptionURL(environment: .production)
+
+        // When
+        let url = SubscriptionURL.performanceOptimizedPaywallURL(basedOn: purchaseURL,
+                                                                 paths: paths,
+                                                                 isTrialEligible: false,
+                                                                 isPersonalInformationRemovalAvailable: true)
+
+        // Then
+        XCTAssertEqual(url?.absoluteString, "https://duckduckgo.com/subscriptions/v2/vpn?trial=false")
+    }
+
+    func testFirstPaywallURLIsNotProducedForOtherFeaturePages() throws {
+        // Given
+        let purchaseURL = try XCTUnwrap(SubscriptionURL.purchaseURLComponentsWithOriginAndFeaturePage(
+            origin: nil,
+            featurePage: SubscriptionURL.FeaturePage.winback,
+            environment: .production
+        )?.url)
+
+        // When
+        let url = SubscriptionURL.performanceOptimizedPaywallURL(basedOn: purchaseURL,
+                                                                 isTrialEligible: true,
+                                                                 isPersonalInformationRemovalAvailable: true)
+
+        // Then
+        XCTAssertNil(url)
     }
 
     func testPurchaseURLComponentsWithOnlyOrigin() throws {

--- a/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/SubscriptionURLTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/SubscriptionURLTests.swift
@@ -377,6 +377,75 @@ final class SubscriptionURLTests: XCTestCase {
         XCTAssertEqual(components?.url, expectedURL)
     }
 
+    // MARK: - First paywall, performance-optimized (not implemented)
+
+    // The `performanceOptimizedPaywalls` flag is wired but unread. When it is on, the two first-paywall
+    // entry points this app opens itself have to be opened at a URL that names the page and states
+    // what the page would otherwise resolve after mount, instead of `/subscriptions` plus a
+    // `featurePage` item.
+    //
+    //     entry point                     URL
+    //     ---------------------------------------------------------------------------------
+    //     VPN      (no featurePage)       /subscriptions/new/mobile/vpn
+    //     Duck.ai  (featurePage=duckai)   /subscriptions/new/mobile/duckai
+    //
+    //     query item   values                when
+    //     ---------------------------------------------------------------------------------
+    //     trial        true | false          always, whichever it is
+    //     pir          false                 only when the offering excludes Personal Information
+    //                                        Removal; the page shows PIR unless told otherwise
+    //     origin       unchanged             carried as it is today
+    //
+    // So the full set is eight URLs, e.g.
+    //
+    //     https://duckduckgo.com/subscriptions/new/mobile/vpn?trial=false
+    //     https://duckduckgo.com/subscriptions/new/mobile/duckai?trial=true&pir=false
+    //
+    // `trial` is whether the offering includes a free trial; `pir` is whether it includes Personal
+    // Information Removal, which is sold in the USA storefront and not in the rest of the world. Both
+    // have to be settled before the URL is opened — that is the whole point, since the page ships
+    // both CTA labels and both feature lists and reveals one from the URL. Where they are read from,
+    // whether the store is allowed to be waited on, and what happens when it never answers are open
+    // questions, deliberately not answered here.
+    //
+    // What must not move: `pir`, `stripe` and `winback` featurePages, intercepted `/pro` links, and
+    // every desktop entry point stay on the URL they use today. The first two create or refresh a
+    // cart account on mount, which would make a load-time comparison measure the network.
+
+    /// Skipped until something produces the URLs above. Delete the `XCTSkipIf` to see it fail, then
+    /// replace the `XCTFail` with assertions against whatever ends up building them.
+    func testFirstPaywallURLsWhenPerformanceOptimizedPaywallsIsOn() throws {
+        try XCTSkipIf(true, "Pending: the server-rendered first paywall is not implemented")
+
+        let required = [
+            "https://duckduckgo.com/subscriptions/new/mobile/vpn?trial=false",
+            "https://duckduckgo.com/subscriptions/new/mobile/vpn?trial=true",
+            "https://duckduckgo.com/subscriptions/new/mobile/vpn?trial=false&pir=false",
+            "https://duckduckgo.com/subscriptions/new/mobile/vpn?trial=true&pir=false",
+            "https://duckduckgo.com/subscriptions/new/mobile/duckai?trial=false",
+            "https://duckduckgo.com/subscriptions/new/mobile/duckai?trial=true",
+            "https://duckduckgo.com/subscriptions/new/mobile/duckai?trial=false&pir=false",
+            "https://duckduckgo.com/subscriptions/new/mobile/duckai?trial=true&pir=false"
+        ]
+
+        XCTFail("Nothing produces the server-rendered first paywall URLs yet: \(required.joined(separator: ", "))")
+    }
+
+    /// Skipped until the state items are ignored when matching screens. `trial` and `pir` choose what
+    /// the page reveals, not which page it is, so every "am I on the purchase screen?" check — and
+    /// the offer-screen impression that the whole comparison is read from — has to see through them.
+    ///
+    /// This one is a real assertion already: delete the `XCTSkipIf` and it fails against today's
+    /// `forComparison()`.
+    func testForComparisonIgnoresFirstPaywallStateParameters() throws {
+        try XCTSkipIf(true, "Pending: forComparison() does not ignore trial and pir yet")
+
+        let page = URL(string: "https://duckduckgo.com/subscriptions/new/mobile/vpn")!
+        let pageWithState = URL(string: "https://duckduckgo.com/subscriptions/new/mobile/vpn?trial=true&pir=false")!
+
+        XCTAssertEqual(pageWithState.forComparison(), page.forComparison())
+    }
+
     func testPurchaseURLComponentsWithOnlyOrigin() throws {
         // Given
         let origin = "funnel_appsettings_ios"

--- a/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/SubscriptionURLTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/SubscriptionURLTests.swift
@@ -379,41 +379,18 @@ final class SubscriptionURLTests: XCTestCase {
 
     // MARK: - First paywall, performance-optimized (not implemented)
 
-    // The `performanceOptimizedPaywalls` flag is wired but unread. When it is on, the two first-paywall
-    // entry points this app opens itself have to be opened at a URL that names the page and states
-    // what the page would otherwise resolve after mount, instead of `/subscriptions` plus a
-    // `featurePage` item.
+    // With `performanceOptimizedPaywalls` on, the two entry points this app opens itself become:
     //
-    //     entry point                     URL
-    //     ---------------------------------------------------------------------------------
-    //     VPN      (no featurePage)       /subscriptions/new/mobile/vpn
-    //     Duck.ai  (featurePage=duckai)   /subscriptions/new/mobile/duckai
+    //     VPN      (no featurePage)      /subscriptions/new/mobile/vpn
+    //     Duck.ai  (featurePage=duckai)  /subscriptions/new/mobile/duckai
     //
-    //     query item   values                when
-    //     ---------------------------------------------------------------------------------
-    //     trial        true | false          always, whichever it is
-    //     pir          false                 only when the offering excludes Personal Information
-    //                                        Removal; the page shows PIR unless told otherwise
-    //     origin       unchanged             carried as it is today
+    //     trial=true|false   always stated
+    //     pir=false          only when the offering excludes Personal Information Removal
+    //     origin             unchanged
     //
-    // So the full set is eight URLs, e.g.
-    //
-    //     https://duckduckgo.com/subscriptions/new/mobile/vpn?trial=false
-    //     https://duckduckgo.com/subscriptions/new/mobile/duckai?trial=true&pir=false
-    //
-    // `trial` is whether the offering includes a free trial; `pir` is whether it includes Personal
-    // Information Removal, which is sold in the USA storefront and not in the rest of the world. Both
-    // have to be settled before the URL is opened — that is the whole point, since the page ships
-    // both CTA labels and both feature lists and reveals one from the URL. Where they are read from,
-    // whether the store is allowed to be waited on, and what happens when it never answers are open
-    // questions, deliberately not answered here.
-    //
-    // What must not move: `pir`, `stripe` and `winback` featurePages, intercepted `/pro` links, and
-    // every desktop entry point stay on the URL they use today. The first two create or refresh a
-    // cart account on mount, which would make a load-time comparison measure the network.
+    // Everything else keeps today's URL: other featurePages, intercepted `/pro` links, desktop.
 
-    /// Skipped until something produces the URLs above. Delete the `XCTSkipIf` to see it fail, then
-    /// replace the `XCTFail` with assertions against whatever ends up building them.
+    /// Delete the `XCTSkipIf` and replace the `XCTFail` with assertions against whatever builds them.
     func testFirstPaywallURLsWhenPerformanceOptimizedPaywallsIsOn() throws {
         try XCTSkipIf(true, "Pending: the server-rendered first paywall is not implemented")
 
@@ -431,12 +408,8 @@ final class SubscriptionURLTests: XCTestCase {
         XCTFail("Nothing produces the server-rendered first paywall URLs yet: \(required.joined(separator: ", "))")
     }
 
-    /// Skipped until the state items are ignored when matching screens. `trial` and `pir` choose what
-    /// the page reveals, not which page it is, so every "am I on the purchase screen?" check — and
-    /// the offer-screen impression that the whole comparison is read from — has to see through them.
-    ///
-    /// This one is a real assertion already: delete the `XCTSkipIf` and it fails against today's
-    /// `forComparison()`.
+    /// `trial` and `pir` pick what the page reveals, not which page it is, so screen matching has to
+    /// ignore them. Already a real assertion: delete the `XCTSkipIf` and it fails.
     func testForComparisonIgnoresFirstPaywallStateParameters() throws {
         try XCTSkipIf(true, "Pending: forComparison() does not ignore trial and pir yet")
 

--- a/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/SubscriptionURLTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/SubscriptionURLTests.swift
@@ -379,16 +379,19 @@ final class SubscriptionURLTests: XCTestCase {
 
     // MARK: - First paywall, performance-optimized
 
-    // With `performanceOptimizedPaywalls` on, the two entry points this app opens itself become:
+    // With `performanceOptimizedPaywalls` on, the first paywall's three entry points become:
     //
     //     VPN      (no featurePage)      /subscriptions/new/mobile/vpn
     //     Duck.ai  (featurePage=duckai)  /subscriptions/new/mobile/duckai
+    //     PIR      (featurePage=pir)     /subscriptions/new/mobile/pir
     //
     //     trial=true|false   always stated
     //     pir=false          only when the offering excludes Personal Information Removal
-    //     origin             unchanged
+    //     origin             unchanged, along with every other query item
     //
-    // Everything else keeps today's URL: other featurePages, intercepted `/pro` links, desktop.
+    // Any other featurePage — `winback`, or one the frontend adds later — resolves to no entry point,
+    // so the rewrite returns nil and the caller keeps today's client-rendered URL. Intercepted `/pro`
+    // links are held back by the caller, in `SubscriptionContainerViewFactory`; desktop is untouched.
 
     func testFirstPaywallURLsWhenPerformanceOptimizedPaywallsIsOn() throws {
         // Given
@@ -396,7 +399,13 @@ final class SubscriptionURLTests: XCTestCase {
         let duckai = try XCTUnwrap(SubscriptionURL.purchaseURLComponentsWithOriginAndFeaturePage(origin: nil,
                                                                                                 featurePage: "duckai",
                                                                                                 environment: .production)?.url)
+        let pir = try XCTUnwrap(SubscriptionURL.purchaseURLComponentsWithOriginAndFeaturePage(origin: nil,
+                                                                                              featurePage: "pir",
+                                                                                              environment: .production)?.url)
 
+        // `pir` entry point with `pir=false` doesn't arise in practice — a user the offering excludes
+        // Personal Information Removal from never reaches the dashboard that hands us that URL — but the
+        // rule is stated uniformly across the three entry points rather than special-cased.
         let cases: [(url: URL, isTrialEligible: Bool, isPIRAvailable: Bool, expected: String)] = [
             (vpn, false, true, "https://duckduckgo.com/subscriptions/new/mobile/vpn?trial=false"),
             (vpn, true, true, "https://duckduckgo.com/subscriptions/new/mobile/vpn?trial=true"),
@@ -405,7 +414,11 @@ final class SubscriptionURLTests: XCTestCase {
             (duckai, false, true, "https://duckduckgo.com/subscriptions/new/mobile/duckai?trial=false"),
             (duckai, true, true, "https://duckduckgo.com/subscriptions/new/mobile/duckai?trial=true"),
             (duckai, false, false, "https://duckduckgo.com/subscriptions/new/mobile/duckai?trial=false&pir=false"),
-            (duckai, true, false, "https://duckduckgo.com/subscriptions/new/mobile/duckai?trial=true&pir=false")
+            (duckai, true, false, "https://duckduckgo.com/subscriptions/new/mobile/duckai?trial=true&pir=false"),
+            (pir, false, true, "https://duckduckgo.com/subscriptions/new/mobile/pir?trial=false"),
+            (pir, true, true, "https://duckduckgo.com/subscriptions/new/mobile/pir?trial=true"),
+            (pir, false, false, "https://duckduckgo.com/subscriptions/new/mobile/pir?trial=false&pir=false"),
+            (pir, true, false, "https://duckduckgo.com/subscriptions/new/mobile/pir?trial=true&pir=false")
         ]
 
         for testCase in cases {
@@ -415,7 +428,7 @@ final class SubscriptionURLTests: XCTestCase {
                                                                      isPersonalInformationRemovalAvailable: testCase.isPIRAvailable)
 
             // Then
-            XCTAssertEqual(url?.absoluteString, testCase.expected)
+            XCTAssertEqual(url?.absoluteString, testCase.expected, "built from \(testCase.url.absoluteString)")
         }
     }
 
@@ -477,17 +490,67 @@ final class SubscriptionURLTests: XCTestCase {
     func testFirstPaywallURLUsesConfiguredPaths() throws {
         // Given
         let paths = SubscriptionURL.PerformanceOptimizedPaywallPaths(vpn: "/subscriptions/v2/vpn",
-                                                                    duckai: "/subscriptions/v2/duckai")
+                                                                    duckai: "/subscriptions/v2/duckai",
+                                                                    pir: "/subscriptions/v2/pir")
         let purchaseURL = SubscriptionURL.purchase.subscriptionURL(environment: .production)
+        let pirPurchaseURL = try XCTUnwrap(SubscriptionURL.purchaseURLComponentsWithOriginAndFeaturePage(origin: nil,
+                                                                                                        featurePage: "pir",
+                                                                                                        environment: .production)?.url)
 
         // When
         let url = SubscriptionURL.performanceOptimizedPaywallURL(basedOn: purchaseURL,
                                                                  paths: paths,
                                                                  isTrialEligible: false,
                                                                  isPersonalInformationRemovalAvailable: true)
+        let pirURL = SubscriptionURL.performanceOptimizedPaywallURL(basedOn: pirPurchaseURL,
+                                                                    paths: paths,
+                                                                    isTrialEligible: false,
+                                                                    isPersonalInformationRemovalAvailable: true)
 
         // Then
         XCTAssertEqual(url?.absoluteString, "https://duckduckgo.com/subscriptions/v2/vpn?trial=false")
+        XCTAssertEqual(pirURL?.absoluteString, "https://duckduckgo.com/subscriptions/v2/pir?trial=false")
+    }
+
+    /// `featurePage`, `trial` and `pir` are the only names the rewrite owns. Everything the URL arrived
+    /// with — attribution, environment, experiment cohorts, whatever the frontend attached — carries
+    /// over in its original order.
+    func testFirstPaywallURLCarriesOverEveryOtherQueryItem() throws {
+        // Given
+        let purchaseURL = try XCTUnwrap(URL(string: "https://duckduckgo.com/subscriptions"
+                                            + "?origin=funnel_pir_ios"
+                                            + "&featurePage=pir"
+                                            + "&environment=staging"
+                                            + "&experiment_mobileannualtrials2_ios=treatment"
+                                            + "&using=something"))
+
+        // When
+        let url = SubscriptionURL.performanceOptimizedPaywallURL(basedOn: purchaseURL,
+                                                                 isTrialEligible: true,
+                                                                 isPersonalInformationRemovalAvailable: true)
+
+        // Then
+        XCTAssertEqual(url?.absoluteString, "https://duckduckgo.com/subscriptions/new/mobile/pir"
+                       + "?origin=funnel_pir_ios"
+                       + "&environment=staging"
+                       + "&experiment_mobileannualtrials2_ios=treatment"
+                       + "&using=something"
+                       + "&trial=true")
+    }
+
+    /// A URL that already states `trial` or `pir` gets the rewrite's answer, not a second copy alongside
+    /// the stale one.
+    func testFirstPaywallURLStatesTrialAndPIROnlyOnce() throws {
+        // Given
+        let purchaseURL = try XCTUnwrap(URL(string: "https://duckduckgo.com/subscriptions?trial=true&pir=true"))
+
+        // When
+        let url = SubscriptionURL.performanceOptimizedPaywallURL(basedOn: purchaseURL,
+                                                                 isTrialEligible: false,
+                                                                 isPersonalInformationRemovalAvailable: false)
+
+        // Then
+        XCTAssertEqual(url?.absoluteString, "https://duckduckgo.com/subscriptions/new/mobile/vpn?trial=false&pir=false")
     }
 
     func testFirstPaywallURLIsNotProducedForOtherFeaturePages() throws {

--- a/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/SubscriptionURLTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/SubscriptionURLTests.swift
@@ -379,20 +379,6 @@ final class SubscriptionURLTests: XCTestCase {
 
     // MARK: - First paywall, performance-optimized
 
-    // With `performanceOptimizedPaywalls` on, the first paywall's three entry points become:
-    //
-    //     VPN      (no featurePage)      /subscriptions/new/mobile/vpn
-    //     Duck.ai  (featurePage=duckai)  /subscriptions/new/mobile/duckai
-    //     PIR      (featurePage=pir)     /subscriptions/new/mobile/pir
-    //
-    //     trial=true|false   always stated
-    //     pir=false          only when the offering excludes Personal Information Removal
-    //     origin             unchanged, along with every other query item
-    //
-    // Any other featurePage — `winback`, or one the frontend adds later — resolves to no entry point,
-    // so the rewrite returns nil and the caller keeps today's client-rendered URL. Intercepted `/pro`
-    // links are held back by the caller, in `SubscriptionContainerViewFactory`; desktop is untouched.
-
     func testFirstPaywallURLsWhenPerformanceOptimizedPaywallsIsOn() throws {
         // Given
         let vpn = SubscriptionURL.purchase.subscriptionURL(environment: .production)
@@ -403,9 +389,7 @@ final class SubscriptionURLTests: XCTestCase {
                                                                                               featurePage: "pir",
                                                                                               environment: .production)?.url)
 
-        // `pir` entry point with `pir=false` doesn't arise in practice — a user the offering excludes
-        // Personal Information Removal from never reaches the dashboard that hands us that URL — but the
-        // rule is stated uniformly across the three entry points rather than special-cased.
+        // Keep the matrix uniform even though the PIR entry point cannot produce `pir=false` in practice.
         let cases: [(url: URL, isTrialEligible: Bool, isPIRAvailable: Bool, expected: String)] = [
             (vpn, false, true, "https://duckduckgo.com/subscriptions/new/mobile/vpn?trial=false"),
             (vpn, true, true, "https://duckduckgo.com/subscriptions/new/mobile/vpn?trial=true"),
@@ -432,8 +416,6 @@ final class SubscriptionURLTests: XCTestCase {
         }
     }
 
-    /// `trial` and `pir` pick what the page reveals, not which page it is, so screen matching has to
-    /// ignore them.
     func testForComparisonIgnoresFirstPaywallStateParameters() throws {
         let page = URL(string: "https://duckduckgo.com/subscriptions/new/mobile/vpn")!
         let pageWithState = URL(string: "https://duckduckgo.com/subscriptions/new/mobile/vpn?trial=true&pir=false")!
@@ -536,9 +518,6 @@ final class SubscriptionURLTests: XCTestCase {
         XCTAssertNil(paths.purchaseRedirectComponents(from: unknown))
     }
 
-    /// `featurePage`, `trial` and `pir` are the only names the rewrite owns. Everything the URL arrived
-    /// with — attribution, environment, experiment cohorts, whatever the frontend attached — carries
-    /// over in its original order.
     func testFirstPaywallURLCarriesOverEveryOtherQueryItem() throws {
         // Given
         let purchaseURL = try XCTUnwrap(URL(string: "https://duckduckgo.com/subscriptions"

--- a/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/SubscriptionURLTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/SubscriptionTests/SubscriptionURLTests.swift
@@ -512,6 +512,30 @@ final class SubscriptionURLTests: XCTestCase {
         XCTAssertEqual(pirURL?.absoluteString, "https://duckduckgo.com/subscriptions/v2/pir?trial=false")
     }
 
+    func testPerformanceOptimizedPaywallPathsMakePurchaseRedirectComponents() throws {
+        let paths = SubscriptionURL.PerformanceOptimizedPaywallPaths(vpn: "/subscriptions/v2/vpn",
+                                                                    duckai: "/subscriptions/v2/duckai",
+                                                                    pir: "/subscriptions/v2/pir")
+        let testCases = [
+            (path: "/subscriptions/v2/vpn", featurePage: "vpn"),
+            (path: "/subscriptions/v2/duckai", featurePage: "duckai"),
+            (path: "/subscriptions/v2/pir", featurePage: "pir")
+        ]
+
+        for testCase in testCases {
+            let source = try XCTUnwrap(URLComponents(
+                string: "https://duckduckgo.com\(testCase.path)?origin=test&featurePage=stale"))
+
+            let redirect = paths.purchaseRedirectComponents(from: source)
+
+            XCTAssertEqual(redirect?.url?.absoluteString,
+                           "https://duckduckgo.com/subscriptions?origin=test&featurePage=\(testCase.featurePage)")
+        }
+
+        let unknown = try XCTUnwrap(URLComponents(string: "https://duckduckgo.com/subscriptions/v2/unknown"))
+        XCTAssertNil(paths.purchaseRedirectComponents(from: unknown))
+    }
+
     /// `featurePage`, `trial` and `pir` are the only names the rewrite owns. Everything the URL arrived
     /// with — attribution, environment, experiment cohorts, whatever the frontend attached — carries
     /// over in its original order.

--- a/iOS/DuckDuckGo/DebugScreensViewModel+Screens.swift
+++ b/iOS/DuckDuckGo/DebugScreensViewModel+Screens.swift
@@ -259,7 +259,11 @@ extension DebugScreensViewModel {
             }),
             .controller(title: "Subscription", { dependencies in
                 let subscriptionDebugViewController = self.debugStoryboard.instantiateViewController(identifier: "SubscriptionDebugViewController") { coder in
-                    SubscriptionDebugViewController(coder: coder, subscriptionDataReporter: dependencies.subscriptionDataReporter)
+                    SubscriptionDebugViewController(
+                        coder: coder,
+                        subscriptionDataReporter: dependencies.subscriptionDataReporter,
+                        debugSettings: SubscriptionDebugSettingsUserDefaultsPersistor(keyValueStore: dependencies.keyValueStore)
+                    )
                 }
                 subscriptionDebugViewController.keyValueStore = dependencies.keyValueStore
                 return subscriptionDebugViewController

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -3937,6 +3937,10 @@ class MainViewController: UIViewController {
 
     private func makeDataBrokerProtectionSubscriptionFlowViewController(redirectURLComponents: URLComponents?) -> UIViewController {
         let subscriptionNavigationCoordinator = SubscriptionNavigationCoordinator()
+        let performanceOptimizedPaywallsProvider = DefaultPerformanceOptimizedPaywallsProvider(
+            privacyConfigurationManager: userScriptsDependencies.privacyConfigurationManager,
+            featureFlagger: featureFlagger
+        )
         let viewController = UIHostingController(rootView: SubscriptionContainerViewFactory.makePurchaseFlowV2(
             redirectURLComponents: redirectURLComponents,
             navigationCoordinator: subscriptionNavigationCoordinator,
@@ -3949,6 +3953,7 @@ class MainViewController: UIViewController {
             dataBrokerProtectionViewControllerProvider: dbpIOSPublicInterface,
             wideEvent: AppDependencyProvider.shared.wideEvent,
             featureFlagger: featureFlagger,
+            performanceOptimizedPaywallsProvider: performanceOptimizedPaywallsProvider,
             onboardingKeyValueStore: keyValueStore,
             meetsPIRLocaleRequirement: { [weak dbpIOSPublicInterface] in
                 dbpIOSPublicInterface?.meetsLocaleRequirement ?? false

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -3941,6 +3941,7 @@ class MainViewController: UIViewController {
             privacyConfigurationManager: userScriptsDependencies.privacyConfigurationManager,
             featureFlagger: featureFlagger
         )
+        let subscriptionDebugSettings = SubscriptionDebugSettingsUserDefaultsPersistor(keyValueStore: keyValueStore)
         let viewController = UIHostingController(rootView: SubscriptionContainerViewFactory.makePurchaseFlowV2(
             redirectURLComponents: redirectURLComponents,
             navigationCoordinator: subscriptionNavigationCoordinator,
@@ -3953,6 +3954,7 @@ class MainViewController: UIViewController {
             dataBrokerProtectionViewControllerProvider: dbpIOSPublicInterface,
             wideEvent: AppDependencyProvider.shared.wideEvent,
             featureFlagger: featureFlagger,
+            isDebugOverlayEnabled: subscriptionDebugSettings.isDebugOverlayEnabled,
             performanceOptimizedPaywallsProvider: performanceOptimizedPaywallsProvider,
             onboardingKeyValueStore: keyValueStore,
             meetsPIRLocaleRequirement: { [weak dbpIOSPublicInterface] in

--- a/iOS/DuckDuckGo/SettingsRootView.swift
+++ b/iOS/DuckDuckGo/SettingsRootView.swift
@@ -156,6 +156,7 @@ struct SettingsRootView: View {
             privacyConfigurationManager: viewModel.userScriptsDependencies.privacyConfigurationManager,
             featureFlagger: featureFlagger
         )
+        let subscriptionDebugSettings = SubscriptionDebugSettingsUserDefaultsPersistor(keyValueStore: viewModel.keyValueStore)
         SubscriptionContainerViewFactory.makeSubscribeFlowV2(redirectURLComponents: redirectURLComponents,
                                                              landingURL: landingURL,
                                                              navigationCoordinator: subscriptionNavigationCoordinator,
@@ -168,6 +169,7 @@ struct SettingsRootView: View {
                                                              dataBrokerProtectionViewControllerProvider: viewModel.dataBrokerProtectionViewControllerProvider,
                                                              wideEvent: AppDependencyProvider.shared.wideEvent,
                                                              featureFlagger: featureFlagger,
+                                                             isDebugOverlayEnabled: subscriptionDebugSettings.isDebugOverlayEnabled,
                                                              performanceOptimizedPaywallsProvider: performanceOptimizedPaywallsProvider,
                                                              onboardingKeyValueStore: viewModel.keyValueStore,
                                                              meetsPIRLocaleRequirement: { viewModel.meetsLocaleRequirement },

--- a/iOS/DuckDuckGo/SettingsRootView.swift
+++ b/iOS/DuckDuckGo/SettingsRootView.swift
@@ -19,6 +19,7 @@
 
 import SwiftUI
 import UIKit
+import BrowserServicesKit
 import DataBrokerProtection_iOS
 import DesignResourcesKit
 import Subscription
@@ -150,6 +151,11 @@ struct SettingsRootView: View {
 
     @ViewBuilder func subscriptionFlowNavigationDestination(redirectURLComponents: URLComponents?,
                                                             landingURL: URL? = nil) -> some View {
+        let featureFlagger = viewModel.featureFlagger
+        let performanceOptimizedPaywallsProvider = DefaultPerformanceOptimizedPaywallsProvider(
+            privacyConfigurationManager: viewModel.userScriptsDependencies.privacyConfigurationManager,
+            featureFlagger: featureFlagger
+        )
         SubscriptionContainerViewFactory.makeSubscribeFlowV2(redirectURLComponents: redirectURLComponents,
                                                              landingURL: landingURL,
                                                              navigationCoordinator: subscriptionNavigationCoordinator,
@@ -161,7 +167,8 @@ struct SettingsRootView: View {
                                                              internalUserDecider: AppDependencyProvider.shared.internalUserDecider,
                                                              dataBrokerProtectionViewControllerProvider: viewModel.dataBrokerProtectionViewControllerProvider,
                                                              wideEvent: AppDependencyProvider.shared.wideEvent,
-                                                             featureFlagger: viewModel.featureFlagger,
+                                                             featureFlagger: featureFlagger,
+                                                             performanceOptimizedPaywallsProvider: performanceOptimizedPaywallsProvider,
                                                              onboardingKeyValueStore: viewModel.keyValueStore,
                                                              meetsPIRLocaleRequirement: { viewModel.meetsLocaleRequirement },
                                                              onRequestDuckAIChat: viewModel.onRequestOnboardingDuckAIChat)

--- a/iOS/DuckDuckGo/Subscription/SubscriptionPageFeatureFlagAdapter.swift
+++ b/iOS/DuckDuckGo/Subscription/SubscriptionPageFeatureFlagAdapter.swift
@@ -42,3 +42,25 @@ struct SubscriptionPageFeatureFlagAdapter: SubscriptionPageFeatureFlagProviding 
         }
     }
 }
+
+private struct PerformanceOptimizedPaywallsFeatureFlagger: PerformanceOptimizedPaywallsFeatureFlagging {
+    private let featureFlagger: FeatureFlagger
+
+    init(featureFlagger: FeatureFlagger) {
+        self.featureFlagger = featureFlagger
+    }
+
+    var isPerformanceOptimizedPaywallsEnabled: Bool {
+        featureFlagger.isFeatureOn(.performanceOptimizedPaywalls)
+    }
+}
+
+extension DefaultPerformanceOptimizedPaywallsProvider {
+
+    init(privacyConfigurationManager: PrivacyConfigurationManaging, featureFlagger: FeatureFlagger) {
+        self.init(
+            privacyConfigurationManager: privacyConfigurationManager,
+            featureFlagger: PerformanceOptimizedPaywallsFeatureFlagger(featureFlagger: featureFlagger)
+        )
+    }
+}

--- a/iOS/DuckDuckGo/Subscription/ViewModel/SubscriptionFlowViewModel.swift
+++ b/iOS/DuckDuckGo/Subscription/ViewModel/SubscriptionFlowViewModel.swift
@@ -393,8 +393,8 @@ final class SubscriptionFlowViewModel: ObservableObject {
 
     private func shouldAllowWebViewBackNavigationForURL(currentURL: URL) -> Bool {
         return !currentURL.shouldPreventBackNavigation &&
-        // The flow's own starting page is its root, whatever path it sits on. `performanceOptimizedPaywalls`
-        // moves the first paywall off `/subscriptions`, so matching `.purchase` alone no longer catches it.
+        // A performance-optimized paywall such as `/subscriptions/new/mobile/vpn` does not match
+        // `.purchase` (`/subscriptions`), so treat the URL that started the flow as an additional navigation root.
         !isCurrentURL(matching: initialURL) &&
         !isCurrentURL(matching: .purchase) &&
         !isCurrentURL(matching: .plans) &&

--- a/iOS/DuckDuckGo/Subscription/ViewModel/SubscriptionFlowViewModel.swift
+++ b/iOS/DuckDuckGo/Subscription/ViewModel/SubscriptionFlowViewModel.swift
@@ -393,6 +393,9 @@ final class SubscriptionFlowViewModel: ObservableObject {
 
     private func shouldAllowWebViewBackNavigationForURL(currentURL: URL) -> Bool {
         return !currentURL.shouldPreventBackNavigation &&
+        // The flow's own starting page is its root, whatever path it sits on. `performanceOptimizedPaywalls`
+        // moves the first paywall off `/subscriptions`, so matching `.purchase` alone no longer catches it.
+        !isCurrentURL(matching: initialURL) &&
         !isCurrentURL(matching: .purchase) &&
         !isCurrentURL(matching: .plans) &&
         !isCurrentURL(matching: .welcome) &&

--- a/iOS/DuckDuckGo/Subscription/Views/SubscriptionContainerViewFactory.swift
+++ b/iOS/DuckDuckGo/Subscription/Views/SubscriptionContainerViewFactory.swift
@@ -20,6 +20,7 @@
 import SwiftUI
 import Subscription
 import Common
+import Core
 import FoundationExtensions
 import BrowserServicesKit
 import PrivacyConfig
@@ -92,7 +93,27 @@ enum SubscriptionContainerViewFactory {
             return subscriptionManager.urlForPurchaseFromRedirect(redirectURLComponents: redirectURLComponents, tld: tld)
         }()
 
-        let initialURL = landingURL ?? redirectPurchaseURL
+        let initialURL: URL = {
+            // A landing URL is an explicit destination, like the post-purchase welcome page, never a paywall.
+            if let landingURL { return landingURL }
+
+            // Falls back to the default purchase URL so the rewrite below sees the URL the flow will
+            // actually open — `SubscriptionContainerViewModel` applies that same default otherwise.
+            let purchaseURL = redirectPurchaseURL ?? subscriptionManager.url(for: .purchase)
+
+            let paywalls = DefaultPerformanceOptimizedPaywallsProvider(
+                privacyConfigurationManager: ContentBlocking.shared.privacyConfigurationManager,
+                isFeatureEnabled: { featureFlagger.isFeatureOn(.performanceOptimizedPaywalls) }
+            )
+            guard paywalls.isEnabled else { return purchaseURL }
+
+            return SubscriptionURL.performanceOptimizedPaywallURL(
+                basedOn: purchaseURL,
+                paths: paywalls.paths,
+                isTrialEligible: subscriptionManager.isUserEligibleForFreeTrial(),
+                isPersonalInformationRemovalAvailable: subscriptionManager.currentStorefrontRegion == .usa
+            ) ?? purchaseURL
+        }()
 
         let origin = redirectURLComponents?.queryItems?.first(where: { $0.name == AttributionParameter.origin })?.value
 

--- a/iOS/DuckDuckGo/Subscription/Views/SubscriptionContainerViewFactory.swift
+++ b/iOS/DuckDuckGo/Subscription/Views/SubscriptionContainerViewFactory.swift
@@ -101,6 +101,12 @@ enum SubscriptionContainerViewFactory {
             // actually open — `SubscriptionContainerViewModel` applies that same default otherwise.
             let purchaseURL = redirectPurchaseURL ?? subscriptionManager.url(for: .purchase)
 
+            // An intercepted `/pro` link keeps today's paywall: it isn't one this app chose to open.
+            // `urlForPurchaseFromRedirect` has already rebuilt it onto `/subscriptions`, so the redirect's
+            // own path is all that still tells the two apart — and nothing in the app produces `/pro`,
+            // only `TabURLInterceptor`, which copies the intercepted URL verbatim.
+            if redirectURLComponents?.path == SubscriptionPurchaseFlowPath.pro.rawValue { return purchaseURL }
+
             let paywalls = DefaultPerformanceOptimizedPaywallsProvider(
                 privacyConfigurationManager: ContentBlocking.shared.privacyConfigurationManager,
                 isFeatureEnabled: { featureFlagger.isFeatureOn(.performanceOptimizedPaywalls) }

--- a/iOS/DuckDuckGo/Subscription/Views/SubscriptionContainerViewFactory.swift
+++ b/iOS/DuckDuckGo/Subscription/Views/SubscriptionContainerViewFactory.swift
@@ -20,7 +20,6 @@
 import SwiftUI
 import Subscription
 import Common
-import Core
 import FoundationExtensions
 import BrowserServicesKit
 import PrivacyConfig
@@ -68,6 +67,7 @@ enum SubscriptionContainerViewFactory {
                                     dataBrokerProtectionViewControllerProvider: DBPIOSInterface.DataBrokerProtectionViewControllerProvider?,
                                     wideEvent: WideEventManaging,
                                     featureFlagger: FeatureFlagger,
+                                    performanceOptimizedPaywallsProvider: any PerformanceOptimizedPaywallsProviding,
                                     onboardingKeyValueStore: ThrowingKeyValueStoring?,
                                     meetsPIRLocaleRequirement: @escaping () -> Bool,
                                     onRequestDuckAIChat: ((String?) -> Bool)? = nil) -> some View {
@@ -88,41 +88,13 @@ enum SubscriptionContainerViewFactory {
                                                                    wideEvent: wideEvent,
                                                                    pendingTransactionHandler: pendingTransactionHandler)
 
-        let redirectPurchaseURL: URL? = {
-            guard let redirectURLComponents else { return nil }
-            return subscriptionManager.urlForPurchaseFromRedirect(redirectURLComponents: redirectURLComponents, tld: tld)
-        }()
-
-        let initialURL: URL = {
-            // A landing URL is an explicit destination, like the post-purchase welcome page, never a paywall.
-            if let landingURL { return landingURL }
-
-            // Falls back to the default purchase URL so the rewrite below sees the URL the flow will
-            // actually open — `SubscriptionContainerViewModel` applies that same default otherwise.
-            let purchaseURL = redirectPurchaseURL ?? subscriptionManager.url(for: .purchase)
-
-            // An intercepted `/pro` link keeps today's paywall: it isn't one this app chose to open.
-            // `urlForPurchaseFromRedirect` has already rebuilt it onto `/subscriptions`, so the redirect's
-            // own path is all that still tells the two apart — and nothing in the app produces `/pro`,
-            // only `TabURLInterceptor`, which copies the intercepted URL verbatim.
-            if redirectURLComponents?.path == SubscriptionPurchaseFlowPath.pro.rawValue { return purchaseURL }
-
-            let paywalls = DefaultPerformanceOptimizedPaywallsProvider(
-                privacyConfigurationManager: ContentBlocking.shared.privacyConfigurationManager,
-                isFeatureEnabled: { featureFlagger.isFeatureOn(.performanceOptimizedPaywalls) }
-            )
-            guard paywalls.isEnabled else { return purchaseURL }
-
-            return SubscriptionURL.performanceOptimizedPaywallURL(
-                basedOn: purchaseURL,
-                paths: paywalls.paths,
-                isTrialEligible: subscriptionManager.isUserEligibleForFreeTrial(),
-                isPersonalInformationRemovalAvailable: subscriptionManager.currentStorefrontRegion == .usa
-            ) ?? purchaseURL
-        }()
+        let initialURL = makeSubscribeFlowInitialURL(redirectURLComponents: redirectURLComponents,
+                                                     landingURL: landingURL,
+                                                     subscriptionManager: subscriptionManager,
+                                                     tld: tld,
+                                                     performanceOptimizedPaywalls: performanceOptimizedPaywallsProvider)
 
         let origin = redirectURLComponents?.queryItems?.first(where: { $0.name == AttributionParameter.origin })?.value
-
 
         let viewModel = SubscriptionContainerViewModel(
             subscriptionManager: subscriptionManager,
@@ -153,6 +125,31 @@ enum SubscriptionContainerViewFactory {
             .environmentObject(navigationCoordinator)
     }
 
+    private static func makeSubscribeFlowInitialURL(redirectURLComponents: URLComponents?,
+                                                    landingURL: URL?,
+                                                    subscriptionManager: SubscriptionManager,
+                                                    tld: TLD,
+                                                    performanceOptimizedPaywalls: any PerformanceOptimizedPaywallsProviding) -> URL {
+        // A landing URL is an explicit destination, like the post-purchase welcome page, never a paywall.
+        if let landingURL { return landingURL }
+
+        let purchaseURL = redirectURLComponents.map {
+            subscriptionManager.urlForPurchaseFromRedirect(redirectURLComponents: $0, tld: tld)
+        } ?? subscriptionManager.url(for: .purchase)
+
+        // Intercepted `/pro` URLs are excluded from performance-optimized paywalls.
+        guard performanceOptimizedPaywalls.isEnabled,
+              redirectURLComponents?.path != SubscriptionPurchaseFlowPath.pro.rawValue else { return purchaseURL }
+
+        let performanceOptimizedPaywallURL = SubscriptionURL.performanceOptimizedPaywallURL(
+            basedOn: purchaseURL,
+            paths: performanceOptimizedPaywalls.paths,
+            isTrialEligible: subscriptionManager.isUserEligibleForFreeTrial(),
+            isPersonalInformationRemovalAvailable: subscriptionManager.currentStorefrontRegion == .usa
+        )
+        return performanceOptimizedPaywallURL ?? purchaseURL
+    }
+
     @ViewBuilder
     static func makePurchaseFlowV2(redirectURLComponents: URLComponents?,
                                    navigationCoordinator: SubscriptionNavigationCoordinator,
@@ -165,6 +162,7 @@ enum SubscriptionContainerViewFactory {
                                    dataBrokerProtectionViewControllerProvider: DBPIOSInterface.DataBrokerProtectionViewControllerProvider?,
                                    wideEvent: WideEventManaging,
                                    featureFlagger: FeatureFlagger,
+                                   performanceOptimizedPaywallsProvider: any PerformanceOptimizedPaywallsProviding,
                                    onboardingKeyValueStore: ThrowingKeyValueStoring?,
                                    meetsPIRLocaleRequirement: @escaping () -> Bool,
                                    onRequestDuckAIChat: ((String?) -> Bool)? = nil) -> some View {
@@ -191,6 +189,7 @@ enum SubscriptionContainerViewFactory {
                                 dataBrokerProtectionViewControllerProvider: dataBrokerProtectionViewControllerProvider,
                                 wideEvent: wideEvent,
                                 featureFlagger: featureFlagger,
+                                performanceOptimizedPaywallsProvider: performanceOptimizedPaywallsProvider,
                                 onboardingKeyValueStore: onboardingKeyValueStore,
                                 meetsPIRLocaleRequirement: meetsPIRLocaleRequirement,
                                 onRequestDuckAIChat: onRequestDuckAIChat)

--- a/iOS/DuckDuckGo/Subscription/Views/SubscriptionContainerViewFactory.swift
+++ b/iOS/DuckDuckGo/Subscription/Views/SubscriptionContainerViewFactory.swift
@@ -67,6 +67,7 @@ enum SubscriptionContainerViewFactory {
                                     dataBrokerProtectionViewControllerProvider: DBPIOSInterface.DataBrokerProtectionViewControllerProvider?,
                                     wideEvent: WideEventManaging,
                                     featureFlagger: FeatureFlagger,
+                                    isDebugOverlayEnabled: Bool,
                                     performanceOptimizedPaywallsProvider: any PerformanceOptimizedPaywallsProviding,
                                     onboardingKeyValueStore: ThrowingKeyValueStoring?,
                                     meetsPIRLocaleRequirement: @escaping () -> Bool,
@@ -88,11 +89,14 @@ enum SubscriptionContainerViewFactory {
                                                                    wideEvent: wideEvent,
                                                                    pendingTransactionHandler: pendingTransactionHandler)
 
-        let initialURL = makeSubscribeFlowInitialURL(redirectURLComponents: redirectURLComponents,
+        var initialURL = makeSubscribeFlowInitialURL(redirectURLComponents: redirectURLComponents,
                                                      landingURL: landingURL,
                                                      subscriptionManager: subscriptionManager,
                                                      tld: tld,
                                                      performanceOptimizedPaywalls: performanceOptimizedPaywallsProvider)
+        if isDebugOverlayEnabled {
+            initialURL = initialURL.appendingParameter(name: "debug", value: "1")
+        }
 
         let origin = redirectURLComponents?.queryItems?.first(where: { $0.name == AttributionParameter.origin })?.value
 
@@ -162,6 +166,7 @@ enum SubscriptionContainerViewFactory {
                                    dataBrokerProtectionViewControllerProvider: DBPIOSInterface.DataBrokerProtectionViewControllerProvider?,
                                    wideEvent: WideEventManaging,
                                    featureFlagger: FeatureFlagger,
+                                   isDebugOverlayEnabled: Bool,
                                    performanceOptimizedPaywallsProvider: any PerformanceOptimizedPaywallsProviding,
                                    onboardingKeyValueStore: ThrowingKeyValueStoring?,
                                    meetsPIRLocaleRequirement: @escaping () -> Bool,
@@ -189,6 +194,7 @@ enum SubscriptionContainerViewFactory {
                                 dataBrokerProtectionViewControllerProvider: dataBrokerProtectionViewControllerProvider,
                                 wideEvent: wideEvent,
                                 featureFlagger: featureFlagger,
+                                isDebugOverlayEnabled: isDebugOverlayEnabled,
                                 performanceOptimizedPaywallsProvider: performanceOptimizedPaywallsProvider,
                                 onboardingKeyValueStore: onboardingKeyValueStore,
                                 meetsPIRLocaleRequirement: meetsPIRLocaleRequirement,

--- a/iOS/DuckDuckGo/Subscription/Views/SubscriptionContainerViewFactory.swift
+++ b/iOS/DuckDuckGo/Subscription/Views/SubscriptionContainerViewFactory.swift
@@ -89,11 +89,11 @@ enum SubscriptionContainerViewFactory {
                                                                    wideEvent: wideEvent,
                                                                    pendingTransactionHandler: pendingTransactionHandler)
 
-        var initialURL = makeSubscribeFlowInitialURL(redirectURLComponents: redirectURLComponents,
-                                                     landingURL: landingURL,
-                                                     subscriptionManager: subscriptionManager,
-                                                     tld: tld,
-                                                     performanceOptimizedPaywalls: performanceOptimizedPaywallsProvider)
+        var initialURL = SubscribeFlowInitialURLBuilder.makeInitialURL(redirectURLComponents: redirectURLComponents,
+                                                                       landingURL: landingURL,
+                                                                       subscriptionManager: subscriptionManager,
+                                                                       tld: tld,
+                                                                       performanceOptimizedPaywalls: performanceOptimizedPaywallsProvider)
         if isDebugOverlayEnabled {
             initialURL = initialURL.appendingParameter(name: "debug", value: "1")
         }
@@ -127,31 +127,6 @@ enum SubscriptionContainerViewFactory {
         viewModel.email.setEmailFlowMode(.restoreFlow)
         return SubscriptionContainerView(currentView: .subscribe, viewModel: viewModel, featureFlagger: featureFlagger)
             .environmentObject(navigationCoordinator)
-    }
-
-    private static func makeSubscribeFlowInitialURL(redirectURLComponents: URLComponents?,
-                                                    landingURL: URL?,
-                                                    subscriptionManager: SubscriptionManager,
-                                                    tld: TLD,
-                                                    performanceOptimizedPaywalls: any PerformanceOptimizedPaywallsProviding) -> URL {
-        // A landing URL is an explicit destination, like the post-purchase welcome page, never a paywall.
-        if let landingURL { return landingURL }
-
-        let purchaseURL = redirectURLComponents.map {
-            subscriptionManager.urlForPurchaseFromRedirect(redirectURLComponents: $0, tld: tld)
-        } ?? subscriptionManager.url(for: .purchase)
-
-        // Intercepted `/pro` URLs are excluded from performance-optimized paywalls.
-        guard performanceOptimizedPaywalls.isEnabled,
-              redirectURLComponents?.path != SubscriptionPurchaseFlowPath.pro.rawValue else { return purchaseURL }
-
-        let performanceOptimizedPaywallURL = SubscriptionURL.performanceOptimizedPaywallURL(
-            basedOn: purchaseURL,
-            paths: performanceOptimizedPaywalls.paths,
-            isTrialEligible: subscriptionManager.isUserEligibleForFreeTrial(),
-            isPersonalInformationRemovalAvailable: subscriptionManager.currentStorefrontRegion == .usa
-        )
-        return performanceOptimizedPaywallURL ?? purchaseURL
     }
 
     @ViewBuilder
@@ -370,5 +345,34 @@ enum SubscriptionContainerViewFactory {
         return SubscriptionContainerView(currentView: .email, viewModel: viewModel, featureFlagger: featureFlagger)
             .environmentObject(navigationCoordinator)
             .onDisappear(perform: { onDisappear() })
+    }
+}
+
+enum SubscribeFlowInitialURLBuilder {
+
+    static func makeInitialURL(redirectURLComponents: URLComponents?,
+                               landingURL: URL?,
+                               subscriptionManager: SubscriptionManager,
+                               tld: TLD,
+                               performanceOptimizedPaywalls: any PerformanceOptimizedPaywallsProviding) -> URL {
+        // A landing URL is an explicit destination, like the post-purchase welcome page, never a paywall.
+        if let landingURL { return landingURL }
+
+        let purchaseURL = redirectURLComponents.map {
+            subscriptionManager.urlForPurchaseFromRedirect(redirectURLComponents: $0, tld: tld)
+        } ?? subscriptionManager.url(for: .purchase)
+
+        // Existing subscribers and intercepted `/pro` URLs keep the legacy paywall.
+        guard performanceOptimizedPaywalls.isEnabled,
+              !subscriptionManager.isSubscriptionPresent(),
+              redirectURLComponents?.path != SubscriptionPurchaseFlowPath.pro.rawValue else { return purchaseURL }
+
+        let performanceOptimizedPaywallURL = SubscriptionURL.performanceOptimizedPaywallURL(
+            basedOn: purchaseURL,
+            paths: performanceOptimizedPaywalls.paths,
+            isTrialEligible: subscriptionManager.isUserEligibleForFreeTrial(),
+            isPersonalInformationRemovalAvailable: subscriptionManager.currentStorefrontRegion == .usa
+        )
+        return performanceOptimizedPaywallURL ?? purchaseURL
     }
 }

--- a/iOS/DuckDuckGo/SubscriptionDebugViewController.swift
+++ b/iOS/DuckDuckGo/SubscriptionDebugViewController.swift
@@ -34,11 +34,34 @@ import Lottie
 import FeatureFlags_iOS
 import Persistence
 
+protocol SubscriptionDebugSettingsPersisting {
+    var isDebugOverlayEnabled: Bool { get set }
+}
+
+struct SubscriptionDebugSettingsUserDefaultsPersistor: SubscriptionDebugSettingsPersisting {
+
+    private enum Key: String {
+        case isDebugOverlayEnabled = "subscription-debug-overlay-enabled"
+    }
+
+    private let keyValueStore: ThrowingKeyValueStoring
+
+    init(keyValueStore: ThrowingKeyValueStoring) {
+        self.keyValueStore = keyValueStore
+    }
+
+    var isDebugOverlayEnabled: Bool {
+        get { (try? keyValueStore.object(forKey: Key.isDebugOverlayEnabled.rawValue) as? Bool) ?? false }
+        set { try? keyValueStore.set(newValue, forKey: Key.isDebugOverlayEnabled.rawValue) }
+    }
+}
+
 final class SubscriptionDebugViewController: UITableViewController {
 
     private let subscriptionAppGroup = Bundle.main.appGroup(bundle: .subs)
     private lazy var subscriptionUserDefaults = UserDefaults(suiteName: subscriptionAppGroup)!
     private let reporter: SubscriptionDataReporting
+    private var debugSettings: any SubscriptionDebugSettingsPersisting
 
     var keyValueStore: ThrowingKeyValueStoring?
 
@@ -52,13 +75,16 @@ final class SubscriptionDebugViewController: UITableViewController {
         AppDependencyProvider.shared.subscriptionManager.currentEnvironment
     }
 
-    init?(coder: NSCoder, subscriptionDataReporter: SubscriptionDataReporting) {
+    init?(coder: NSCoder,
+          subscriptionDataReporter: SubscriptionDataReporting,
+          debugSettings: any SubscriptionDebugSettingsPersisting) {
         self.reporter = subscriptionDataReporter
+        self.debugSettings = debugSettings
         super.init(coder: coder)
     }
     
     required init?(coder: NSCoder) {
-        fatalError("Use init(coder:subscriptionDataReporter:) instead")
+        fatalError("Use init(coder:subscriptionDataReporter:debugSettings:) instead")
     }
 
     private let titles = [
@@ -71,6 +97,7 @@ final class SubscriptionDebugViewController: UITableViewController {
         Sections.metadata: "StoreKit Metadata",
         Sections.regionOverride: "Region override for App Store Sandbox",
         Sections.expirationReminder: "Expiration Reminder Notification",
+        Sections.subscriptionURLs: "Subscription URLs",
         Sections.onboarding: "Onboarding — On-Device Progress",
         Sections.onboardingMock: "Onboarding — Mock Flow",
         Sections.onboardingMockConfig: "Onboarding — Configure Mock Flow",
@@ -87,6 +114,7 @@ final class SubscriptionDebugViewController: UITableViewController {
         case metadata
         case regionOverride
         case expirationReminder
+        case subscriptionURLs
         case onboarding
         case onboardingMock
         case onboardingMockConfig
@@ -137,6 +165,10 @@ final class SubscriptionDebugViewController: UITableViewController {
     enum ExpirationReminderRows: Int, CaseIterable {
         case currentStatus
         case triggerMockNotification
+    }
+
+    enum SubscriptionURLRows: Int, CaseIterable {
+        case debugOverlay
     }
 
     // Onboarding row enums (OnboardingRows, OnboardingMockRows, OnboardingMockConfigRows,
@@ -303,6 +335,20 @@ final class SubscriptionDebugViewController: UITableViewController {
                 break
             }
 
+        case .subscriptionURLs:
+            switch SubscriptionURLRows(rawValue: indexPath.row) {
+            case .debugOverlay:
+                cell.textLabel?.text = "Debug overlay"
+                cell.selectionStyle = .none
+
+                let toggle = UISwitch()
+                toggle.isOn = debugSettings.isDebugOverlayEnabled
+                toggle.addTarget(self, action: #selector(debugOverlayToggled(_:)), for: .valueChanged)
+                cell.accessoryView = toggle
+            case .none:
+                break
+            }
+
         case .regionOverride:
             switch RegionOverrideRows(rawValue: indexPath.row) {
             case .currentRegionOverride:
@@ -380,6 +426,7 @@ final class SubscriptionDebugViewController: UITableViewController {
         case .metadata: return MetadataRows.allCases.count
         case .regionOverride: return RegionOverrideRows.allCases.count
         case .expirationReminder: return ExpirationReminderRows.allCases.count
+        case .subscriptionURLs: return SubscriptionURLRows.allCases.count
         case .onboarding: return OnboardingRows.allCases.count
         case .onboardingMock: return OnboardingMockRows.allCases.count
         case .onboardingMockConfig: return OnboardingMockConfigRows.allCases.count
@@ -432,6 +479,8 @@ final class SubscriptionDebugViewController: UITableViewController {
             case .triggerMockNotification: triggerMockExpirationReminder()
             default: break
             }
+        case .subscriptionURLs:
+            break
         case .onboarding:
             didSelectOnboardingRow(at: indexPath)
         case .onboardingMock:
@@ -444,6 +493,10 @@ final class SubscriptionDebugViewController: UITableViewController {
             break
         }
         tableView.deselectRow(at: indexPath, animated: true)
+    }
+
+    @objc private func debugOverlayToggled(_ sender: UISwitch) {
+        debugSettings.isDebugOverlayEnabled = sender.isOn
     }
 
     private func changeSubscriptionEnvironment(envRows: EnvironmentRows) {

--- a/iOS/DuckDuckGo/TabURLInterceptor.swift
+++ b/iOS/DuckDuckGo/TabURLInterceptor.swift
@@ -72,6 +72,10 @@ extension TabURLInterceptorDefault {
             return components
         }
 
+        guard components.path.hasPrefix("\(SubscriptionPurchaseFlowPath.purchase.rawValue)/") else {
+            return nil
+        }
+
         return performanceOptimizedPaywalls.paths.purchaseRedirectComponents(from: components)
             ?? SubscriptionURL.PerformanceOptimizedPaywallPaths.default.purchaseRedirectComponents(from: components)
     }

--- a/iOS/DuckDuckGo/TabURLInterceptor.swift
+++ b/iOS/DuckDuckGo/TabURLInterceptor.swift
@@ -18,6 +18,7 @@
 //
 
 import Foundation
+import BrowserServicesKit
 import PrivacyConfig
 import Common
 import FoundationExtensions
@@ -32,26 +33,25 @@ final class TabURLInterceptorDefault: TabURLInterceptor {
     typealias CanPurchaseUpdater = () -> Bool
     private let canPurchase: CanPurchaseUpdater
     private let featureFlagger: FeatureFlagger
+    private let performanceOptimizedPaywalls: any PerformanceOptimizedPaywallsProviding
 
     init(featureFlagger: FeatureFlagger,
-         canPurchase: @escaping CanPurchaseUpdater
-    ) {
+         performanceOptimizedPaywalls: any PerformanceOptimizedPaywallsProviding,
+         canPurchase: @escaping CanPurchaseUpdater) {
         self.canPurchase = canPurchase
         self.featureFlagger = featureFlagger
+        self.performanceOptimizedPaywalls = performanceOptimizedPaywalls
     }
-
-    static let interceptedURLs = SubscriptionPurchaseFlowPath.allCases.map(\.rawValue)
     
     func allowsNavigatingTo(url: URL) -> Bool {
         guard url.isPart(ofDomain: "duckduckgo.com") || (url.isPart(ofDomain: "duck.co") && featureFlagger.internalUserDecider.isInternalUser),
               let components = normalizeScheme(url.absoluteString),
-              Self.interceptedURLs.contains(components.path) else {
+              let redirectComponents = subscriptionRedirectComponents(from: components) else {
             return true
         }
 
-        return interceptSubscriptionURL(components)
+        return interceptSubscriptionURL(redirectComponents)
     }
-
 }
 
 extension TabURLInterceptorDefault {
@@ -65,6 +65,15 @@ extension TabURLInterceptorDefault {
         let noScheme = rawUrl.dropping(prefix: URL.NavigationalScheme.https.separated()).dropping(prefix: URL.NavigationalScheme.http.separated())
 
         return URLComponents(string: "\(URL.NavigationalScheme.https.separated())\(noScheme)")
+    }
+
+    private func subscriptionRedirectComponents(from components: URLComponents) -> URLComponents? {
+        if SubscriptionPurchaseFlowPath.contains(components.path) {
+            return components
+        }
+
+        return performanceOptimizedPaywalls.paths.purchaseRedirectComponents(from: components)
+            ?? SubscriptionURL.PerformanceOptimizedPaywallPaths.default.purchaseRedirectComponents(from: components)
     }
 
     private func interceptSubscriptionURL(_ components: URLComponents) -> Bool {

--- a/iOS/DuckDuckGo/TabViewController.swift
+++ b/iOS/DuckDuckGo/TabViewController.swift
@@ -869,7 +869,11 @@ class TabViewController: UIViewController {
         self.pixelFiring = pixelFiring
         self.tabTerminationErrorPageInstrumentation = tabTerminationErrorPageInstrumentation
             ?? DefaultTabTerminationErrorPageInstrumentation(pixelFiring: pixelFiring)
-        self.tabURLInterceptor = TabURLInterceptorDefault(featureFlagger: featureFlagger) {
+        let performanceOptimizedPaywallsProvider = DefaultPerformanceOptimizedPaywallsProvider(
+            privacyConfigurationManager: userScriptsDependencies.privacyConfigurationManager,
+            featureFlagger: featureFlagger)
+        self.tabURLInterceptor = TabURLInterceptorDefault(featureFlagger: featureFlagger,
+                                                          performanceOptimizedPaywalls: performanceOptimizedPaywallsProvider) {
             return AppDependencyProvider.shared.subscriptionManager.isSubscriptionPurchaseEligible
         }
         

--- a/iOS/DuckDuckGoTests/Subscription/SubscriptionFlowTypeTests.swift
+++ b/iOS/DuckDuckGoTests/Subscription/SubscriptionFlowTypeTests.swift
@@ -18,6 +18,10 @@
 //
 
 import XCTest
+import BrowserServicesKit
+import Common
+import Subscription
+import SubscriptionTestingUtilities
 @testable import DuckDuckGo
 
 final class SubscriptionFlowTypeTests: XCTestCase {
@@ -75,4 +79,47 @@ final class SubscriptionFlowTypeTests: XCTestCase {
         // Then
         XCTAssertNil(flowType.impressionPixel)
     }
+}
+
+final class SubscribeFlowInitialURLBuilderTests: XCTestCase {
+
+    private let purchaseURL = URL(string: "https://duckduckgo.com/subscriptions")!
+    private let performanceOptimizedPaywallURL = URL(string: "https://duckduckgo.com/subscriptions/new/mobile/vpn?trial=false")!
+    private let performanceOptimizedPaywalls = MockPerformanceOptimizedPaywallsProvider()
+
+    func testWhenPerformanceOptimizedPaywallsAreEnabledAndUserIsNotSubscribedThenReturnsPerformanceOptimizedPaywallURL() {
+        let subscriptionManager = SubscriptionManagerMock()
+        subscriptionManager.resultURL = purchaseURL
+
+        let initialURL = SubscribeFlowInitialURLBuilder.makeInitialURL(
+            redirectURLComponents: nil,
+            landingURL: nil,
+            subscriptionManager: subscriptionManager,
+            tld: TLD(),
+            performanceOptimizedPaywalls: performanceOptimizedPaywalls
+        )
+
+        XCTAssertEqual(initialURL, performanceOptimizedPaywallURL)
+    }
+
+    func testWhenPerformanceOptimizedPaywallsAreEnabledAndUserIsSubscribedThenReturnsLegacyPurchaseURL() {
+        let subscriptionManager = SubscriptionManagerMock()
+        subscriptionManager.resultURL = purchaseURL
+        subscriptionManager.resultSubscription = .success(SubscriptionMockFactory.subscription(status: .autoRenewable))
+
+        let initialURL = SubscribeFlowInitialURLBuilder.makeInitialURL(
+            redirectURLComponents: nil,
+            landingURL: nil,
+            subscriptionManager: subscriptionManager,
+            tld: TLD(),
+            performanceOptimizedPaywalls: performanceOptimizedPaywalls
+        )
+
+        XCTAssertEqual(initialURL, purchaseURL)
+    }
+}
+
+private struct MockPerformanceOptimizedPaywallsProvider: PerformanceOptimizedPaywallsProviding {
+    let isEnabled = true
+    let paths = SubscriptionURL.PerformanceOptimizedPaywallPaths.default
 }

--- a/iOS/DuckDuckGoTests/TabURLInterceptorTests.swift
+++ b/iOS/DuckDuckGoTests/TabURLInterceptorTests.swift
@@ -18,6 +18,7 @@
 //
 
 import XCTest
+import BrowserServicesKit
 import PrivacyConfig
 import Subscription
 import SubscriptionTestingUtilities
@@ -26,13 +27,22 @@ import SubscriptionTestingUtilities
 class TabURLInterceptorDefaultTests: XCTestCase {
 
     private var mockInternalUserStoring = MockInternalUserStoring()
+    private let performanceOptimizedPaywallPaths = SubscriptionURL.PerformanceOptimizedPaywallPaths(
+        vpn: "/subscriptions/v2/vpn",
+        duckai: "/subscriptions/v2/duckai",
+        pir: "/subscriptions/v2/pir")
 
     var urlInterceptor: TabURLInterceptorDefault!
 
     override func setUp() {
         super.setUp()
         mockInternalUserStoring.isInternalUser = false
-        urlInterceptor = TabURLInterceptorDefault(featureFlagger: MockFeatureFlagger(internalUserDecider: DefaultInternalUserDecider(store: mockInternalUserStoring)),
+        let featureFlagger = MockFeatureFlagger(
+            internalUserDecider: DefaultInternalUserDecider(store: mockInternalUserStoring))
+        urlInterceptor = TabURLInterceptorDefault(featureFlagger: featureFlagger,
+                                                  performanceOptimizedPaywalls: MockPerformanceOptimizedPaywallsProvider(
+                                                    isEnabled: false,
+                                                    paths: performanceOptimizedPaywallPaths),
                                                   canPurchase: { true })
     }
     
@@ -196,4 +206,67 @@ class TabURLInterceptorDefaultTests: XCTestCase {
         await fulfillment(of: [notificationExpectation], timeout: 0.5)
     }
 
+    func testConfiguredPerformanceOptimizedPaywallPathsAreInterceptedWhenFeatureIsDisabled() throws {
+        let testCases: [(path: String, entryPoint: SubscriptionURL.PerformanceOptimizedPaywallEntryPoint)] = [
+            (performanceOptimizedPaywallPaths.vpn, .vpn),
+            (performanceOptimizedPaywallPaths.duckai, .duckai),
+            (performanceOptimizedPaywallPaths.pir, .pir)
+        ]
+
+        for testCase in testCases {
+            let url = try XCTUnwrap(URL(
+                string: "https://duckduckgo.com\(testCase.path)"
+                + "?origin=test_origin"
+                + "&experiment_mobileannualtrials2_ios=treatment"
+                + "&featurePage=stale"))
+
+            let redirectComponents = try interceptedRedirectComponents(for: url)
+
+            XCTAssertEqual(redirectComponents.path, SubscriptionPurchaseFlowPath.purchase.rawValue)
+            XCTAssertEqual(redirectComponents.queryItems?.first { $0.name == AttributionParameter.origin }?.value, "test_origin")
+            XCTAssertEqual(redirectComponents.queryItems?.first { $0.name == "experiment_mobileannualtrials2_ios" }?.value, "treatment")
+            let featurePages = (redirectComponents.queryItems ?? [])
+                .filter { $0.name == "featurePage" }
+                .compactMap(\.value)
+            XCTAssertEqual(featurePages, [testCase.entryPoint.rawValue])
+        }
+    }
+
+    func testDefaultPerformanceOptimizedPaywallPathIsInterceptedWhenConfiguredPathIsDifferent() throws {
+        let url = try XCTUnwrap(URL(string: "https://duckduckgo.com/subscriptions/new/mobile/vpn"))
+
+        let redirectComponents = try interceptedRedirectComponents(for: url)
+
+        XCTAssertEqual(redirectComponents.path, SubscriptionPurchaseFlowPath.purchase.rawValue)
+        XCTAssertEqual(redirectComponents.queryItems?.count, 1)
+        XCTAssertEqual(redirectComponents.queryItems?.first?.name, "featurePage")
+        XCTAssertEqual(redirectComponents.queryItems?.first?.value, "vpn")
+    }
+
+    func testUnknownPerformanceOptimizedPaywallPathIsNotIntercepted() throws {
+        let notificationExpectation = expectation(forNotification: .urlInterceptSubscription, object: nil, handler: nil)
+        notificationExpectation.isInverted = true
+        let url = try XCTUnwrap(URL(string: "https://duckduckgo.com/subscriptions/v2/unknown"))
+
+        XCTAssertTrue(urlInterceptor.allowsNavigatingTo(url: url))
+        wait(for: [notificationExpectation], timeout: 0.5)
+    }
+
+    private func interceptedRedirectComponents(for url: URL) throws -> URLComponents {
+        var capturedNotification: Notification?
+        let notificationExpectation = expectation(forNotification: .urlInterceptSubscription, object: nil) { notification in
+            capturedNotification = notification
+            return true
+        }
+
+        XCTAssertFalse(urlInterceptor.allowsNavigatingTo(url: url))
+        wait(for: [notificationExpectation], timeout: 1)
+
+        return try XCTUnwrap(capturedNotification?.userInfo?[TabURLInterceptorParameter.interceptedURLComponents] as? URLComponents)
+    }
+}
+
+private struct MockPerformanceOptimizedPaywallsProvider: PerformanceOptimizedPaywallsProviding {
+    let isEnabled: Bool
+    let paths: SubscriptionURL.PerformanceOptimizedPaywallPaths
 }

--- a/iOS/DuckDuckGoTests/TabURLInterceptorTests.swift
+++ b/iOS/DuckDuckGoTests/TabURLInterceptorTests.swift
@@ -33,16 +33,18 @@ class TabURLInterceptorDefaultTests: XCTestCase {
         pir: "/subscriptions/v2/pir")
 
     var urlInterceptor: TabURLInterceptorDefault!
+    private var performanceOptimizedPaywallsProvider: MockPerformanceOptimizedPaywallsProvider!
 
     override func setUp() {
         super.setUp()
         mockInternalUserStoring.isInternalUser = false
         let featureFlagger = MockFeatureFlagger(
             internalUserDecider: DefaultInternalUserDecider(store: mockInternalUserStoring))
+        performanceOptimizedPaywallsProvider = MockPerformanceOptimizedPaywallsProvider(
+            isEnabled: false,
+            paths: performanceOptimizedPaywallPaths)
         urlInterceptor = TabURLInterceptorDefault(featureFlagger: featureFlagger,
-                                                  performanceOptimizedPaywalls: MockPerformanceOptimizedPaywallsProvider(
-                                                    isEnabled: false,
-                                                    paths: performanceOptimizedPaywallPaths),
+                                                  performanceOptimizedPaywalls: performanceOptimizedPaywallsProvider,
                                                   canPurchase: { true })
     }
     
@@ -59,6 +61,13 @@ class TabURLInterceptorDefaultTests: XCTestCase {
     func testAllowsNavigationForUninterceptedDuckDuckGoPath() {
         let url = URL(string: "https://duckduckgo.com/about")!
         XCTAssertTrue(urlInterceptor.allowsNavigatingTo(url: url))
+    }
+
+    func testUninterceptedDuckDuckGoPathDoesNotReadPerformanceOptimizedPaywallPaths() {
+        let url = URL(string: "https://duckduckgo.com/?q=privacy")!
+
+        XCTAssertTrue(urlInterceptor.allowsNavigatingTo(url: url))
+        XCTAssertEqual(performanceOptimizedPaywallsProvider.pathsAccessCount, 0)
     }
     
     func testNotificationForInterceptedSubscriptionPath() {
@@ -266,7 +275,18 @@ class TabURLInterceptorDefaultTests: XCTestCase {
     }
 }
 
-private struct MockPerformanceOptimizedPaywallsProvider: PerformanceOptimizedPaywallsProviding {
+private final class MockPerformanceOptimizedPaywallsProvider: PerformanceOptimizedPaywallsProviding {
     let isEnabled: Bool
-    let paths: SubscriptionURL.PerformanceOptimizedPaywallPaths
+    private let configuredPaths: SubscriptionURL.PerformanceOptimizedPaywallPaths
+    private(set) var pathsAccessCount = 0
+
+    var paths: SubscriptionURL.PerformanceOptimizedPaywallPaths {
+        pathsAccessCount += 1
+        return configuredPaths
+    }
+
+    init(isEnabled: Bool, paths: SubscriptionURL.PerformanceOptimizedPaywallPaths) {
+        self.isEnabled = isEnabled
+        self.configuredPaths = paths
+    }
 }

--- a/iOS/LocalPackages/FeatureFlags-iOS/Sources/FeatureFlags/FeatureFlag.swift
+++ b/iOS/LocalPackages/FeatureFlags-iOS/Sources/FeatureFlags/FeatureFlag.swift
@@ -147,9 +147,6 @@ public enum FeatureFlag: String {
 
     /// Gates the server-rendered first paywall: `/subscriptions/new/mobile/<emphasis>` in place of
     /// `/subscriptions` with a `featurePage` query item.
-    ///
-    /// Wired only. Nothing reads this yet — see `SubscriptionURLTests` for the URLs it has to
-    /// produce once something does.
     case performanceOptimizedPaywalls
 
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1213569392605475

--- a/iOS/LocalPackages/FeatureFlags-iOS/Sources/FeatureFlags/FeatureFlag.swift
+++ b/iOS/LocalPackages/FeatureFlags-iOS/Sources/FeatureFlags/FeatureFlag.swift
@@ -145,6 +145,13 @@ public enum FeatureFlag: String {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866712841283
     case privacyProOnboardingPromotion
 
+    /// Gates the server-rendered first paywall: `/subscriptions/new/mobile/<emphasis>` in place of
+    /// `/subscriptions` with a `featurePage` query item.
+    ///
+    /// Wired only. Nothing reads this yet — see `SubscriptionURLTests` for the URLs it has to
+    /// produce once something does.
+    case performanceOptimizedPaywalls
+
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1213569392605475
     case subscriptionPromoForReinstallers
 
@@ -691,6 +698,8 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(source: .remoteReleasable(MaliciousSiteProtectionSubfeature.scamProtection))
         case .privacyProOnboardingPromotion:
             Config(source: .remoteReleasable(PrivacyProSubfeature.privacyProOnboardingPromotion))
+        case .performanceOptimizedPaywalls:
+            Config(source: .remoteReleasable(PrivacyProSubfeature.performanceOptimizedPaywalls))
         case .subscriptionPromoForReinstallers:
             Config(defaultValue: .enabled, source: .remoteReleasable(PrivacyProSubfeature.subscriptionPromoForReinstallers))
         case .subscriptionExpirationReminderNotification:

--- a/iOS/LocalPackages/FeatureFlags-iOS/Sources/FeatureFlags/FeatureFlag.swift
+++ b/iOS/LocalPackages/FeatureFlags-iOS/Sources/FeatureFlags/FeatureFlag.swift
@@ -145,8 +145,7 @@ public enum FeatureFlag: String {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866712841283
     case privacyProOnboardingPromotion
 
-    /// Gates the server-rendered first paywall: `/subscriptions/new/mobile/<emphasis>` in place of
-    /// `/subscriptions` with a `featurePage` query item.
+    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1218354517064977
     case performanceOptimizedPaywalls
 
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1213569392605475


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1217750626830942?focus=true
Tech Design URL:
CC: @shakyShane 

### Description
* This PR adds routing to the performance-optimized VPN, Duck.ai, and PIR paywalls. Depending on the feature flag.
* The behavior is gated by the `performanceOptimizedPaywalls` flag: will route to performance-optimized variants when on, and will keep the existing URLs when off.
* The new paywall paths are remotely configured ([PR here](https://github.com/duckduckgo/privacy-configuration/pull/5809))

### Testing Steps
Performance-optimized paywalls load much faster than the regular ones, so you should be able to notice that they are working just by the loading speed, but you can also inspect the URL in Xcode.

Prerequisite:
My recommendation is to use the [Privacy Protections Debugger](https://app.asana.com/1/137249556945/project/1202500774821704/task/1218144635698499?focus=true) and add the following section to `ios-override`:
```
"performanceOptimizedPaywalls": {
    "state": "enabled",
    "settings": {
        "entryPoints": {
            "vpn": {
                "path": "/subscriptions/new/mobile/vpn"
            },
            "duckai": {
                "path": "/subscriptions/new/mobile/duckai"
            },
            "pir": {
                "path": "/subscriptions/new/mobile/pir"
            }
        }
    }
}
```

1. Open the subscription flow from App Settings → URL should be `/subscriptions/new/mobile/vpn` instead of `subscriptions`
2. Open the subscription flow from a Duck.ai entry point → URL should be `/subscriptions/new/mobile/duckai` instead of `/subscriptions?featurePage=duckai`
3. Open the subscription flow from PIR (e.g. Freemium from App Settings) entry point → URL should be `/subscriptions/new/mobile/pir` instead of `/subscriptions?featurePage=pir`
4. Disable the `performanceOptimizedPaywalls` feature flag and open a subscription flow → the existing subscription paywall is displayed.

### Impact
Medium: It updates the construction logic for the subscription landing page. It is gated by a feature flag to mitigate the risk.

#### What could go wrong?
We could end up on the wrong paywall or pass incorrect parameters.

### Quality Considerations
I've added unit tests to cover the path combinations/URL parameters.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how first-purchase URLs are built and intercepted for subscription flows; incorrect routing or trial/PIR query params could show the wrong paywall, though rollout is feature-flagged.
> 
> **Overview**
> Adds **performance-optimized (pre-rendered) first paywalls** for VPN, Duck.ai, and PIR, controlled by the new `performanceOptimizedPaywalls` privacy-config subfeature and iOS feature flag.
> 
> When the flag is on and the user is eligible for the new flow, subscribe entry points build an initial URL via `SubscribeFlowInitialURLBuilder` and `SubscriptionURL.performanceOptimizedPaywallURL`, swapping `/subscriptions` (and `featurePage`) for remotely configured paths like `/subscriptions/new/mobile/vpn` and encoding **trial** and **pir** query state up front. Paths are supplied by `DefaultPerformanceOptimizedPaywallsProvider` (JSON settings with per-entry fallbacks). **Tab URL interception** is extended so in-tab navigation to those pre-rendered paths is rewritten back to the canonical purchase URL with the right `featurePage`, including default paths when config differs.
> 
> Subscription web navigation treats the flow’s **initial URL** as a back-navigation root so optimized paths behave like the legacy purchase page. Internal **debug** adds a persisted “debug overlay” toggle that appends `debug=1` to subscribe URLs. Unit tests cover URL rewriting, config path resolution, interceptor behavior, and initial-URL selection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2910d7cb4a9bc40dcf94a59cbf6010933b4fa784. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->