### PR TITLE
Confirm before closing the Sync pairing dialog

### DIFF
--- a/macOS/DuckDuckGo/Common/Extensions/NSAlertExtension.swift
+++ b/macOS/DuckDuckGo/Common/Extensions/NSAlertExtension.swift
@@ -186,6 +186,16 @@ extension NSAlert {
         return alert
     }
 
+    static func syncCloseSetupConfirmation() -> NSAlert {
+        let alert = NSAlert()
+        alert.messageText = UserText.syncCloseSetupConfirmationTitleV2
+        alert.informativeText = UserText.syncCloseSetupConfirmationMessageV2
+        alert.alertStyle = .informational
+        alert.addButton(withTitle: UserText.syncCloseSetupConfirmationActionV2)
+        alert.addButton(withTitle: UserText.cancel)
+        return alert
+    }
+
     static func dataSyncingDisabledByFeatureFlag(showLearnMore: Bool, upgradeRequired: Bool = false) -> NSAlert {
         let alert = NSAlert()
         alert.messageText = UserText.syncPausedTitle

--- a/macOS/DuckDuckGo/Common/Localizables/UserText.swift
+++ b/macOS/DuckDuckGo/Common/Localizables/UserText.swift
@@ -1507,6 +1507,11 @@ struct UserText {
             comment: "Message for the dialog to confirm sync setup with another DuckDuckGo device")
         return String(format: message, peerName)
     }
+
+    // Confirmation shown when closing the Sync setup dialog while a device is still being connected (V2 — simplifiedSyncSetupV2). Not localized while behind the feature flag.
+    static let syncCloseSetupConfirmationTitleV2 = NotLocalizedString("sync.close-setup-v2.confirmation.title", value: "Are you sure you want to close this window?", comment: "Title of the confirmation shown when closing the Sync setup dialog before the devices finished connecting (V2)")
+    static let syncCloseSetupConfirmationMessageV2 = NotLocalizedString("sync.close-setup-v2.confirmation.message", value: "Closing this window will stop connecting Sync & Backup.", comment: "Message of the confirmation shown when closing the Sync setup dialog before the devices finished connecting (V2)")
+    static let syncCloseSetupConfirmationActionV2 = NotLocalizedString("sync.close-setup-v2.confirmation.action", value: "Close", comment: "Button that confirms closing the Sync setup dialog before the devices finished connecting (V2)")
     static let syncBookmarkPausedAlertTitle = NSLocalizedString("alert.sync-bookmarks-paused-title", value: "Bookmark Sync is Paused", comment: "Title for alert shown when sync bookmarks paused for too many items")
     static let syncBookmarkPausedAlertDescription = NSLocalizedString("alert.sync-bookmarks-paused-description", value: "You've reached the maximum number of bookmarks. Please delete some bookmarks to resume sync.", comment: "Description for alert shown when sync bookmarks paused for too many items")
     static let syncCredentialsPausedAlertTitle = NSLocalizedString("alert.sync-credentials-paused-title", value: "Password Sync is Paused", comment: "Title for alert shown when sync credentials paused for too many items")

