### PR TITLE
Attribute Duck.ai conversations started on the duckduckgo.com homepage

### DIFF
--- a/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatConsumableDataHandling.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatConsumableDataHandling.swift
@@ -112,6 +112,10 @@ public enum AIChatConversationSource: String, CaseIterable {
 
     case settings = "settings"
 
+    /// Inferred rather than stamped: no native code opens this one, so it is deduced from the tab
+    /// having loaded on the bare homepage with nothing else claiming the chat.
+    case duckduckgoHomepage = "duckduckgo-homepage"
+
     /// Named for the attribution gap it measures, not "direct": the app cannot tell deliberate
     /// direct navigation from an entry point nobody has instrumented yet.
     case unattributed = "unattributed"

--- a/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatConsumableDataHandling.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatConsumableDataHandling.swift
@@ -145,6 +145,13 @@ public final class AIChatConversationSourceHandler: AIChatConsumableDataHandling
         self.data = data
     }
 
+    /// For a source deduced from a navigation rather than from a deliberate action, so it can never
+    /// displace one a real surface staged moments earlier for the same chat.
+    public func setDataIfAbsent(_ data: DataType) {
+        guard self.data == nil else { return }
+        self.data = data
+    }
+
     public func consumeData() -> DataType? {
         let currentData = data
         reset()

--- a/SharedPackages/AIChat/Sources/AIChat/Shared/URL+Extension.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/URL+Extension.swift
@@ -80,7 +80,7 @@ extension URL {
     /// Returns `true` for the bare DuckDuckGo homepage, including variants that carry only
     /// non-search query parameters (e.g. `?ia=web`, `?atb=…`). Returns `false` for SERP URLs
     /// (which require a `q=` parameter) and for sub-pages like `/settings` or `/about`.
-    var isDuckDuckGoHomepage: Bool {
+    public var isDuckDuckGoHomepage: Bool {
         guard host == DuckDuckGo.host, path.isEmpty || path == "/" else { return false }
         return queryItems?.contains { $0.name == DuckDuckGo.bangQueryName } != true
     }

--- a/SharedPackages/AIChat/Sources/AIChat/Shared/URL+Extension.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/URL+Extension.swift
@@ -28,6 +28,7 @@ extension URL {
         static let bangQueryName = "q"
         static let supportedBangs: Set<String> = ["ai", "aichat", "chat", "duckai"]
         static let revokeAccessPath = "/revoke-duckai-access"
+        static let chatFragment = "chat"
     }
 
     static var duckDuckGoHost: String { DuckDuckGo.host }
@@ -83,6 +84,12 @@ extension URL {
     public var isDuckDuckGoHomepage: Bool {
         guard host == DuckDuckGo.host, path.isEmpty || path == "/" else { return false }
         return queryItems?.contains { $0.name == DuckDuckGo.bangQueryName } != true
+    }
+
+    /// Duck.ai's in-page chat route (`#chat`), which duckduckgo.com switches to without leaving the
+    /// document — invisible to `isDuckAIURL`, which only inspects the path and query.
+    public var isDuckAIChatFragment: Bool {
+        fragment?.lowercased().hasPrefix(DuckDuckGo.chatFragment) == true
     }
 
     /// Returns `true` if the URL points to Duck AI voice mode (`?mode=voice`).

--- a/SharedPackages/AIChat/Tests/AIChatTests/AIChatConversationSourceHandlerTests.swift
+++ b/SharedPackages/AIChat/Tests/AIChatTests/AIChatConversationSourceHandlerTests.swift
@@ -1,0 +1,56 @@
+//
+//  AIChatConversationSourceHandlerTests.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+@testable import AIChat
+
+final class AIChatConversationSourceHandlerTests: XCTestCase {
+
+    private var handler: AIChatConversationSourceHandler!
+
+    override func setUp() {
+        super.setUp()
+        handler = AIChatConversationSourceHandler()
+    }
+
+    override func tearDown() {
+        handler = nil
+        super.tearDown()
+    }
+
+    func testSetDataIfAbsentStoresWhenEmpty() {
+        handler.setDataIfAbsent(.duckduckgoHomepage)
+
+        XCTAssertEqual(handler.consumeData(), .duckduckgoHomepage)
+    }
+
+    func testSetDataIfAbsentLeavesAnExistingSourceAlone() {
+        handler.setData(.omnibar)
+        handler.setDataIfAbsent(.duckduckgoHomepage)
+
+        XCTAssertEqual(handler.consumeData(), .omnibar)
+    }
+
+    func testSetDataIfAbsentStoresAgainAfterConsuming() {
+        handler.setData(.omnibar)
+        _ = handler.consumeData()
+        handler.setDataIfAbsent(.duckduckgoHomepage)
+
+        XCTAssertEqual(handler.consumeData(), .duckduckgoHomepage)
+    }
+}

--- a/SharedPackages/AIChat/Tests/AIChatTests/URLExtensionTests.swift
+++ b/SharedPackages/AIChat/Tests/AIChatTests/URLExtensionTests.swift
@@ -364,6 +364,22 @@ final class URLExtensionTests: XCTestCase {
         XCTAssertFalse(URL(string: "https://duck.ai/")!.isDuckDuckGoHomepage)
     }
 
+    // MARK: - Duck.ai Chat Fragment Tests
+
+    func testIsDuckAIChatFragment() {
+        XCTAssertTrue(URL(string: "https://duckduckgo.com/#chat")!.isDuckAIChatFragment)
+        XCTAssertTrue(URL(string: "https://duckduckgo.com/#chat/abc123")!.isDuckAIChatFragment)
+        XCTAssertFalse(URL(string: "https://duckduckgo.com/")!.isDuckAIChatFragment)
+        XCTAssertFalse(URL(string: "https://duckduckgo.com/#settings")!.isDuckAIChatFragment)
+    }
+
+    /// The fragment is invisible to the path/query predicates, which is why it is checked separately.
+    func testChatFragmentIsInvisibleToTheOtherPredicates() {
+        let url = URL(string: "https://duckduckgo.com/#chat")!
+        XCTAssertTrue(url.isDuckDuckGoHomepage)
+        XCTAssertFalse(url.isDuckAIURL)
+    }
+
     // MARK: - AIChatTabMetadata.shouldExcludeFromTabPicker
 
     func testShouldExcludeFromTabPickerCoversAllThreeRules() {

--- a/macOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
+++ b/macOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
@@ -200,6 +200,10 @@ final class AIChatUserScriptHandler: AIChatUserScriptHandling {
     private var didConsumeConversationSource = false
     private let conversationSourceHandler: AIChatConversationSourceHandler
 
+    /// Captured at load rather than read at prompt time: by then the page may have navigated off the
+    /// homepage (`?q=…&ia=chat`) as part of starting the very conversation being described.
+    private var loadedOnDuckDuckGoHomepage = false
+
     /// Whether page context with content is currently attached to this chat — set by the native
     /// auto-attach push and updated by the frontend's add/remove toggle. Read at prompt submit for
     /// the conversation pixels' `hasPageContext`. Best-effort, mirroring Windows: only sidebar chats
@@ -268,15 +272,28 @@ final class AIChatUserScriptHandler: AIChatUserScriptHandling {
     }
 
     public func getAIChatNativeConfigValues(params: Any, message: UserScriptMessage) async -> Encodable? {
+        // Read up front so no suspension splits the commit below. `!isDuckAIURL` because the chat
+        // itself can be served from a homepage-shaped URL (`?ia=chat`).
+        let isHomepage = await message.messageWebView?.url.map { $0.isDuckDuckGoHomepage && !$0.isDuckAIURL } == true
+
         // Consume exactly once, at load, before the user can submit a prompt. Guarded by a flag (not
         // by `conversationSource == nil`) so a chat that loaded with an empty mailbox can't later
         // steal a different chat's pending source on a subsequent config fetch.
         if !didConsumeConversationSource {
             didConsumeConversationSource = true
-            conversationSource = conversationSourceHandler.consumeData()
+            // `??` so a first prompt racing ahead of this fetch keeps the source it already settled.
+            conversationSource = conversationSourceHandler.consumeData() ?? conversationSource
+            loadedOnDuckDuckGoHomepage = isHomepage
         }
         let isFireWindow = isFireWindowProvider?() ?? false
         return messageHandling.getNativeConfigValues(isFireWindow: isFireWindow)
+    }
+
+    /// duckduckgo.com fetches the config on every visit, so a homepage load drains the mailbox before
+    /// any chat starts; scoped to that case and the first prompt so no chat drains another's stamp.
+    private func resolveHomepageConversationSourceIfNeeded() {
+        guard conversationSource == nil, loadedOnDuckDuckGoHomepage else { return }
+        conversationSource = conversationSourceHandler.consumeData() ?? .duckduckgoHomepage
     }
 
     func closeAIChat(params: Any, message: UserScriptMessage) async -> Encodable? {
@@ -1094,6 +1111,7 @@ extension AIChatUserScriptHandler: AIChatMetricReportingHandling {
             pageContextConsumedSubject.send()
             // Selections were consumed by the prompt; clear the pull-store so a later init doesn't resurrect them.
             messageHandling.clearSelectionContexts()
+            resolveHomepageConversationSourceIfNeeded()
             pixelFiring?.fire(
                 AIChatPixel.aiChatMetricStartNewConversation(source: pixelConversationSource,
                                                              hasPageContext: hasAttachedPageContext),

--- a/macOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
+++ b/macOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
@@ -279,19 +279,28 @@ final class AIChatUserScriptHandler: AIChatUserScriptHandling {
     }
 
     /// duckduckgo.com fetches this config on every document load, so keying the capture to the
-    /// document is what keeps a source tied to one conversation: a real navigation re-captures
-    /// (clearing the previous conversation's source), while the homepage's same-document `#chat`
-    /// toggle keeps what that document captured.
+    /// document is what keeps a source tied to one conversation: leaving the chat drops the source,
+    /// while the homepage's same-document `#chat` toggle keeps what that document captured.
     private func captureConversationSource(for url: URL?) {
         let document = url?.strippingFragment
         guard !didCaptureConversationSource || document != conversationSourceDocument else { return }
         didCaptureConversationSource = true
         conversationSourceDocument = document
-        conversationSource = conversationSourceHandler.consumeData()
-        // A chat URL or `#chat` means the document opened as a chat, so no homepage started it here.
-        loadedOnDuckDuckGoHomepage = url.map {
-            $0.isDuckDuckGoHomepage && !$0.isDuckAIURL && !$0.isDuckAIChatFragment
-        } == true
+
+        // Only a chat can claim a stamp, and only if this conversation has none yet: a stamp is set
+        // just before a chat opens, so letting an ordinary page — or a conversation that already
+        // knows its source — consume it would take it from the chat it was meant for.
+        guard let url, !url.isDuckAIURL, !url.isDuckAIChatFragment else {
+            if conversationSource == nil {
+                conversationSource = conversationSourceHandler.consumeData()
+            }
+            loadedOnDuckDuckGoHomepage = false
+            return
+        }
+
+        // Not a chat, so whatever opened the last one no longer describes what happens here.
+        conversationSource = nil
+        loadedOnDuckDuckGoHomepage = url.isDuckDuckGoHomepage
     }
 
     /// The homepage switches to Duck.ai in place, so nothing native ever stamps a source for it;

--- a/macOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
+++ b/macOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
@@ -195,13 +195,14 @@ final class AIChatUserScriptHandler: AIChatUserScriptHandling {
 
     var isFireWindowProvider: (() -> Bool)?
 
-    /// Surface that opened this chat, consumed once at load and retained for the conversation's pixels.
+    /// Surface that opened this chat, consumed once per document and retained for its pixels.
     private var conversationSource: AIChatConversationSource?
-    private var didConsumeConversationSource = false
     private let conversationSourceHandler: AIChatConversationSourceHandler
 
-    /// Captured at load rather than read at prompt time: by then the page may have navigated off the
-    /// homepage (`?q=…&ia=chat`) as part of starting the very conversation being described.
+    /// Document the source was captured for, fragment stripped, so a real navigation re-captures
+    /// while the homepage's in-place `#chat` toggle keeps what that document captured.
+    private var didCaptureConversationSource = false
+    private var conversationSourceDocument: URL?
     private var loadedOnDuckDuckGoHomepage = false
 
     /// Whether page context with content is currently attached to this chat — set by the native
@@ -272,28 +273,32 @@ final class AIChatUserScriptHandler: AIChatUserScriptHandling {
     }
 
     public func getAIChatNativeConfigValues(params: Any, message: UserScriptMessage) async -> Encodable? {
-        // Read up front so no suspension splits the commit below. `!isDuckAIURL` because the chat
-        // itself can be served from a homepage-shaped URL (`?ia=chat`).
-        let isHomepage = await message.messageWebView?.url.map { $0.isDuckDuckGoHomepage && !$0.isDuckAIURL } == true
-
-        // Consume exactly once, at load, before the user can submit a prompt. Guarded by a flag (not
-        // by `conversationSource == nil`) so a chat that loaded with an empty mailbox can't later
-        // steal a different chat's pending source on a subsequent config fetch.
-        if !didConsumeConversationSource {
-            didConsumeConversationSource = true
-            // `??` so a first prompt racing ahead of this fetch keeps the source it already settled.
-            conversationSource = conversationSourceHandler.consumeData() ?? conversationSource
-            loadedOnDuckDuckGoHomepage = isHomepage
-        }
+        captureConversationSource(for: await message.messageWebView?.url)
         let isFireWindow = isFireWindowProvider?() ?? false
         return messageHandling.getNativeConfigValues(isFireWindow: isFireWindow)
     }
 
-    /// duckduckgo.com fetches the config on every visit, so a homepage load drains the mailbox before
-    /// any chat starts; scoped to that case and the first prompt so no chat drains another's stamp.
+    /// duckduckgo.com fetches this config on every document load, so keying the capture to the
+    /// document is what keeps a source tied to one conversation: a real navigation re-captures
+    /// (clearing the previous conversation's source), while the homepage's same-document `#chat`
+    /// toggle keeps what that document captured.
+    private func captureConversationSource(for url: URL?) {
+        let document = url?.strippingFragment
+        guard !didCaptureConversationSource || document != conversationSourceDocument else { return }
+        didCaptureConversationSource = true
+        conversationSourceDocument = document
+        conversationSource = conversationSourceHandler.consumeData()
+        // A chat URL or `#chat` means the document opened as a chat, so no homepage started it here.
+        loadedOnDuckDuckGoHomepage = url.map {
+            $0.isDuckDuckGoHomepage && !$0.isDuckAIURL && !$0.isDuckAIChatFragment
+        } == true
+    }
+
+    /// The homepage switches to Duck.ai in place, so nothing native ever stamps a source for it;
+    /// infer one from what this document loaded as, and only when nothing else claimed the chat.
     private func resolveHomepageConversationSourceIfNeeded() {
         guard conversationSource == nil, loadedOnDuckDuckGoHomepage else { return }
-        conversationSource = conversationSourceHandler.consumeData() ?? .duckduckgoHomepage
+        conversationSource = .duckduckgoHomepage
     }
 
     func closeAIChat(params: Any, message: UserScriptMessage) async -> Encodable? {
@@ -1187,4 +1192,15 @@ extension AIChatUserScriptHandler: AIChatMetricReportingHandling {
         freeTrialConversionService.markDuckAIActivated()
     }
 
+}
+
+private extension URL {
+
+    /// Two URLs differing only by fragment are the same document, which is how the homepage's
+    /// `#chat` toggle is told apart from a navigation that starts a different conversation.
+    var strippingFragment: URL {
+        guard fragment != nil, var components = URLComponents(url: self, resolvingAgainstBaseURL: false) else { return self }
+        components.fragment = nil
+        return components.url ?? self
+    }
 }

--- a/macOS/DuckDuckGo/Tab/TabExtensions/AIChatTabExtension.swift
+++ b/macOS/DuckDuckGo/Tab/TabExtensions/AIChatTabExtension.swift
@@ -44,6 +44,7 @@ final class AIChatTabExtension {
     private weak var webView: WKWebView?
     private let featureDiscovery: FeatureDiscovery
     private let featureFlagger: FeatureFlagger
+    private let aiChatConversationSourceHandler: AIChatConversationSourceHandler
     private let bootstrapRefresher: DuckAiNativeStorageBootstrapScriptRefresher?
     private let fireModeStorageProvider: () -> DuckAiFireModeStorage
 
@@ -62,12 +63,14 @@ final class AIChatTabExtension {
          featureFlagger: FeatureFlagger = NSApp.delegateTyped.featureFlagger,
          duckAiNativeStorageHandler: DuckAiNativeStorageHandling? = NSApp.delegateTyped.duckAiNativeStorageHandler,
          burnerDuckAiStorageRegistry: BurnerDuckAiStorageRegistry? = NSApp.delegateTyped.burnerDuckAiStorageRegistry,
+         aiChatConversationSourceHandler: AIChatConversationSourceHandler = NSApp.delegateTyped.aiChatConversationSourceHandler,
          aiChatDebugURLSettings: (any KeyedStoring<AIChatDebugURLSettings>)? = nil) {
         self.isLoadedInSidebar = isLoadedInSidebar
         self.isTabBurner = isTabBurner
         self.burnerMode = burnerMode
         self.featureDiscovery = featureDiscovery
         self.featureFlagger = featureFlagger
+        self.aiChatConversationSourceHandler = aiChatConversationSourceHandler
         let debugSettings: any KeyedStoring<AIChatDebugURLSettings> = if let aiChatDebugURLSettings { aiChatDebugURLSettings } else { UserDefaults.standard.keyedStoring() }
         self.fireModeStorageProvider = { [burnerMode, weak burnerDuckAiStorageRegistry] in
             .resolve(isFireMode: burnerMode.isBurner,
@@ -275,6 +278,7 @@ extension AIChatTabExtension: NavigationResponder {
 
     func decidePolicy(for navigationAction: NavigationAction, preferences: inout NavigationPreferences) async -> NavigationActionPolicy? {
         refreshNativeStorageBootstrapIfNeeded(for: navigationAction)
+        stampHomepageConversationSourceIfNeeded(for: navigationAction)
 
         // Only handle sidebar, user-initiated, cross-document navigations; otherwise let them proceed normally
         guard isLoadedInSidebar,
@@ -313,6 +317,40 @@ extension AIChatTabExtension: NavigationResponder {
     func navigationDidFinish(_ navigation: Navigation) {
         if navigation.url.isDuckAIURL {
             featureDiscovery.setWasUsedBefore(.aiChat)
+        }
+    }
+
+    /// The duckduckgo.com homepage opens Duck.ai by navigating there itself, so nothing else records
+    /// a source for it. Restricted to web-originated navigations: a typed URL, bookmark, restored
+    /// session or native surface is not the homepage handing over, and each of those either records
+    /// its own source or is meant to stay unattributed.
+    private func stampHomepageConversationSourceIfNeeded(for navigationAction: NavigationAction) {
+        guard !isLoadedInSidebar,
+              navigationAction.isForMainFrame,
+              navigationAction.url.isDuckAIURL,
+              navigationAction.sourceFrame.url.isDuckDuckGoHomepage
+        else { return }
+
+        guard navigationAction.navigationType.isWebOriginated else {
+            Logger.aiChat.debug("Duck.ai opened from the homepage by \(navigationAction.navigationType.debugDescription, privacy: .public) — not the homepage handing over")
+            return
+        }
+
+        aiChatConversationSourceHandler.setDataIfAbsent(.duckduckgoHomepage)
+    }
+}
+
+private extension NavigationType {
+
+    /// Started by the page itself rather than by the browser, which is what separates the homepage
+    /// handing over to Duck.ai from the user typing or bookmarking a chat URL.
+    var isWebOriginated: Bool {
+        switch self {
+        case .linkActivated, .formSubmitted, .formResubmitted, .other:
+            return true
+        case .backForward, .reload, .redirect, .sessionRestoration, .alternateHtmlLoad,
+             .sameDocumentNavigation, .custom:
+            return false
         }
     }
 }

--- a/macOS/PixelDefinitions/pixels/params_dictionary.json5
+++ b/macOS/PixelDefinitions/pixels/params_dictionary.json5
@@ -480,7 +480,7 @@
     "aiChatConversationSource": {
         "key": "source",
         "type": "string",
-        "description": "The user-facing surface that opened the Duck.ai conversation this prompt was submitted in. Recorded just before the chat opens and consumed once when it loads, so for an ongoing chat it describes how that chat was originally opened, not where this particular prompt came from. Values name the specific control that was used, down to the individual menu item, so a voice, image-generation or resumed-chat start stays attributable to the surface it came from (e.g. 'new-tab-page-voice', 'main-menu-image', 'omnibar-recent-chat'). The 'contextual-*' values are page actions on the current page or selection; 'address-bar-context-menu' is the right-click menu on the address-bar Duck.ai button and is unrelated to them. 'unattributed' means no surface was recorded \u2014 direct navigation to duck.ai, a session restored at startup, a bookmark or external link, or an entry point not yet instrumented \u2014 so it measures the attribution gap rather than naming a real entry point. Mirrors AIChatConversationSource in SharedPackages/AIChat.",
+        "description": "The user-facing surface that opened the Duck.ai conversation this prompt was submitted in. Recorded just before the chat opens and consumed once when it loads, so for an ongoing chat it describes how that chat was originally opened, not where this particular prompt came from. Values name the specific control that was used, down to the individual menu item, so a voice, image-generation or resumed-chat start stays attributable to the surface it came from (e.g. 'new-tab-page-voice', 'main-menu-image', 'omnibar-recent-chat'). The 'contextual-*' values are page actions on the current page or selection; 'address-bar-context-menu' is the right-click menu on the address-bar Duck.ai button and is unrelated to them. 'duckduckgo-homepage' is a conversation the duckduckgo.com homepage started itself, through its own search/Duck.ai toggle: unlike every other value it is inferred rather than recorded, from the tab having been on the bare homepage when the page loaded with no native surface claiming the chat, so it also covers a second chat started later in such a tab. 'unattributed' means no surface was recorded \u2014 direct navigation to duck.ai, a session restored at startup, a bookmark or external link, or an entry point not yet instrumented \u2014 so it measures the attribution gap rather than naming a real entry point. Mirrors AIChatConversationSource in SharedPackages/AIChat.",
         "enum": [
             "tab-bar-button",
             "ask-about-page",
@@ -519,6 +519,7 @@
             "serp",
             "sidebar-handoff",
             "settings",
+            "duckduckgo-homepage",
             "unattributed"
         ]
     }

--- a/macOS/UnitTests/AIChat/AIChatUserScriptHandlerTests.swift
+++ b/macOS/UnitTests/AIChat/AIChatUserScriptHandlerTests.swift
@@ -26,6 +26,7 @@ import FoundationExtensions
 import PrivacyConfig
 @_spi(Testing) import SharedTestUtilities
 import Subscription
+import SubscriptionTestingUtilities
 import Testing
 import UserScript
 import WebKit
@@ -543,7 +544,8 @@ struct AIChatUserScriptHandlerTests {
     /// value — these read the fired parameters directly.
     @MainActor
     private func firedConversationParameters(source: AIChatConversationSource?,
-                                             metric: AIChatMetricName) async -> [String: String]? {
+                                             metric: AIChatMetricName,
+                                             webView: WKWebView? = nil) async -> [String: String]? {
         let sourceHandler = AIChatConversationSourceHandler()
         if let source {
             sourceHandler.setData(source)
@@ -564,7 +566,7 @@ struct AIChatUserScriptHandlerTests {
         )
 
         // The first native-config fetch is what consumes the pending source.
-        _ = await testHandler.getAIChatNativeConfigValues(params: [], message: WKScriptMessage.mock())
+        _ = await testHandler.getAIChatNativeConfigValues(params: [], message: WKScriptMessage.mock(webView: webView))
 
         await withCheckedContinuation { continuation in
             testHandler.didReportMetric(.init(metricName: metric)) {
@@ -582,6 +584,103 @@ struct AIChatUserScriptHandlerTests {
         let parameters = await firedConversationParameters(source: nil, metric: .userDidSubmitFirstPrompt)
         #expect(parameters?["source"] == "unattributed")
         #expect(parameters?["isOpenedFromAskDuckAiButton"] == "false")
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test("A chat with no recorded surface loaded on the bare duckduckgo.com homepage is attributed to it", .timeLimit(.minutes(1)))
+    @MainActor
+    func testThatConversationPixelAttributesUnstampedChatToDuckDuckGoHomepage() async {
+        let webView = mockWebView(url: "https://duckduckgo.com/")
+        let parameters = await firedConversationParameters(source: nil, metric: .userDidSubmitFirstPrompt, webView: webView)
+        #expect(parameters?["source"] == "duckduckgo-homepage")
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test("A chat with no recorded surface loaded on a non-homepage duckduckgo.com URL stays unattributed", .timeLimit(.minutes(1)))
+    @MainActor
+    func testThatConversationPixelDoesNotAttributeNonHomepageURLToDuckDuckGoHomepage() async {
+        let webView = mockWebView(url: "https://duckduckgo.com/?q=test")
+        let parameters = await firedConversationParameters(source: nil, metric: .userDidSubmitFirstPrompt, webView: webView)
+        #expect(parameters?["source"] == "unattributed")
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test("A recorded surface wins over the homepage fallback", .timeLimit(.minutes(1)))
+    @MainActor
+    func testThatConversationPixelPrefersRecordedSourceOverDuckDuckGoHomepageFallback() async {
+        let webView = mockWebView(url: "https://duckduckgo.com/")
+        let parameters = await firedConversationParameters(source: .serp, metric: .userDidSubmitFirstPrompt, webView: webView)
+        #expect(parameters?["source"] == "serp")
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test("A source staged after an earlier, empty config fetch is still picked up when the prompt is submitted", .timeLimit(.minutes(1)))
+    @MainActor
+    func testThatConversationPixelPicksUpSourceStagedAfterAnEarlierEmptyConfigFetch() async {
+        // Mirrors the omnibar reusing a tab already on duckduckgo.com: the homepage's config fetch
+        // drains the mailbox first, and only then does the omnibar stamp the real source.
+        let sourceHandler = AIChatConversationSourceHandler()
+        let testPixelFiring = PixelKitMock()
+        let testHandler = makeHandler(sourceHandler: sourceHandler, pixelFiring: testPixelFiring)
+
+        let homepageWebView = mockWebView(url: "https://duckduckgo.com/")
+        _ = await testHandler.getAIChatNativeConfigValues(params: [], message: WKScriptMessage.mock(webView: homepageWebView))
+
+        sourceHandler.setData(.omnibar)
+
+        _ = await testHandler.reportMetric(params: ["metricName": "userDidSubmitFirstPrompt"], message: WKScriptMessage.mock())
+
+        #expect(testPixelFiring.actualFireCalls.first?.pixel.parameters?["source"] == "omnibar")
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test("A chat served from a homepage-shaped duckduckgo.com URL is not attributed to the homepage", .timeLimit(.minutes(1)))
+    @MainActor
+    func testThatAChatServedFromAHomepageShapedURLIsNotAttributedToTheHomepage() async {
+        // `?ia=chat` carries no `q=`, so it is homepage-shaped while actually being the chat itself.
+        let webView = mockWebView(url: "https://duckduckgo.com/?ia=chat")
+        let parameters = await firedConversationParameters(source: nil, metric: .userDidSubmitFirstPrompt, webView: webView)
+        #expect(parameters?["source"] == "unattributed")
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test("An ongoing chat keeps the source its first prompt resolved and leaves a later stamp alone", .timeLimit(.minutes(1)))
+    @MainActor
+    func testThatOngoingChatKeepsItsSourceAndLeavesALaterStampAlone() async {
+        // The mailbox is app-wide, so a stamp can land mid-conversation for a different chat: this
+        // one must neither re-attribute itself to it nor consume it out from under its owner.
+        let sourceHandler = AIChatConversationSourceHandler()
+        let testPixelFiring = PixelKitMock()
+        let testHandler = makeHandler(sourceHandler: sourceHandler, pixelFiring: testPixelFiring)
+
+        let homepageWebView = mockWebView(url: "https://duckduckgo.com/")
+        _ = await testHandler.getAIChatNativeConfigValues(params: [], message: WKScriptMessage.mock(webView: homepageWebView))
+        _ = await testHandler.reportMetric(params: ["metricName": "userDidSubmitFirstPrompt"], message: WKScriptMessage.mock())
+
+        sourceHandler.setData(.omnibar)
+        _ = await testHandler.reportMetric(params: ["metricName": "userDidSubmitPrompt"], message: WKScriptMessage.mock())
+
+        #expect(testPixelFiring.actualFireCalls.last?.pixel.parameters?["source"] == "duckduckgo-homepage")
+        #expect(sourceHandler.consumeData() == .omnibar)
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test("The homepage fallback still applies once the page has moved on to a chat URL by prompt time", .timeLimit(.minutes(1)))
+    @MainActor
+    func testThatConversationPixelAttributesToHomepageEvenAfterTheURLMovesOnByPromptTime() async {
+        // Guards against re-regressing to sniffing the live URL at prompt time, which reads the
+        // in-place navigation the homepage toggle performs as "not the homepage".
+        let sourceHandler = AIChatConversationSourceHandler()
+        let testPixelFiring = PixelKitMock()
+        let testHandler = makeHandler(sourceHandler: sourceHandler, pixelFiring: testPixelFiring)
+
+        let homepageWebView = mockWebView(url: "https://duckduckgo.com/")
+        _ = await testHandler.getAIChatNativeConfigValues(params: [], message: WKScriptMessage.mock(webView: homepageWebView))
+
+        let chatWebView = mockWebView(url: "https://duckduckgo.com/?q=test&ia=chat")
+        _ = await testHandler.reportMetric(params: ["metricName": "userDidSubmitFirstPrompt"], message: WKScriptMessage.mock(webView: chatWebView))
+
+        #expect(testPixelFiring.actualFireCalls.first?.pixel.parameters?["source"] == "duckduckgo-homepage")
     }
 
     @available(iOS 16, macOS 13, *)
@@ -1129,6 +1228,30 @@ struct AIChatUserScriptHandlerTests {
         )
     }
 
+    /// For tests that stage the mailbox mid-flight, so they hold it and the pixel mock themselves.
+    @MainActor
+    private func makeHandler(sourceHandler: AIChatConversationSourceHandler,
+                             pixelFiring: PixelKitMock) -> AIChatUserScriptHandler {
+        AIChatUserScriptHandler(
+            storage: storage,
+            messageHandling: messageHandler,
+            windowControllersManager: windowControllersManager,
+            pixelFiring: pixelFiring,
+            statisticsLoader: statisticsLoader,
+            syncServiceProvider: { nil },
+            syncErrorHandler: syncErrorHandler,
+            featureFlagger: MockFeatureFlagger(),
+            notificationCenter: notificationCenter,
+            conversationSourceHandler: sourceHandler
+        )
+    }
+
+    /// Module-qualified because this test target has its own unrelated `MockWKWebView`. Bind the
+    /// result to a local — `WKScriptMessage.mock` holds the web view weakly.
+    private func mockWebView(url: String) -> WKWebView {
+        SubscriptionTestingUtilities.MockWKWebView(url: URL(string: url)!)
+    }
+
     // MARK: - Free Trial Conversion Tracking
 
     @available(iOS 16, macOS 13, *)
@@ -1522,6 +1645,7 @@ struct AIChatConversationSourcePixelTests {
         "serp",
         "sidebar-handoff",
         "settings",
+        "duckduckgo-homepage",
         "unattributed"
     ]
 

--- a/macOS/UnitTests/AIChat/AIChatUserScriptHandlerTests.swift
+++ b/macOS/UnitTests/AIChat/AIChatUserScriptHandlerTests.swift
@@ -608,9 +608,52 @@ struct AIChatUserScriptHandlerTests {
     @Test("A recorded surface wins over the homepage fallback", .timeLimit(.minutes(1)))
     @MainActor
     func testThatConversationPixelPrefersRecordedSourceOverDuckDuckGoHomepageFallback() async {
-        let webView = mockWebView(url: "https://duckduckgo.com/")
+        let webView = mockWebView(url: "https://duckduckgo.com/?ia=chat")
         let parameters = await firedConversationParameters(source: .serp, metric: .userDidSubmitFirstPrompt, webView: webView)
         #expect(parameters?["source"] == "serp")
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test("An ordinary duckduckgo.com page leaves a stamp pending for the chat it was meant for", .timeLimit(.minutes(1)))
+    @MainActor
+    func testThatANonChatPageDoesNotConsumeAPendingStamp() async {
+        // The mailbox is app-wide, so a page that can't be a chat must not drain it — the chat it
+        // was stamped for may be loading in another tab.
+        let sourceHandler = AIChatConversationSourceHandler()
+        let testPixelFiring = PixelKitMock()
+        let testHandler = makeHandler(sourceHandler: sourceHandler, pixelFiring: testPixelFiring)
+
+        sourceHandler.setData(.tabBarButton)
+
+        let serpWebView = mockWebView(url: "https://duckduckgo.com/?q=test")
+        _ = await testHandler.getAIChatNativeConfigValues(params: [], message: WKScriptMessage.mock(webView: serpWebView))
+
+        #expect(sourceHandler.consumeData() == .tabBarButton)
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test("A resolved source survives the chat's own URL changing mid-conversation", .timeLimit(.minutes(1)))
+    @MainActor
+    func testThatAResolvedSourceSurvivesTheChatURLChanging() async {
+        // The frontend can rewrite the chat's URL as the conversation proceeds (e.g. appending a
+        // chatID); that is the same conversation, so its source must not be re-derived or dropped.
+        let sourceHandler = AIChatConversationSourceHandler()
+        let testPixelFiring = PixelKitMock()
+        let testHandler = makeHandler(sourceHandler: sourceHandler, pixelFiring: testPixelFiring)
+
+        let homepageWebView = mockWebView(url: "https://duckduckgo.com/")
+        _ = await testHandler.getAIChatNativeConfigValues(params: [], message: WKScriptMessage.mock(webView: homepageWebView))
+        _ = await testHandler.reportMetric(params: ["metricName": "userDidSubmitFirstPrompt"], message: WKScriptMessage.mock())
+        #expect(testPixelFiring.actualFireCalls.first?.pixel.parameters?["source"] == "duckduckgo-homepage")
+
+        // A stamp for a different chat lands while this conversation continues.
+        sourceHandler.setData(.omnibar)
+        let chatIDWebView = mockWebView(url: "https://duckduckgo.com/?ia=chat&chatID=abc123")
+        _ = await testHandler.getAIChatNativeConfigValues(params: [], message: WKScriptMessage.mock(webView: chatIDWebView))
+        _ = await testHandler.reportMetric(params: ["metricName": "userDidSubmitPrompt"], message: WKScriptMessage.mock())
+
+        #expect(testPixelFiring.actualFireCalls.last?.pixel.parameters?["source"] == "duckduckgo-homepage")
+        #expect(sourceHandler.consumeData() == .omnibar)
     }
 
     @available(iOS 16, macOS 13, *)

--- a/macOS/UnitTests/AIChat/AIChatUserScriptHandlerTests.swift
+++ b/macOS/UnitTests/AIChat/AIChatUserScriptHandlerTests.swift
@@ -618,7 +618,7 @@ struct AIChatUserScriptHandlerTests {
     @MainActor
     func testThatConversationPixelPicksUpSourceStagedAfterAnEarlierEmptyConfigFetch() async {
         // Mirrors the omnibar reusing a tab already on duckduckgo.com: the homepage's config fetch
-        // drains the mailbox first, and only then does the omnibar stamp the real source.
+        // drains the mailbox, then the omnibar stamps the real source and navigates that same tab.
         let sourceHandler = AIChatConversationSourceHandler()
         let testPixelFiring = PixelKitMock()
         let testHandler = makeHandler(sourceHandler: sourceHandler, pixelFiring: testPixelFiring)
@@ -628,9 +628,83 @@ struct AIChatUserScriptHandlerTests {
 
         sourceHandler.setData(.omnibar)
 
+        let chatWebView = mockWebView(url: "https://duckduckgo.com/?q=test&ia=chat")
+        _ = await testHandler.getAIChatNativeConfigValues(params: [], message: WKScriptMessage.mock(webView: chatWebView))
         _ = await testHandler.reportMetric(params: ["metricName": "userDidSubmitFirstPrompt"], message: WKScriptMessage.mock())
 
         #expect(testPixelFiring.actualFireCalls.first?.pixel.parameters?["source"] == "omnibar")
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test("Switching to Duck.ai in place keeps the homepage attribution", .timeLimit(.minutes(1)))
+    @MainActor
+    func testThatTheInPlaceChatToggleKeepsTheHomepageAttribution() async {
+        // `#chat` is a fragment change, so it is the same document and must not re-capture.
+        let sourceHandler = AIChatConversationSourceHandler()
+        let testPixelFiring = PixelKitMock()
+        let testHandler = makeHandler(sourceHandler: sourceHandler, pixelFiring: testPixelFiring)
+
+        let homepageWebView = mockWebView(url: "https://duckduckgo.com/")
+        _ = await testHandler.getAIChatNativeConfigValues(params: [], message: WKScriptMessage.mock(webView: homepageWebView))
+
+        let chatFragmentWebView = mockWebView(url: "https://duckduckgo.com/#chat")
+        _ = await testHandler.getAIChatNativeConfigValues(params: [], message: WKScriptMessage.mock(webView: chatFragmentWebView))
+        _ = await testHandler.reportMetric(params: ["metricName": "userDidSubmitFirstPrompt"], message: WKScriptMessage.mock())
+
+        #expect(testPixelFiring.actualFireCalls.first?.pixel.parameters?["source"] == "duckduckgo-homepage")
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test("A chat opened straight at #chat is not attributed to the homepage", .timeLimit(.minutes(1)))
+    @MainActor
+    func testThatAChatOpenedStraightAtTheChatFragmentIsNotAttributedToTheHomepage() async {
+        // A bookmark or typed `duckduckgo.com/#chat`: homepage-shaped, but it opened as a chat.
+        let webView = mockWebView(url: "https://duckduckgo.com/#chat")
+        let parameters = await firedConversationParameters(source: nil, metric: .userDidSubmitFirstPrompt, webView: webView)
+        #expect(parameters?["source"] == "unattributed")
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test("Leaving the homepage for Duck.ai in the same tab drops the homepage attribution", .timeLimit(.minutes(1)))
+    @MainActor
+    func testThatNavigatingFromTheHomepageToDuckAIIsNotAttributedToTheHomepage() async {
+        let sourceHandler = AIChatConversationSourceHandler()
+        let testPixelFiring = PixelKitMock()
+        let testHandler = makeHandler(sourceHandler: sourceHandler, pixelFiring: testPixelFiring)
+
+        let homepageWebView = mockWebView(url: "https://duckduckgo.com/")
+        _ = await testHandler.getAIChatNativeConfigValues(params: [], message: WKScriptMessage.mock(webView: homepageWebView))
+
+        let duckAIWebView = mockWebView(url: "https://duck.ai/")
+        _ = await testHandler.getAIChatNativeConfigValues(params: [], message: WKScriptMessage.mock(webView: duckAIWebView))
+        _ = await testHandler.reportMetric(params: ["metricName": "userDidSubmitFirstPrompt"], message: WKScriptMessage.mock())
+
+        #expect(testPixelFiring.actualFireCalls.first?.pixel.parameters?["source"] == "unattributed")
+    }
+
+    @available(iOS 16, macOS 13, *)
+    @Test("Returning to the homepage for a second conversation drops the first conversation's source", .timeLimit(.minutes(1)))
+    @MainActor
+    func testThatASecondConversationInTheSameTabDoesNotReuseTheFirstSource() async {
+        let sourceHandler = AIChatConversationSourceHandler()
+        let testPixelFiring = PixelKitMock()
+        let testHandler = makeHandler(sourceHandler: sourceHandler, pixelFiring: testPixelFiring)
+
+        let homepageWebView = mockWebView(url: "https://duckduckgo.com/")
+        _ = await testHandler.getAIChatNativeConfigValues(params: [], message: WKScriptMessage.mock(webView: homepageWebView))
+
+        sourceHandler.setData(.omnibar)
+        let chatWebView = mockWebView(url: "https://duckduckgo.com/?q=test&ia=chat")
+        _ = await testHandler.getAIChatNativeConfigValues(params: [], message: WKScriptMessage.mock(webView: chatWebView))
+        _ = await testHandler.reportMetric(params: ["metricName": "userDidSubmitFirstPrompt"], message: WKScriptMessage.mock())
+        #expect(testPixelFiring.actualFireCalls.first?.pixel.parameters?["source"] == "omnibar")
+
+        // Back to the homepage in that same tab, then start a fresh conversation from its toggle.
+        let secondHomepageWebView = mockWebView(url: "https://duckduckgo.com/")
+        _ = await testHandler.getAIChatNativeConfigValues(params: [], message: WKScriptMessage.mock(webView: secondHomepageWebView))
+        _ = await testHandler.reportMetric(params: ["metricName": "userDidSubmitFirstPrompt"], message: WKScriptMessage.mock())
+
+        #expect(testPixelFiring.actualFireCalls.last?.pixel.parameters?["source"] == "duckduckgo-homepage")
     }
 
     @available(iOS 16, macOS 13, *)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1148564399326804/task/1218148420865620?focus=true

### Description

- This PR ensures that when a Duck.ai chat starts at duckduckgo.com the `m_mac_aichat_start_new_conversation` pixel reports `duckduckgo-homepage` as source

### Testing Steps

1. New tab → `duckduckgo.com` → Ask AI → submit a prompt → `source=duckduckgo-homepage`
2. New tab → `duckduckgo.com` → submit a prompt with the browser's omnibar Duck.ai mode → `source=omnibar`
3. On the homepage, type `duck.ai` in the address bar → submit a prompt → `source=unattributed`
4. After step 2, in the same tab go back to `duckduckgo.com` → Ask AI → submit → `source=duckduckgo-homepage` (not `omnibar`)
5. SERP → Ask Duck.ai handoff → `source=serp`; Duck.ai tab-bar button → `source=tab-bar-button` (unchanged)
6. Continue any of the above with a second prompt → `aichat_sent_prompt_ongoing_chat` carries the same source

### Impact

Low — pixel attribution only; no user-facing behaviour changes.

#### What could go wrong?

- The frontend renames `origin=funnel_home_website` → homepage conversations fall back to `unattributed` (today's behaviour), never to a wrong source. Same class of dependency as `isDuckAIURL` has on `ia=chat`.
- `AIChatTabExtension.didCommit` has no unit harness (constructing a `Navigation` isn't practical) → covered by the manual steps above; the handler-side reset it calls is unit-tested.
