### PR TITLE
iOS [iPad]: Fire autocomplete display/click pixels in the suggestions popover

### DIFF
--- a/iOS/DuckDuckGo/AutocompleteSuggestionsPixels.swift
+++ b/iOS/DuckDuckGo/AutocompleteSuggestionsPixels.swift
@@ -60,6 +60,17 @@ struct AutocompleteSuggestionsPixels {
         if openTab { pixelFiring.fire(.autocompleteDisplayedOpenedTab, withAdditionalParameters: [:]) }
     }
 
+    /// The single entry point hosts should use for a tapped suggestion: fires the standard click
+    /// pixel plus, for `.askAIChat`, its daily pixel — so no surface can fire a partial set.
+    func fireClickPixels(for suggestion: Suggestion,
+                         isExperimentalAIChatExperience: @autoclosure () -> Bool,
+                         aiChatDiscoveryParameters: @autoclosure () -> [String: String]) {
+        fireClickPixel(for: suggestion)
+        guard case .askAIChat = suggestion else { return }
+        fireAskAIChatClickPixel(isExperimentalExperience: isExperimentalAIChatExperience(),
+                                additionalParameters: aiChatDiscoveryParameters())
+    }
+
     /// Fires the click pixel matching a tapped suggestion. `.askAIChat` is a daily pixel with
     /// feature-discovery params, so it's fired separately via `fireAskAIChatClickPixel`.
     func fireClickPixel(for suggestion: Suggestion) {

--- a/iOS/DuckDuckGo/SuggestionTrayViewController.swift
+++ b/iOS/DuckDuckGo/SuggestionTrayViewController.swift
@@ -117,6 +117,8 @@ class SuggestionTrayViewController: UIViewController {
     /// `AutocompleteViewController`; its source is retained here for row-tap resolution.
     private var popoverSearchController: PopoverSuggestionsController?
     private var popoverSearchSource: SearchSuggestionsSource?
+    /// Retained so the display pixels can report the results last shown when the surface is removed.
+    private var popoverSearchLoader: SearchSuggestionsLoader?
     /// iPad Duck.ai surface hosted in the same popover; source provided by the owner.
     weak var duckAINavigationDelegate: SuggestionTrayDuckAINavigationDelegate?
     private var popoverDuckAIController: PopoverSuggestionsController?
@@ -144,6 +146,7 @@ class SuggestionTrayViewController: UIViewController {
     private let aiChatSettings: AIChatSettingsProvider
     private let featureDiscovery: FeatureDiscovery
     private let hideBorder: Bool
+    private let autocompletePixels = AutocompleteSuggestionsPixels()
 
     var coversFullScreen: Bool = false
 
@@ -557,6 +560,7 @@ class SuggestionTrayViewController: UIViewController {
                                              query: { querySubject.value },
                                              showAskAIChat: aiChatSettings.isAIChatEnabled)
         popoverSearchSource = source
+        popoverSearchLoader = loader
 
         let controller = PopoverSuggestionsController(
             source: source,
@@ -566,8 +570,9 @@ class SuggestionTrayViewController: UIViewController {
             self?.applyPopoverContentHeight(height, from: .search)
         }
         controller.onSelectRow = { [weak self] id in
-            guard let suggestion = source.suggestion(forRowID: id) else { return }
-            self?.autocompleteDelegate?.autocomplete(selectedSuggestion: suggestion)
+            guard let self, let suggestion = source.suggestion(forRowID: id) else { return }
+            self.fireSearchSuggestionClickPixels(for: suggestion)
+            self.autocompleteDelegate?.autocomplete(selectedSuggestion: suggestion)
         }
         controller.onTapAheadRow = { [weak self] id in
             guard let suggestion = source.suggestion(forRowID: id) else { return }
@@ -598,6 +603,23 @@ class SuggestionTrayViewController: UIViewController {
                 additionalInsets: UIEdgeInsets(top: 0, left: autocompleteHorizontalInset, bottom: 0, right: autocompleteHorizontalInset))
         controller.view.isHidden = (popoverMode != .search)
         popoverSearchController = controller
+    }
+
+    // MARK: - iPad search surface pixels
+
+    /// The iPad popover replaced `AutocompleteViewController`, which was the only thing firing the
+    /// autocomplete telemetry on this path, so both surfaces fire it through the shared mapper.
+    private func fireSearchSuggestionClickPixels(for suggestion: Suggestion) {
+        autocompletePixels.fireClickPixels(
+            for: suggestion,
+            isExperimentalAIChatExperience: aiChatSettings.isAIChatSearchInputUserSettingsEnabled,
+            aiChatDiscoveryParameters: featureDiscovery.addToParams([:], forFeature: .aiChat))
+    }
+
+    /// Fires one display pixel per local category last shown, at the same point in the surface's
+    /// lifecycle as the legacy `viewWillDisappear` it replaced.
+    private func fireSearchSuggestionsDisplayPixels() {
+        autocompletePixels.fireDisplayPixels(for: popoverSearchLoader?.result.all ?? [])
     }
 
     // MARK: - iPad Duck.ai surface
@@ -730,10 +752,12 @@ class SuggestionTrayViewController: UIViewController {
 
     private func removeAutocomplete(animated: Bool) {
         if let popoverController = popoverSearchController {
+            fireSearchSuggestionsDisplayPixels()
             popoverController.tearDown()
             removeController(popoverController, animated: animated)
             popoverSearchController = nil
             popoverSearchSource = nil
+            popoverSearchLoader = nil
         }
         guard let controller = autocompleteController else { return }
         removeController(controller, animated: deferAutocompleteReveal ? false : animated)

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedInputContentContainerViewController.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedInputContentContainerViewController.swift
@@ -1074,14 +1074,13 @@ extension UnifiedInputContentContainerViewController {
         delegate?.unifiedInputEditingStateDidRequestSyncSetup()
     }
 
-    /// Fires the click pixel for a tapped Search-surface suggestion. `.askAIChat` gets its own daily
-    /// pixel (needs feature-discovery params), so it's fired here after the standard mapping.
+    /// Fires the click pixels for a tapped Search-surface suggestion. Shared with the iPad popover
+    /// (`SuggestionTrayViewController`) so both surfaces report the same set.
     private func fireSearchSuggestionClickPixel(for suggestion: Suggestion) {
-        autocompletePixels.fireClickPixel(for: suggestion)
-        guard case .askAIChat = suggestion else { return }
-        autocompletePixels.fireAskAIChatClickPixel(
-            isExperimentalExperience: aiChatSettings.isAIChatSearchInputUserSettingsEnabled,
-            additionalParameters: featureDiscovery.addToParams([:], forFeature: .aiChat))
+        autocompletePixels.fireClickPixels(
+            for: suggestion,
+            isExperimentalAIChatExperience: aiChatSettings.isAIChatSearchInputUserSettingsEnabled,
+            aiChatDiscoveryParameters: featureDiscovery.addToParams([:], forFeature: .aiChat))
     }
 
     private func fireDuckAISuggestionClickPixel(for suggestion: Suggestion) {

--- a/iOS/DuckDuckGoTests/Autocomplete/AutocompleteSuggestionsPixelsTests.swift
+++ b/iOS/DuckDuckGoTests/Autocomplete/AutocompleteSuggestionsPixelsTests.swift
@@ -130,6 +130,38 @@ final class AutocompleteSuggestionsPixelsTests: XCTestCase {
         XCTAssertTrue(firedNames.isEmpty)
     }
 
+    // MARK: - Click (total entry point)
+
+    func testClickPixelsFiresOnlyTheStandardPixelForANonAIChatSuggestion() {
+        pixels.fireClickPixels(for: .phrase(phrase: "q"),
+                               isExperimentalAIChatExperience: true,
+                               aiChatDiscoveryParameters: [:])
+
+        XCTAssertEqual(firedNames, [Pixel.Event.autocompleteClickPhrase.name])
+        XCTAssertNil(PixelFiringMock.lastDailyPixelInfo)
+    }
+
+    func testClickPixelsFiresTheDailyPixelForAskAIChat() {
+        pixels.fireClickPixels(for: .askAIChat(value: "q"),
+                               isExperimentalAIChatExperience: true,
+                               aiChatDiscoveryParameters: ["was_used_before": "1"])
+
+        XCTAssertEqual(PixelFiringMock.lastDailyPixelInfo?.pixelName,
+                       Pixel.Event.autocompleteAskAIChatExperimentalExperience.name)
+        XCTAssertEqual(PixelFiringMock.lastDailyPixelInfo?.params?["was_used_before"], "1")
+    }
+
+    /// The AI-chat context reads settings and feature-discovery state, so it must stay unevaluated on
+    /// the common (non-AI-chat) tap.
+    func testClickPixelsDoesNotResolveTheAIChatContextForOtherSuggestions() {
+        var didResolveContext = false
+        pixels.fireClickPixels(for: .website(url: url("https://a.com")),
+                               isExperimentalAIChatExperience: { didResolveContext = true; return true }(),
+                               aiChatDiscoveryParameters: [:])
+
+        XCTAssertFalse(didResolveContext)
+    }
+
     // MARK: - Ask AI Chat (daily)
 
     func testAskAIChatExperimentalDailyPixel() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204912272578138/task/1217942587809031

### Description

iPad autocomplete pixels have been dead since 7.226. #5411 moved iPad to the suggestions popover,
which bypassed the only code reporting them. #5953 fixed this for iPhone's unified input — a surface
iPad never uses.

Reports the same pixels from the iPad popover. No new pixel names, no behaviour change. Both surfaces
now report a tap through one shared call instead of two, which is what let iPad ship half-wired.

### Testing Steps

Needs an iPad sim. Stream logs: `xcrun simctl spawn <udid> log stream --predicate 'subsystem == "Pixels"' --level debug`

1. Type `example.com` → Go → `m.addressbar.click.ntp`
2. Tap **+**, leaving that tab open
3. Type `exam` → tap **Switch to Tab** → `m.autocomplete.click.switch.to.tab`, then
   `m.autocomplete.display.local.history` + `m.autocomplete.display.switch.to.tab` on dismissal
4. Type `duck` → tap top search row → `m.autocomplete.click.phrase`
5. Same on iPhone → unchanged

Verified on iPad Pro 11-inch (M5) / iOS 26.4.

### Impact

Low — analytics only.