--- a/macOS/DuckDuckGo/Preferences/Model/SyncDialogController.swift
+++ b/macOS/DuckDuckGo/Preferences/Model/SyncDialogController.swift
@@ -93,6 +93,11 @@ final class SyncDialogController {
     private static let defaultConnectionControllerFactory: (DDGSyncing, SyncConnectionControllerDelegate) -> SyncConnectionControlling = { syncService, delegate in
         syncService.createConnectionController(deviceName: deviceInfo().name, deviceType: deviceInfo().type, delegate: delegate)
     }
+    private static let defaultCloseSetupConfirmation: @MainActor () async -> Bool = {
+        NSAlert.syncCloseSetupConfirmation().runModal() == .alertFirstButtonReturn
+    }
+    private let confirmCloseSetup: @MainActor () async -> Bool
+
     private let connectionControllerFactory: (DDGSyncing, SyncConnectionControllerDelegate) -> SyncConnectionControlling
     private lazy var connectionController: SyncConnectionControlling = connectionControllerFactory(syncService, self)
 
@@ -122,8 +127,10 @@ final class SyncDialogController {
         connectionControllerFactory: ((DDGSyncing, SyncConnectionControllerDelegate) -> SyncConnectionControlling)? = nil,
         featureFlagger: FeatureFlagger? = nil,
         pixelFiring: PixelFiring? = PixelKit.shared,
-        keyValueStore: KeyValueStoring = UserDefaults.standard
+        keyValueStore: KeyValueStoring = UserDefaults.standard,
+        confirmCloseSetup: (@MainActor () async -> Bool)? = nil
     ) {
+        self.confirmCloseSetup = confirmCloseSetup ?? SyncDialogController.defaultCloseSetupConfirmation
         self.syncService = syncService
         self.userAuthenticator = userAuthenticator
         self.syncPausedStateManager = syncPausedStateManager
@@ -632,6 +639,15 @@ extension SyncDialogController: ManagementDialogModelDelegate {
         default:
             break
         }
+    }
+
+    func shouldEndFlow(from dialog: ManagementDialogKind) async -> Bool {
+        guard managementDialogModel.isSimplifiedSyncSetupV2Enabled,
+              case .syncWithAnotherDevice = dialog else {
+            return true
+        }
+
+        return await confirmCloseSetup()
     }
 
     func switchAccountsCancelled() {

--- a/macOS/LocalPackages/SyncUI-macOS/Package.swift
+++ b/macOS/LocalPackages/SyncUI-macOS/Package.swift
@@ -24,6 +24,7 @@ let package = Package(
         .package(path: "../../../SharedPackages/Infrastructure/DesignResourcesKit"),
         .package(path: "../../../SharedPackages/Infrastructure/DesignResourcesKitIcons"),
         .package(path: "../../../SharedPackages/SnapshotTestingSupport"),
+        .package(url: "https://github.com/airbnb/lottie-spm.git", exact: "4.6.1"),
     ],
     targets: [
         .target(
@@ -34,6 +35,7 @@ let package = Package(
                 .product(name: "DesignResourcesKit", package: "DesignResourcesKit"),
                 .product(name: "DesignResourcesKitIcons", package: "DesignResourcesKitIcons"),
                 .product(name: "PreviewSnapshots", package: "SnapshotTestingSupport"),
+                .product(name: "Lottie", package: "lottie-spm"),
             ],
             resources: [
                 .process("Assets.xcassets"),

--- a/macOS/LocalPackages/SyncUI-macOS/Sources/SyncUI-macOS/ViewModels/ManagementDialogModel.swift
+++ b/macOS/LocalPackages/SyncUI-macOS/Sources/SyncUI-macOS/ViewModels/ManagementDialogModel.swift
@@ -39,6 +39,7 @@ public protocol ManagementDialogModelDelegate: AnyObject {
     func openSystemPasswordSettings()
     func userConfirmedSwitchAccounts(recoveryCode: String)
     func userPressedCancel(from dialog: ManagementDialogKind)
+    func shouldEndFlow(from dialog: ManagementDialogKind) async -> Bool
     func switchAccountsCancelled()
     func enterCodeViewDidAppear()
     func didEndFlow()
@@ -83,6 +84,14 @@ public final class ManagementDialogModel: ObservableObject {
             delegate?.userPressedCancel(from: currentDialog)
         }
         endFlow()
+    }
+
+    @MainActor
+    public func cancelPressedWithConfirmation() async {
+        if let currentDialog, let delegate {
+            guard await delegate.shouldEndFlow(from: currentDialog) else { return }
+        }
+        cancelPressed()
     }
 
     @MainActor

--- a/macOS/LocalPackages/SyncUI-macOS/Sources/SyncUI-macOS/Views/Dialogs/DeviceDetailsViewV2.swift
+++ b/macOS/LocalPackages/SyncUI-macOS/Sources/SyncUI-macOS/Views/Dialogs/DeviceDetailsViewV2.swift
@@ -79,9 +79,13 @@ struct DeviceDetailsViewV2: View {
             Text(UserText.deviceDetailsNameLabelV2)
                 .font(.system(size: 13))
                 .foregroundColor(Color(designSystemColor: .textPrimary))
-            TextField("", text: $deviceName, onCommit: save)
-                .disabled(isSaving)
-                .accessibilityIdentifier("SyncSettings.deviceDetails.nameField")
+            TextField(text: $deviceName) {
+                EmptyView()
+            }
+            .labelsHidden()
+            .onSubmit(save)
+            .disabled(isSaving)
+            .accessibilityIdentifier("SyncSettings.deviceDetails.nameField")
         }
         .padding(.horizontal, 10)
         .frame(height: 45)

--- a/macOS/LocalPackages/SyncUI-macOS/Sources/SyncUI-macOS/Views/Dialogs/SyncWithAnotherDeviceViewV2.swift
+++ b/macOS/LocalPackages/SyncUI-macOS/Sources/SyncUI-macOS/Views/Dialogs/SyncWithAnotherDeviceViewV2.swift
@@ -83,7 +83,9 @@ struct SyncWithAnotherDeviceViewV2: View {
         } buttons: {
             Spacer()
             Button(UserText.cancel) {
-                model.cancelPressed()
+                Task {
+                    await model.cancelPressedWithConfirmation()
+                }
             }
             .buttonStyle(DismissActionButtonStyle())
         }

--- a/macOS/UnitTests/Sync/SyncDialogControllerTests.swift
+++ b/macOS/UnitTests/Sync/SyncDialogControllerTests.swift
@@ -38,6 +38,21 @@ private final class MockUserAuthenticator: UserAuthenticating {
     }
 }
 
+@MainActor
+private final class StubCloseSetupConfirmation {
+    var answer: Bool
+    private(set) var presentationCount = 0
+
+    init(answer: Bool) {
+        self.answer = answer
+    }
+
+    func present() -> Bool {
+        presentationCount += 1
+        return answer
+    }
+}
+
 private final class MockDeviceSyncCoordinationDelegate: DeviceSyncCoordinationDelegate {
     var didEndFlowCalled: (() -> Void)?
 
@@ -1612,7 +1627,87 @@ final class SyncDialogControllerTests: XCTestCase {
         await fulfillment(of: [cancelCalled, didEndFlowCalled], timeout: 5.0)
     }
 
+    // MARK: - Closing the setup flow
+
+    func testCancellingPairing_whenUserConfirms_endsTheFlow() async {
+        let confirmation = StubCloseSetupConfirmation(answer: true)
+        makeControllerWithCloseSetupConfirmation(confirmation, isSimplifiedSyncSetupV2Enabled: true)
+        managementDialogModel.currentDialog = .syncWithAnotherDevice(codeForDisplayOrPasting: testRecoveryCode, stringForQRCode: testRecoveryCode)
+
+        await managementDialogModel.cancelPressedWithConfirmation()
+
+        XCTAssertEqual(confirmation.presentationCount, 1)
+        XCTAssertNil(managementDialogModel.currentDialog)
+    }
+
+    func testCancellingPairing_whenUserDeclines_keepsTheDialogOpen() async {
+        let confirmation = StubCloseSetupConfirmation(answer: false)
+        makeControllerWithCloseSetupConfirmation(confirmation, isSimplifiedSyncSetupV2Enabled: true)
+        let dialog = ManagementDialogKind.syncWithAnotherDevice(codeForDisplayOrPasting: testRecoveryCode, stringForQRCode: testRecoveryCode)
+        managementDialogModel.currentDialog = dialog
+
+        await managementDialogModel.cancelPressedWithConfirmation()
+
+        XCTAssertEqual(confirmation.presentationCount, 1)
+        XCTAssertEqual(managementDialogModel.currentDialog, dialog)
+    }
+
+    func testCancellingPairing_whenSimplifiedSyncSetupV2Disabled_endsTheFlowWithoutConfirming() async {
+        let confirmation = StubCloseSetupConfirmation(answer: false)
+        makeControllerWithCloseSetupConfirmation(confirmation, isSimplifiedSyncSetupV2Enabled: false)
+        managementDialogModel.currentDialog = .syncWithAnotherDevice(codeForDisplayOrPasting: testRecoveryCode, stringForQRCode: testRecoveryCode)
+
+        await managementDialogModel.cancelPressedWithConfirmation()
+
+        XCTAssertEqual(confirmation.presentationCount, 0)
+        XCTAssertNil(managementDialogModel.currentDialog)
+    }
+
+    func testCancellingADialogOutsideSetup_endsTheFlowWithoutConfirming() async {
+        let confirmation = StubCloseSetupConfirmation(answer: false)
+        makeControllerWithCloseSetupConfirmation(confirmation, isSimplifiedSyncSetupV2Enabled: true)
+        managementDialogModel.currentDialog = .removeDeviceV2(SyncDevice(kind: .current, name: "Mac", id: "1"))
+
+        await managementDialogModel.cancelPressedWithConfirmation()
+
+        XCTAssertEqual(confirmation.presentationCount, 0)
+        XCTAssertNil(managementDialogModel.currentDialog)
+    }
+
+    func testCancellingPairing_whenUserDeclinesThenConfirms_endsTheFlow() async {
+        let confirmation = StubCloseSetupConfirmation(answer: false)
+        makeControllerWithCloseSetupConfirmation(confirmation, isSimplifiedSyncSetupV2Enabled: true)
+        let dialog = ManagementDialogKind.syncWithAnotherDevice(codeForDisplayOrPasting: testRecoveryCode, stringForQRCode: testRecoveryCode)
+        managementDialogModel.currentDialog = dialog
+
+        await managementDialogModel.cancelPressedWithConfirmation()
+        XCTAssertEqual(managementDialogModel.currentDialog, dialog)
+
+        confirmation.answer = true
+        await managementDialogModel.cancelPressedWithConfirmation()
+
+        XCTAssertEqual(confirmation.presentationCount, 2)
+        XCTAssertNil(managementDialogModel.currentDialog)
+    }
+
     // MARK: - Helper Methods
+
+    private func makeControllerWithCloseSetupConfirmation(_ confirmation: StubCloseSetupConfirmation, isSimplifiedSyncSetupV2Enabled: Bool) {
+        featureFlagger.isFeatureOn[FeatureFlag.simplifiedSyncSetupV2.rawValue] = isSimplifiedSyncSetupV2Enabled
+        syncDialogController = SyncDialogController(
+            syncService: ddgSyncing,
+            managementDialogModel: managementDialogModel,
+            userAuthenticator: authenticator,
+            syncPausedStateManager: pausedStateManager,
+            connectionControllerFactory: { [weak self] _, _ in
+                self?.connectionController ?? MockSyncConnectionControlling()
+            },
+            featureFlagger: featureFlagger,
+            pixelFiring: pixelKitMock,
+            keyValueStore: mockKeyValueStore,
+            confirmCloseSetup: { await confirmation.present() }
+        )
+    }
 
     private func setUpWithSingleDevice(id: String) {
         ddgSyncing.account = SyncAccount(deviceId: id, deviceName: "iPhone", deviceType: "iPhone", userId: "", primaryKey: Data(), secretKey: Data(), token: nil, state: .active)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214200115953388/task/1217193469998975

**Description**:

Cancelling the Sync pairing screen used to tear down an in-progress connection with no warning. It now shows a confirmation first, and only abandons the flow (and fires the abandoned pixel) once the user confirms. Gated on `simplifiedSyncSetupV2`.


**Steps to test this PR**:

1. Enable `simplifiedSyncSetupV2`, go to Settings → Sync & Backup → Sync With Another Device, and authenticate.
2. On the "Scan QR code to sync" / "Enter the Sync Code" screen, hit Cancel — a confirmation appears with the Dax icon, "Cancel" on the left and "Close" on the right. Choose Cancel; the pairing screen stays open with the connection intact.
3. Hit Cancel again and choose Close — the pairing screen closes and the flow ends.
4. Regression: with `simplifiedSyncSetupV2` off, Cancel on the pairing screen closes it immediately, with no confirmation.

**Impact and Risks**:

Low — the new confirmation only appears behind `simplifiedSyncSetupV2`, on one screen.

**What could go wrong?**

The window-modal alert appears over the sync sheet rather than attached to it; if that reads oddly on a small display, the fallback is `beginSheetModal(for:)` at the cost of the icon.

###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is gated on simplifiedSyncSetupV2 for one screen; main caveat is window-modal alert presentation over the sync sheet on small displays.
> 
> **Overview**
> When **simplified Sync setup V2** is on, **Cancel** on the “Sync with another device” pairing screen no longer dismisses immediately. It runs **`cancelPressedWithConfirmation()`**, which asks **`SyncDialogController.shouldEndFlow`**; only if the user confirms via a new **`NSAlert.syncCloseSetupConfirmation`** does the flow end and the existing abandon/cancel analytics run.
> 
> The alert copy is added as **`NotLocalizedString`** V2 strings, and confirmation is **injectable** in **`SyncDialogController`** for unit tests. Other dialogs and the legacy flag-off path still close without prompting.
> 
> **Drive-by:** **`SyncUI-macOS`** now declares the **Lottie** SPM dependency so the package builds standalone, and the device rename **`TextField`** uses a label-less initializer so an empty localized title stops polluting **`Localizable.xcstrings`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26f9fcd1dea00cb8e750d60f902e8142e46597c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->