### PR TITLE
[macOS] Fix BookmarksBarVisibilityTests with promo in promo queue

### DIFF
--- a/macOS/DuckDuckGo/Promotions/PromoDebugMenu.swift
+++ b/macOS/DuckDuckGo/Promotions/PromoDebugMenu.swift
@@ -124,6 +124,7 @@ final class PromoDebugMenu: NSMenu {
             let undismissClearItem = NSMenuItem(title: "Undismiss + Clear History", action: #selector(undismissPromoAndClearHistory(_:)), keyEquivalent: "")
             undismissClearItem.representedObject = promo.id
             undismissClearItem.target = self
+            undismissClearItem.setAccessibilityIdentifier(AccessibilityIdentifiers.PromoQueue.undismissClearItem)
             submenu.addItem(undismissClearItem)
 
             parentItem.submenu = submenu

--- a/macOS/LocalPackages/Utilities/Sources/Utilities/AccessibilityIdentifiers/AccessibilityIdentifiers+PromoQueue.swift
+++ b/macOS/LocalPackages/Utilities/Sources/Utilities/AccessibilityIdentifiers/AccessibilityIdentifiers+PromoQueue.swift
@@ -28,6 +28,7 @@ public extension AccessibilityIdentifiers {
             "PromoDebugMenu.promoMenuItem.\(id)"
         }
         public static let forceShowPromo = "PromoDebugMenu.promoMenuItem.forceShow"
+        public static let undismissClearItem = "PromoDebugMenu.promoMenuItem.undismissClearItem"
         public static func testPromoAlert(_ id: String) -> String {
             "PromoQueue.testPromoAlert.\(id)"
         }

--- a/macOS/UITests/BookmarksBarVisibilityTests.swift
+++ b/macOS/UITests/BookmarksBarVisibilityTests.swift
@@ -43,6 +43,7 @@ class BookmarksBarVisibilityTests: UITestCase {
         bookmarksBarPromptPopover = app.popovers.containing(\.title, equalTo: "Show Bookmarks Bar?").element
 
         app.resetBookmarks()
+        app.resetPromo(withID: "bookmark-toolbar")
         skipOnboarding()
         app.enforceSingleWindow()
     }

--- a/macOS/UITests/Common/XCUIApplicationExtension.swift
+++ b/macOS/UITests/Common/XCUIApplicationExtension.swift
@@ -1047,4 +1047,11 @@ extension XCUIApplication {
         debugMenu.menuItems[Utilities.AccessibilityIdentifiers.PromoQueue.promoQueueDebugMenu]
     }
 
+    func resetPromo(withID promoID: String) {
+        let promoResetItem = promoQueueMenu
+            .menuItems[Utilities.AccessibilityIdentifiers.PromoQueue.promoMenuItem(promoID)]
+            .menuItems[Utilities.AccessibilityIdentifiers.PromoQueue.undismissClearItem]
+            .clickAfterExistenceTestSucceeds()
+    }
+
 }


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ External contributors: file an issue before opening a PR.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1201037661562251/task/1218171359511331?focus=true
Tech Design URL:
CC:

### Description

Fixes the BookmarksBarVisibilityTests after the promo migrated to the promo queue. This reset the promo in the promo queue so it can be triggered again in subsequent tests.

### Testing Steps
<!-- One action per step. Note expected outcome inline where relevant, e.g. "3. Tap Save → settings screen dismisses". Assume the reviewer is unfamiliar with this part of the app. -->
1. Confirm CI workflow passes: https://github.com/duckduckgo/apple-browsers/actions/runs/33878574954

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact
None: Internal tooling, documentation

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Debug-menu accessibility wiring and UI test setup only; no production promo or bookmarks behavior changes.
> 
> **Overview**
> **Fixes flaky `BookmarksBarVisibilityTests`** after the bookmarks bar prompt moved into the promo queue by clearing promo state before each run.
> 
> Adds an accessibility identifier on the Promo Queue debug menu’s **Undismiss + Clear History** item and a shared UI test helper `resetPromo(withID:)` that drives that menu path. `BookmarksBarVisibilityTests` now calls `resetPromo(withID: "bookmark-toolbar")` during setup so the prompt can show again when tests expect it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b165210d0ca7530fe330a604831d5609af2698cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->