### PR TITLE
macOS: Improve Create Image flow on New Tab Page

### DIFF
--- a/macOS/DuckDuckGo/AIChat/AIChatCreateImageModelSwitchNotice.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatCreateImageModelSwitchNotice.swift
@@ -28,4 +28,14 @@ struct AIChatCreateImageModelSwitchNotice: Equatable {
         newModelShortName = newModel.shortName
         previousModelHasExtraPrivacyProtections = previousModel.provider == .oss
     }
+
+    var localizedTitle: String {
+        UserText.aiChatCreateImageModelSwitchTitle(newModelShortName)
+    }
+
+    var localizedSubtitle: String {
+        previousModelHasExtraPrivacyProtections
+            ? UserText.aiChatCreateImageModelSwitchPrivacySubtitle(previousModelShortName)
+            : UserText.aiChatCreateImageModelSwitchSubtitle(previousModelShortName)
+    }
 }

--- a/macOS/DuckDuckGo/AIChat/AIChatUsageWarningCardView.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatUsageWarningCardView.swift
@@ -398,10 +398,8 @@ final class AIChatUsageWarningCardView: NSView {
     }
 
     func update(with notice: AIChatCreateImageModelSwitchNotice) {
-        let title = UserText.aiChatCreateImageModelSwitchTitle(notice.newModelShortName)
-        let subtitle = notice.previousModelHasExtraPrivacyProtections
-            ? UserText.aiChatCreateImageModelSwitchPrivacySubtitle(notice.previousModelShortName)
-            : UserText.aiChatCreateImageModelSwitchSubtitle(notice.previousModelShortName)
+        let title = notice.localizedTitle
+        let subtitle = notice.localizedSubtitle
 
         applyModelSwitchIcon()
         titleLabel.maximumNumberOfLines = 2

--- a/macOS/DuckDuckGo/NewTabPage/NewTabPageOmnibarActionsHandler.swift
+++ b/macOS/DuckDuckGo/NewTabPage/NewTabPageOmnibarActionsHandler.swift
@@ -154,7 +154,7 @@ final class NewTabPageOmnibarActionsHandler: NewTabPageOmnibarActionsHandling {
             PixelKit.fire(AIChatPixel.aiChatNtpSubmitWithImage(imageCount: images.count), frequency: .dailyAndCount, includeAppVersionParameter: true)
         }
 
-        if mode == AIChatNativePrompt.imageGenerationMode {
+        if mode == AIChatNativePrompt.imageGenerationMode || toolChoice?.contains(AIChatRAGTool.imageGeneration.rawValue) == true {
             PixelKit.fire(AIChatPixel.aiChatNtpImageGenerationSubmitted, frequency: .dailyAndCount, includeAppVersionParameter: true)
         } else if mode == AIChatNativePrompt.voiceMode {
             PixelKit.fire(AIChatPixel.aiChatNewVoiceChatOmnibarNtp, frequency: .dailyAndStandard, includeAppVersionParameter: true)

--- a/macOS/DuckDuckGo/NewTabPage/NewTabPageOmnibarConfigProvider.swift
+++ b/macOS/DuckDuckGo/NewTabPage/NewTabPageOmnibarConfigProvider.swift
@@ -266,6 +266,47 @@ final class NewTabPageOmnibarConfigProvider: NewTabPageOmnibarConfigProviding {
         featureFlagger.isFeatureOn(.aiChatNtpImageGeneration)
     }
 
+    var isUpdatedCreateImageEnabled: Bool {
+        isImageGenerationEnabled && featureFlagger.isFeatureOn(.updatedCreateImage)
+    }
+
+    @MainActor
+    func activateImageGeneration() -> NewTabPageDataModel.OmnibarCreateImageModelSwitch? {
+        guard isUpdatedCreateImageEnabled else { return nil }
+
+        let models = availableModelsProvider()
+        let previousModel = models.first(where: { $0.id == aiChatPreferencesPersistor.selectedModelId })
+        guard let previousModel,
+              !previousModel.supportsTool(.imageGeneration) else {
+            return nil
+        }
+
+        guard let imageModel = AIChatModel.preferredImageGenerationModel(in: models) else {
+            return nil
+        }
+
+        aiChatPreferencesPersistor.selectedModelId = imageModel.id
+        aiChatPreferencesPersistor.selectedModelShortName = imageModel.shortName
+        clearReasoningEffortIfUnsupported(by: imageModel)
+
+        let secondaryText = previousModel.provider == .oss
+            ? UserText.aiChatCreateImageModelSwitchPrivacySubtitle(previousModel.shortName)
+            : UserText.aiChatCreateImageModelSwitchSubtitle(previousModel.shortName)
+        return NewTabPageDataModel.OmnibarCreateImageModelSwitch(
+            message: UserText.aiChatCreateImageModelSwitchTitle(imageModel.shortName),
+            secondaryText: secondaryText
+        )
+    }
+
+    private func clearReasoningEffortIfUnsupported(by model: AIChatModel) {
+        guard let rawValue = aiChatPreferencesPersistor.selectedReasoningEffort,
+              let effort = AIChatReasoningEffort(rawValue: rawValue),
+              !model.isAccessible(effort) else {
+            return
+        }
+        aiChatPreferencesPersistor.selectedReasoningEffort = nil
+    }
+
     var isWebSearchEnabled: Bool {
         featureFlagger.isFeatureOn(.aiChatNtpWebSearch)
     }

--- a/macOS/DuckDuckGo/NewTabPage/NewTabPageOmnibarConfigProvider.swift
+++ b/macOS/DuckDuckGo/NewTabPage/NewTabPageOmnibarConfigProvider.swift
@@ -271,17 +271,19 @@ final class NewTabPageOmnibarConfigProvider: NewTabPageOmnibarConfigProviding {
     }
 
     @MainActor
+    var imageGenerationModelId: String? {
+        guard isUpdatedCreateImageEnabled else { return nil }
+        return imageGenerationModel(in: availableModelsProvider())?.id
+    }
+
+    @MainActor
     func activateImageGeneration() -> NewTabPageDataModel.OmnibarCreateImageModelSwitch? {
         guard isUpdatedCreateImageEnabled else { return nil }
 
         let models = availableModelsProvider()
         let previousModel = models.first(where: { $0.id == aiChatPreferencesPersistor.selectedModelId })
-        guard let previousModel,
-              !previousModel.supportsTool(.imageGeneration) else {
-            return nil
-        }
-
-        guard let imageModel = AIChatModel.preferredImageGenerationModel(in: models) else {
+        guard let imageModel = imageGenerationModel(in: models),
+              previousModel?.id != imageModel.id else {
             return nil
         }
 
@@ -289,21 +291,30 @@ final class NewTabPageOmnibarConfigProvider: NewTabPageOmnibarConfigProviding {
         aiChatPreferencesPersistor.selectedModelShortName = imageModel.shortName
         clearReasoningEffortIfUnsupported(by: imageModel)
 
-        let secondaryText = previousModel.provider == .oss
-            ? UserText.aiChatCreateImageModelSwitchPrivacySubtitle(previousModel.shortName)
-            : UserText.aiChatCreateImageModelSwitchSubtitle(previousModel.shortName)
+        guard let previousModel else { return nil }
+        let notice = AIChatCreateImageModelSwitchNotice(previousModel: previousModel, newModel: imageModel)
         return NewTabPageDataModel.OmnibarCreateImageModelSwitch(
-            message: UserText.aiChatCreateImageModelSwitchTitle(imageModel.shortName),
-            secondaryText: secondaryText
+            message: notice.localizedTitle,
+            secondaryText: notice.localizedSubtitle
         )
     }
 
+    private func imageGenerationModel(in models: [AIChatModel]) -> AIChatModel? {
+        if let selectedModel = models.first(where: { $0.id == aiChatPreferencesPersistor.selectedModelId }),
+           selectedModel.entityHasAccess,
+           selectedModel.supportsTool(.imageGeneration) {
+            return selectedModel
+        }
+        return AIChatModel.preferredImageGenerationModel(in: models)
+    }
+
     private func clearReasoningEffortIfUnsupported(by model: AIChatModel) {
-        guard let rawValue = aiChatPreferencesPersistor.selectedReasoningEffort,
-              let effort = AIChatReasoningEffort(rawValue: rawValue),
-              !model.isAccessible(effort) else {
+        guard let rawValue = aiChatPreferencesPersistor.selectedReasoningEffort else { return }
+        guard let effort = AIChatReasoningEffort(rawValue: rawValue) else {
+            aiChatPreferencesPersistor.selectedReasoningEffort = nil
             return
         }
+        guard !model.supportedReasoningEffort.contains(effort) else { return }
         aiChatPreferencesPersistor.selectedReasoningEffort = nil
     }
 

--- a/macOS/LocalPackages/NewTabPage/Package.swift
+++ b/macOS/LocalPackages/NewTabPage/Package.swift
@@ -46,6 +46,7 @@ let package = Package(
         .target(
             name: "NewTabPage",
             dependencies: [
+                .product(name: "AIChat", package: "AIChat"),
                 .product(name: "AutoconsentStats", package: "BrowserServicesKit"),
                 .product(name: "Bookmarks", package: "BrowserServicesKit"),
                 .product(name: "BrowserServicesKit", package: "BrowserServicesKit"),

--- a/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/Omnibar/NewTabPageDataModel+Omnibar.swift
+++ b/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/Omnibar/NewTabPageDataModel+Omnibar.swift
@@ -97,6 +97,18 @@ public extension NewTabPageDataModel {
         }
     }
 
+    struct OmnibarCreateImageModelSwitch: Codable, Equatable {
+        let message: String
+        let secondaryText: String?
+        let dismissible: Bool
+
+        public init(message: String, secondaryText: String?, dismissible: Bool = true) {
+            self.message = message
+            self.secondaryText = secondaryText
+            self.dismissible = dismissible
+        }
+    }
+
     /// Attachment limits forwarded to the web. All optional: `files`/`images` are backend-sourced; `tabs` is a hardcoded native cap, omitted when the limit is disabled (web then applies no tab limit).
     struct AttachmentLimits: Codable, Equatable {
         public struct FileLimits: Codable, Equatable {
@@ -195,6 +207,14 @@ public extension NewTabPageDataModel {
         let enableAiChatDeletion: Bool?
         /// When true, history-entry suggestions show a delete button that sends `omnibar_removeSuggestion`.
         let enableSearchSuggestionDeletion: Bool?
+        /// Enables the native-driven Create Image model-switch flow in the web omnibar.
+        var enableUpdatedCreateImage: Bool?
+        /// Native-localized notice shown after Create Image switches away from an unsupported model.
+        var createImageModelSwitch: OmnibarCreateImageModelSwitch?
+    }
+
+    struct OmnibarSetImageGenerationActive: Codable, Equatable {
+        let active: Bool
     }
 
     // MARK: - omnibar_getSuggestions

--- a/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/Omnibar/NewTabPageOmnibarClient.swift
+++ b/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/Omnibar/NewTabPageOmnibarClient.swift
@@ -16,10 +16,11 @@
 //  limitations under the License.
 //
 
-import WebKit
+import AIChat
 import Combine
 import Common
 import FoundationExtensions
+import WebKit
 
 public final class NewTabPageOmnibarClient: NewTabPageUserScriptClient {
 
@@ -42,6 +43,8 @@ public final class NewTabPageOmnibarClient: NewTabPageUserScriptClient {
         case showSubscriptionUpgrade = "omnibar_showSubscriptionUpgrade"
         case confirmDeleteAiChat = "omnibar_confirmDeleteAiChat"
         case removeSuggestion = "omnibar_removeSuggestion"
+        case setImageGenerationActive = "omnibar_setImageGenerationActive"
+        case dismissCreateImageModelSwitch = "omnibar_dismissCreateImageModelSwitch"
     }
 
     private let configProvider: NewTabPageOmnibarConfigProviding
@@ -51,6 +54,7 @@ public final class NewTabPageOmnibarClient: NewTabPageUserScriptClient {
     private let actionHandler: NewTabPageOmnibarActionsHandling
     private let tabsProvider: NewTabPageOmnibarTabsProviding
     private let subscriptionDialogPresenter: NewTabPageOmnibarSubscriptionDialogPresenting?
+    private var createImageModelSwitch: NewTabPageDataModel.OmnibarCreateImageModelSwitch?
     private var cancellables = Set<AnyCancellable>()
 
     @MainActor
@@ -127,7 +131,9 @@ public final class NewTabPageOmnibarClient: NewTabPageUserScriptClient {
             MessageName.showSubscriptionUpsell.rawValue: { [weak self] in try await self?.showSubscriptionUpsell(params: $0, original: $1) },
             MessageName.showSubscriptionUpgrade.rawValue: { [weak self] in try await self?.showSubscriptionUpgrade(params: $0, original: $1) },
             MessageName.confirmDeleteAiChat.rawValue: { [weak self] in try await self?.confirmDeleteAiChat(params: $0, original: $1) },
-            MessageName.removeSuggestion.rawValue: { [weak self] in try await self?.removeSuggestion(params: $0, original: $1) }
+            MessageName.removeSuggestion.rawValue: { [weak self] in try await self?.removeSuggestion(params: $0, original: $1) },
+            MessageName.setImageGenerationActive.rawValue: { [weak self] in try await self?.setImageGenerationActive(params: $0, original: $1) },
+            MessageName.dismissCreateImageModelSwitch.rawValue: { [weak self] in try await self?.dismissCreateImageModelSwitch(params: $0, original: $1) }
         ])
     }
 
@@ -162,7 +168,9 @@ public final class NewTabPageOmnibarClient: NewTabPageUserScriptClient {
             attachmentLimits: modelsProvider?.attachmentLimits,
             isEligibleForFreeTrial: modelsProvider?.isEligibleForFreeTrial,
             enableAiChatDeletion: configProvider.isAIChatDeletionEnabled,
-            enableSearchSuggestionDeletion: configProvider.isSearchSuggestionDeletionEnabled
+            enableSearchSuggestionDeletion: configProvider.isSearchSuggestionDeletionEnabled,
+            enableUpdatedCreateImage: configProvider.isUpdatedCreateImageEnabled,
+            createImageModelSwitch: createImageModelSwitch
         )
     }
 
@@ -245,7 +253,9 @@ public final class NewTabPageOmnibarClient: NewTabPageUserScriptClient {
             attachmentLimits: modelsProvider?.attachmentLimits,
             isEligibleForFreeTrial: modelsProvider?.isEligibleForFreeTrial,
             enableAiChatDeletion: configProvider.isAIChatDeletionEnabled,
-            enableSearchSuggestionDeletion: configProvider.isSearchSuggestionDeletionEnabled
+            enableSearchSuggestionDeletion: configProvider.isSearchSuggestionDeletionEnabled,
+            enableUpdatedCreateImage: configProvider.isUpdatedCreateImageEnabled,
+            createImageModelSwitch: createImageModelSwitch
         )
         pushMessage(named: MessageName.onConfigUpdate.rawValue, params: config)
     }
@@ -291,17 +301,19 @@ public final class NewTabPageOmnibarClient: NewTabPageUserScriptClient {
         return nil
     }
 
+    @MainActor
     private func submitChat(params: Any, original: WKScriptMessage) async throws -> Encodable? {
         guard let action: NewTabPageDataModel.SubmitChatAction = DecodableHelper.decode(from: params) else {
             return nil
         }
+        let imageGenerationModelId = imageGenerationModelIdForSubmission(action: action)
         await actionHandler.submitChat(
             action.chat,
             target: action.target,
-            modelId: modelIdForSubmission(action: action),
+            modelId: imageGenerationModelId ?? modelIdForSubmission(action: action),
             images: action.images,
-            mode: action.mode,
-            toolChoice: action.toolChoice,
+            mode: imageGenerationModelId == nil ? action.mode : nil,
+            toolChoice: imageGenerationModelId == nil ? action.toolChoice : [AIChatRAGTool.imageGeneration.rawValue],
             reasoningEffort: reasoningEffortForSubmission(action: action),
             pageContexts: action.pageContext,
             files: action.files
@@ -324,6 +336,37 @@ public final class NewTabPageOmnibarClient: NewTabPageUserScriptClient {
     private func modelIdForSubmission(action: NewTabPageDataModel.SubmitChatAction) -> String? {
         guard let modelId = action.modelId else { return nil }
         return matchedItem(forModelId: modelId)?.isAvailable == false ? nil : modelId
+    }
+
+    @MainActor
+    private func imageGenerationModelIdForSubmission(action: NewTabPageDataModel.SubmitChatAction) -> String? {
+        guard configProvider.isUpdatedCreateImageEnabled,
+              action.mode == AIChatNativePrompt.imageGenerationMode,
+              let selectedModelId = configProvider.selectedModelId,
+              let selectedModel = matchedItem(forModelId: selectedModelId),
+              selectedModel.isAvailable,
+              selectedModel.supportedTools.contains(AIChatRAGTool.imageGeneration.rawValue) else {
+            return nil
+        }
+        return selectedModelId
+    }
+
+    @MainActor
+    private func setImageGenerationActive(params: Any, original: WKScriptMessage) async throws -> Encodable? {
+        guard configProvider.isUpdatedCreateImageEnabled,
+              let request: NewTabPageDataModel.OmnibarSetImageGenerationActive = DecodableHelper.decode(from: params) else {
+            return nil
+        }
+        createImageModelSwitch = request.active ? configProvider.activateImageGeneration() : nil
+        notifyConfigUpdated()
+        return nil
+    }
+
+    @MainActor
+    private func dismissCreateImageModelSwitch(params: Any, original: WKScriptMessage) async throws -> Encodable? {
+        createImageModelSwitch = nil
+        notifyConfigUpdated()
+        return nil
     }
 
     @MainActor

--- a/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/Omnibar/NewTabPageOmnibarClient.swift
+++ b/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/Omnibar/NewTabPageOmnibarClient.swift
@@ -306,14 +306,21 @@ public final class NewTabPageOmnibarClient: NewTabPageUserScriptClient {
         guard let action: NewTabPageDataModel.SubmitChatAction = DecodableHelper.decode(from: params) else {
             return nil
         }
-        let imageGenerationModelId = imageGenerationModelIdForSubmission(action: action)
+        let isUpdatedImageGenerationSubmission = configProvider.isUpdatedCreateImageEnabled && action.mode == AIChatNativePrompt.imageGenerationMode
+        let imageGenerationModelId = isUpdatedImageGenerationSubmission ? configProvider.imageGenerationModelId : nil
+        let modelId = isUpdatedImageGenerationSubmission ? imageGenerationModelId : modelIdForSubmission(action: action)
+        let toolChoice: [String]? = if isUpdatedImageGenerationSubmission {
+            imageGenerationModelId == nil ? nil : [AIChatRAGTool.imageGeneration.rawValue]
+        } else {
+            action.toolChoice
+        }
         await actionHandler.submitChat(
             action.chat,
             target: action.target,
-            modelId: imageGenerationModelId ?? modelIdForSubmission(action: action),
+            modelId: modelId,
             images: action.images,
             mode: imageGenerationModelId == nil ? action.mode : nil,
-            toolChoice: imageGenerationModelId == nil ? action.toolChoice : [AIChatRAGTool.imageGeneration.rawValue],
+            toolChoice: toolChoice,
             reasoningEffort: reasoningEffortForSubmission(action: action),
             pageContexts: action.pageContext,
             files: action.files
@@ -336,19 +343,6 @@ public final class NewTabPageOmnibarClient: NewTabPageUserScriptClient {
     private func modelIdForSubmission(action: NewTabPageDataModel.SubmitChatAction) -> String? {
         guard let modelId = action.modelId else { return nil }
         return matchedItem(forModelId: modelId)?.isAvailable == false ? nil : modelId
-    }
-
-    @MainActor
-    private func imageGenerationModelIdForSubmission(action: NewTabPageDataModel.SubmitChatAction) -> String? {
-        guard configProvider.isUpdatedCreateImageEnabled,
-              action.mode == AIChatNativePrompt.imageGenerationMode,
-              let selectedModelId = configProvider.selectedModelId,
-              let selectedModel = matchedItem(forModelId: selectedModelId),
-              selectedModel.isAvailable,
-              selectedModel.supportedTools.contains(AIChatRAGTool.imageGeneration.rawValue) else {
-            return nil
-        }
-        return selectedModelId
     }
 
     @MainActor

--- a/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/Omnibar/NewTabPageOmnibarClient.swift
+++ b/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/Omnibar/NewTabPageOmnibarClient.swift
@@ -321,7 +321,7 @@ public final class NewTabPageOmnibarClient: NewTabPageUserScriptClient {
             images: action.images,
             mode: imageGenerationModelId == nil ? action.mode : nil,
             toolChoice: toolChoice,
-            reasoningEffort: reasoningEffortForSubmission(action: action),
+            reasoningEffort: isUpdatedImageGenerationSubmission ? nil : reasoningEffortForSubmission(action: action),
             pageContexts: action.pageContext,
             files: action.files
         )

--- a/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/Omnibar/NewTabPageOmnibarConfigProviding.swift
+++ b/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/Omnibar/NewTabPageOmnibarConfigProviding.swift
@@ -42,6 +42,13 @@ public protocol NewTabPageOmnibarConfigProviding: AnyObject {
 
     var isImageGenerationEnabled: Bool { get }
 
+    /// Whether Create Image activation is resolved natively, including automatic model switching.
+    var isUpdatedCreateImageEnabled: Bool { get }
+
+    /// Switches to an accessible image-capable model when needed and returns native-localized notice copy.
+    @MainActor
+    func activateImageGeneration() -> NewTabPageDataModel.OmnibarCreateImageModelSwitch?
+
     var isWebSearchEnabled: Bool { get }
 
     /// Whether the "Customize Responses" tool is shown in the NTP omnibar Tools menu.
@@ -103,4 +110,11 @@ public protocol NewTabPageOmnibarConfigProviding: AnyObject {
     /// Whether history-entry suggestions can be deleted. Published so the client can push `omnibar_onConfigUpdate`.
     var isSearchSuggestionDeletionEnabled: Bool { get }
     var isSearchSuggestionDeletionEnabledPublisher: AnyPublisher<Bool, Never> { get }
+}
+
+public extension NewTabPageOmnibarConfigProviding {
+    var isUpdatedCreateImageEnabled: Bool { false }
+
+    @MainActor
+    func activateImageGeneration() -> NewTabPageDataModel.OmnibarCreateImageModelSwitch? { nil }
 }

--- a/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/Omnibar/NewTabPageOmnibarConfigProviding.swift
+++ b/macOS/LocalPackages/NewTabPage/Sources/NewTabPage/Omnibar/NewTabPageOmnibarConfigProviding.swift
@@ -45,6 +45,10 @@ public protocol NewTabPageOmnibarConfigProviding: AnyObject {
     /// Whether Create Image activation is resolved natively, including automatic model switching.
     var isUpdatedCreateImageEnabled: Bool { get }
 
+    /// The accessible image-capable model selected natively for an updated Create Image submission.
+    @MainActor
+    var imageGenerationModelId: String? { get }
+
     /// Switches to an accessible image-capable model when needed and returns native-localized notice copy.
     @MainActor
     func activateImageGeneration() -> NewTabPageDataModel.OmnibarCreateImageModelSwitch?
@@ -110,11 +114,4 @@ public protocol NewTabPageOmnibarConfigProviding: AnyObject {
     /// Whether history-entry suggestions can be deleted. Published so the client can push `omnibar_onConfigUpdate`.
     var isSearchSuggestionDeletionEnabled: Bool { get }
     var isSearchSuggestionDeletionEnabledPublisher: AnyPublisher<Bool, Never> { get }
-}
-
-public extension NewTabPageOmnibarConfigProviding {
-    var isUpdatedCreateImageEnabled: Bool { false }
-
-    @MainActor
-    func activateImageGeneration() -> NewTabPageDataModel.OmnibarCreateImageModelSwitch? { nil }
 }

--- a/macOS/LocalPackages/NewTabPage/Tests/NewTabPageTests/Mocks/MockNewTabPageOmnibarConfigProvider.swift
+++ b/macOS/LocalPackages/NewTabPage/Tests/NewTabPageTests/Mocks/MockNewTabPageOmnibarConfigProvider.swift
@@ -55,6 +55,19 @@ final class MockNewTabPageOmnibarConfigProvider: NewTabPageOmnibarConfigProvidin
 
     var isImageGenerationEnabled: Bool = false
 
+    var isUpdatedCreateImageEnabled: Bool = false
+
+    var imageGenerationModelId: String?
+
+    var activateImageGenerationResult: NewTabPageDataModel.OmnibarCreateImageModelSwitch?
+    private(set) var activateImageGenerationCallCount = 0
+
+    @MainActor
+    func activateImageGeneration() -> NewTabPageDataModel.OmnibarCreateImageModelSwitch? {
+        activateImageGenerationCallCount += 1
+        return activateImageGenerationResult
+    }
+
     var isWebSearchEnabled: Bool = false
 
     var isCustomizeResponsesEnabled: Bool = false

--- a/macOS/LocalPackages/NewTabPage/Tests/NewTabPageTests/NewTabPageOmnibarClientTests.swift
+++ b/macOS/LocalPackages/NewTabPage/Tests/NewTabPageTests/NewTabPageOmnibarClientTests.swift
@@ -777,10 +777,11 @@ final class NewTabPageOmnibarClientTests: XCTestCase {
         configProvider.isUpdatedCreateImageEnabled = true
         configProvider.imageGenerationModelId = "preferred-image-model"
         let expectation = expectation(description: "submitChatCalled")
-        (actionHandler as? MockNewTabPageOmnibarActionsHandler)?.submitChatHandler = { _, _, modelId, _, mode, toolChoice, _, _, _ in
+        (actionHandler as? MockNewTabPageOmnibarActionsHandler)?.submitChatHandler = { _, _, modelId, _, mode, toolChoice, reasoningEffort, _, _ in
             XCTAssertEqual(modelId, "preferred-image-model")
             XCTAssertNil(mode)
             XCTAssertEqual(toolChoice, [AIChatRAGTool.imageGeneration.rawValue])
+            XCTAssertNil(reasoningEffort)
             expectation.fulfill()
         }
 
@@ -791,7 +792,7 @@ final class NewTabPageOmnibarClientTests: XCTestCase {
             images: nil,
             mode: AIChatNativePrompt.imageGenerationMode,
             toolChoice: nil,
-            reasoningEffort: nil,
+            reasoningEffort: "medium",
             pageContext: nil,
             files: nil
         )

--- a/macOS/LocalPackages/NewTabPage/Tests/NewTabPageTests/NewTabPageOmnibarClientTests.swift
+++ b/macOS/LocalPackages/NewTabPage/Tests/NewTabPageTests/NewTabPageOmnibarClientTests.swift
@@ -773,6 +773,86 @@ final class NewTabPageOmnibarClientTests: XCTestCase {
         await fulfillment(of: [expectation], timeout: 1)
     }
 
+    func testWhenUpdatedCreateImageIsSubmittedThenResolvedImageGenerationModelIsUsed() async throws {
+        configProvider.isUpdatedCreateImageEnabled = true
+        configProvider.imageGenerationModelId = "preferred-image-model"
+        let expectation = expectation(description: "submitChatCalled")
+        (actionHandler as? MockNewTabPageOmnibarActionsHandler)?.submitChatHandler = { _, _, modelId, _, mode, toolChoice, _, _, _ in
+            XCTAssertEqual(modelId, "preferred-image-model")
+            XCTAssertNil(mode)
+            XCTAssertEqual(toolChoice, [AIChatRAGTool.imageGeneration.rawValue])
+            expectation.fulfill()
+        }
+
+        let action = NewTabPageDataModel.SubmitChatAction(
+            chat: "Draw a duck",
+            target: .sameTab,
+            modelId: "unsupported-web-model",
+            images: nil,
+            mode: AIChatNativePrompt.imageGenerationMode,
+            toolChoice: nil,
+            reasoningEffort: nil,
+            pageContext: nil,
+            files: nil
+        )
+        try await messageHelper.handleMessageExpectingNilResponse(named: .submitChat, parameters: action)
+        await fulfillment(of: [expectation], timeout: 1)
+    }
+
+    func testWhenUpdatedCreateImageHasNoResolvedModelThenSubmissionUsesLegacyModeWithoutWebModel() async throws {
+        configProvider.isUpdatedCreateImageEnabled = true
+        configProvider.imageGenerationModelId = nil
+        let expectation = expectation(description: "submitChatCalled")
+        (actionHandler as? MockNewTabPageOmnibarActionsHandler)?.submitChatHandler = { _, _, modelId, _, mode, toolChoice, _, _, _ in
+            XCTAssertNil(modelId)
+            XCTAssertEqual(mode, AIChatNativePrompt.imageGenerationMode)
+            XCTAssertNil(toolChoice)
+            expectation.fulfill()
+        }
+
+        let action = NewTabPageDataModel.SubmitChatAction(
+            chat: "Draw a duck",
+            target: .sameTab,
+            modelId: "unsupported-web-model",
+            images: nil,
+            mode: AIChatNativePrompt.imageGenerationMode,
+            toolChoice: [AIChatRAGTool.imageGeneration.rawValue],
+            reasoningEffort: nil,
+            pageContext: nil,
+            files: nil
+        )
+        try await messageHelper.handleMessageExpectingNilResponse(named: .submitChat, parameters: action)
+        await fulfillment(of: [expectation], timeout: 1)
+    }
+
+    func testWhenImageGenerationIsActivatedThenNativeSwitchNoticeIsIncludedInConfig() async throws {
+        let notice = NewTabPageDataModel.OmnibarCreateImageModelSwitch(message: "Now using Luna", secondaryText: "Mistral can't create images.")
+        configProvider.isUpdatedCreateImageEnabled = true
+        configProvider.activateImageGenerationResult = notice
+
+        let request = NewTabPageDataModel.OmnibarSetImageGenerationActive(active: true)
+        try await messageHelper.handleMessageExpectingNilResponse(named: .setImageGenerationActive, parameters: request)
+        let config: NewTabPageDataModel.OmnibarConfig = try await messageHelper.handleMessage(named: .getConfig)
+
+        XCTAssertEqual(configProvider.activateImageGenerationCallCount, 1)
+        XCTAssertEqual(config.createImageModelSwitch, notice)
+    }
+
+    func testWhenCreateImageSwitchNoticeIsDismissedThenItIsRemovedFromConfig() async throws {
+        configProvider.isUpdatedCreateImageEnabled = true
+        configProvider.activateImageGenerationResult = NewTabPageDataModel.OmnibarCreateImageModelSwitch(
+            message: "Now using Luna",
+            secondaryText: "Mistral can't create images."
+        )
+        let request = NewTabPageDataModel.OmnibarSetImageGenerationActive(active: true)
+        try await messageHelper.handleMessageExpectingNilResponse(named: .setImageGenerationActive, parameters: request)
+
+        try await messageHelper.handleMessageExpectingNilResponse(named: .dismissCreateImageModelSwitch)
+        let config: NewTabPageDataModel.OmnibarConfig = try await messageHelper.handleMessage(named: .getConfig)
+
+        XCTAssertNil(config.createImageModelSwitch)
+    }
+
     // MARK: - attach tabs (config)
 
     @MainActor

--- a/macOS/UnitTests/NewTabPage/NewTabPageOmnibarAiChatsProviderTests.swift
+++ b/macOS/UnitTests/NewTabPage/NewTabPageOmnibarAiChatsProviderTests.swift
@@ -343,6 +343,9 @@ private final class MockAiChatsConfigProvider: NewTabPageOmnibarConfigProviding 
     var showViewAllAiChatsPublisher: AnyPublisher<Bool, Never> { Just(false).eraseToAnyPublisher() }
     var isAIChatToolsEnabled: Bool = false
     var isImageGenerationEnabled: Bool = false
+    var isUpdatedCreateImageEnabled: Bool = false
+    @MainActor var imageGenerationModelId: String? { nil }
+    @MainActor func activateImageGeneration() -> NewTabPageDataModel.OmnibarCreateImageModelSwitch? { nil }
     var isWebSearchEnabled: Bool = false
     var isCustomizeResponsesEnabled: Bool = false
     @MainActor

--- a/macOS/UnitTests/NewTabPage/NewTabPageOmnibarConfigProviderTests.swift
+++ b/macOS/UnitTests/NewTabPage/NewTabPageOmnibarConfigProviderTests.swift
@@ -271,7 +271,8 @@ final class NewTabPageOmnibarConfigProviderTests: XCTestCase {
         persistor: AIChatPreferencesPersisting,
         keyValueStore: ThrowingKeyValueStoring? = nil,
         featureFlagger: MockFeatureFlagger = MockFeatureFlagger(),
-        searchPreferences: SearchPreferences? = nil
+        searchPreferences: SearchPreferences? = nil,
+        availableModelsProvider: @escaping () -> [AIChatModel] = { [] }
     ) throws -> NewTabPageOmnibarConfigProvider {
         NewTabPageOmnibarConfigProvider(
             keyValueStore: try keyValueStore ?? makeStore(),
@@ -279,6 +280,7 @@ final class NewTabPageOmnibarConfigProviderTests: XCTestCase {
             featureFlagger: featureFlagger,
             aiChatPreferencesPersistor: persistor,
             searchPreferences: searchPreferences ?? makeSearchPreferences(),
+            availableModelsProvider: availableModelsProvider,
             firePixel: { _ in }
         )
     }
@@ -290,6 +292,37 @@ final class NewTabPageOmnibarConfigProviderTests: XCTestCase {
         flagger.featuresStub[FeatureFlag.aiChatNtpChatTools.rawValue] = true
         flagger.featuresStub[FeatureFlag.aiChatOmnibarReasoningEffort.rawValue] = true
         return flagger
+    }
+
+    private func flaggerWithUpdatedCreateImageOn() -> MockFeatureFlagger {
+        let flagger = MockFeatureFlagger()
+        flagger.featuresStub[FeatureFlag.aiChatNtpImageGeneration.rawValue] = true
+        flagger.featuresStub[FeatureFlag.updatedCreateImage.rawValue] = true
+        return flagger
+    }
+
+    private func makeModel(
+        id: String,
+        shortName: String? = nil,
+        provider: AIChatModel.ModelProvider = .openAI,
+        supportsImageGeneration: Bool = false,
+        entityHasAccess: Bool = true,
+        supportedReasoningEffort: [AIChatReasoningEffort] = [],
+        reasoningEffortAccess: [AIChatReasoningEffortAccess]? = nil,
+        label: AIChatModelLabel? = nil
+    ) -> AIChatModel {
+        AIChatModel(
+            id: id,
+            name: id,
+            shortName: shortName,
+            provider: provider,
+            supportsImageUpload: false,
+            supportedTools: supportsImageGeneration ? [.imageGeneration] : [],
+            entityHasAccess: entityHasAccess,
+            supportedReasoningEffort: supportedReasoningEffort,
+            reasoningEffortAccess: reasoningEffortAccess,
+            label: label
+        )
     }
 
     func testSelectedModelId_readsFromInjectedPersistor() throws {
@@ -399,6 +432,138 @@ final class NewTabPageOmnibarConfigProviderTests: XCTestCase {
         // Second launch: legacy key is gone, so nothing is overwritten.
         _ = try makeProvider(persistor: persistor, keyValueStore: store)
         XCTAssertEqual(persistor.selectedModelId, "claude-4")
+    }
+
+    // MARK: - Create Image model resolution
+
+    func testImageGenerationModelId_usesSelectedAccessibleImageModel() throws {
+        let persistor = MockAIChatPreferencesPersisting()
+        persistor.selectedModelId = "selected-image-model"
+        let models = [
+            makeModel(id: "preferred-image-model", supportsImageGeneration: true, label: .everydayUse),
+            makeModel(id: "selected-image-model", supportsImageGeneration: true, label: .usesLimitsFaster)
+        ]
+        let provider = try makeProvider(
+            persistor: persistor,
+            featureFlagger: flaggerWithUpdatedCreateImageOn(),
+            availableModelsProvider: { models }
+        )
+
+        XCTAssertEqual(provider.imageGenerationModelId, "selected-image-model")
+    }
+
+    func testImageGenerationModelId_usesPreferredModelWhenSelectionIsUnsupported() throws {
+        let persistor = MockAIChatPreferencesPersisting()
+        persistor.selectedModelId = "unsupported-model"
+        let models = [
+            makeModel(id: "unsupported-model"),
+            makeModel(id: "first-image-model", supportsImageGeneration: true, label: .usesLimitsFaster),
+            makeModel(id: "preferred-image-model", supportsImageGeneration: true, label: .everydayUse)
+        ]
+        let provider = try makeProvider(
+            persistor: persistor,
+            featureFlagger: flaggerWithUpdatedCreateImageOn(),
+            availableModelsProvider: { models }
+        )
+
+        XCTAssertEqual(provider.imageGenerationModelId, "preferred-image-model")
+    }
+
+    func testActivateImageGeneration_withMissingSelectionPersistsPreferredModelWithoutNotice() throws {
+        let persistor = MockAIChatPreferencesPersisting()
+        let models = [makeModel(id: "preferred-image-model", shortName: "Luna", supportsImageGeneration: true, label: .everydayUse)]
+        let provider = try makeProvider(
+            persistor: persistor,
+            featureFlagger: flaggerWithUpdatedCreateImageOn(),
+            availableModelsProvider: { models }
+        )
+
+        let notice = provider.activateImageGeneration()
+
+        XCTAssertEqual(persistor.selectedModelId, "preferred-image-model")
+        XCTAssertEqual(persistor.selectedModelShortName, "Luna")
+        XCTAssertNil(notice)
+    }
+
+    func testActivateImageGeneration_withKnownUnsupportedSelectionReturnsSharedLocalizedNotice() throws {
+        let persistor = MockAIChatPreferencesPersisting()
+        persistor.selectedModelId = "oss-model"
+        let previousModel = makeModel(id: "oss-model", shortName: "Open Model", provider: .oss)
+        let imageModel = makeModel(id: "image-model", shortName: "Luna", supportsImageGeneration: true, label: .everydayUse)
+        let provider = try makeProvider(
+            persistor: persistor,
+            featureFlagger: flaggerWithUpdatedCreateImageOn(),
+            availableModelsProvider: { [previousModel, imageModel] }
+        )
+
+        let notice = provider.activateImageGeneration()
+
+        XCTAssertEqual(notice?.message, UserText.aiChatCreateImageModelSwitchTitle("Luna"))
+        XCTAssertEqual(notice?.secondaryText, UserText.aiChatCreateImageModelSwitchPrivacySubtitle("Open Model"))
+    }
+
+    func testActivateImageGeneration_clearsInvalidReasoningEffort() throws {
+        let persistor = MockAIChatPreferencesPersisting()
+        persistor.selectedModelId = "unsupported-model"
+        persistor.selectedReasoningEffort = "invalid"
+        let models = [
+            makeModel(id: "unsupported-model"),
+            makeModel(id: "image-model", supportsImageGeneration: true, label: .everydayUse)
+        ]
+        let provider = try makeProvider(
+            persistor: persistor,
+            featureFlagger: flaggerWithUpdatedCreateImageOn(),
+            availableModelsProvider: { models }
+        )
+
+        _ = provider.activateImageGeneration()
+
+        XCTAssertNil(persistor.selectedReasoningEffort)
+    }
+
+    func testActivateImageGeneration_clearsUnsupportedReasoningEffort() throws {
+        let persistor = MockAIChatPreferencesPersisting()
+        persistor.selectedModelId = "unsupported-model"
+        persistor.selectedReasoningEffort = AIChatReasoningEffort.high.rawValue
+        let models = [
+            makeModel(id: "unsupported-model"),
+            makeModel(id: "image-model", supportsImageGeneration: true, supportedReasoningEffort: [.low], label: .everydayUse)
+        ]
+        let provider = try makeProvider(
+            persistor: persistor,
+            featureFlagger: flaggerWithUpdatedCreateImageOn(),
+            availableModelsProvider: { models }
+        )
+
+        _ = provider.activateImageGeneration()
+
+        XCTAssertNil(persistor.selectedReasoningEffort)
+    }
+
+    func testActivateImageGeneration_preservesSupportedGatedReasoningEffort() throws {
+        let persistor = MockAIChatPreferencesPersisting()
+        persistor.selectedModelId = "unsupported-model"
+        persistor.selectedReasoningEffort = AIChatReasoningEffort.medium.rawValue
+        let gatedEffort = AIChatReasoningEffortAccess(effort: .medium, accessTier: ["pro"], entityHasAccess: false)
+        let models = [
+            makeModel(id: "unsupported-model"),
+            makeModel(
+                id: "image-model",
+                supportsImageGeneration: true,
+                supportedReasoningEffort: [.medium],
+                reasoningEffortAccess: [gatedEffort],
+                label: .everydayUse
+            )
+        ]
+        let provider = try makeProvider(
+            persistor: persistor,
+            featureFlagger: flaggerWithUpdatedCreateImageOn(),
+            availableModelsProvider: { models }
+        )
+
+        _ = provider.activateImageGeneration()
+
+        XCTAssertEqual(persistor.selectedReasoningEffort, AIChatReasoningEffort.medium.rawValue)
     }
 
     // MARK: - Reasoning effort

--- a/macOS/UnitTests/NewTabPage/NewTabPageOmnibarConfigProviderTests.swift
+++ b/macOS/UnitTests/NewTabPage/NewTabPageOmnibarConfigProviderTests.swift
@@ -498,8 +498,13 @@ final class NewTabPageOmnibarConfigProviderTests: XCTestCase {
 
         let notice = provider.activateImageGeneration()
 
-        XCTAssertEqual(notice?.message, UserText.aiChatCreateImageModelSwitchTitle("Luna"))
-        XCTAssertEqual(notice?.secondaryText, UserText.aiChatCreateImageModelSwitchPrivacySubtitle("Open Model"))
+        XCTAssertEqual(
+            notice,
+            NewTabPageDataModel.OmnibarCreateImageModelSwitch(
+                message: UserText.aiChatCreateImageModelSwitchTitle("Luna"),
+                secondaryText: UserText.aiChatCreateImageModelSwitchPrivacySubtitle("Open Model")
+            )
+        )
     }
 
     func testActivateImageGeneration_clearsInvalidReasoningEffort() throws {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204006570077678/task/1216436095926133
Tech Design URL:
CC:

### Description

Adds the updated Create Image flow to the macOS New Tab Page. Native code selects an accessible image-capable model and provides the localized model-switch notice, while the frontend renders and dismisses it.

This depends on the corresponding `content-scope-scripts` changes in branch `pr/3007`.

### Testing Steps

1. Clone `content-scope-scripts`, check out branch `feature/anpete/ntp-omnibar-ai-mode-usage-drawer`, and drag the repository's root folder into `DuckDuckGo.xcworkspace` in Xcode.
2. Run macOS with the updated Create Image and NTP image-generation feature flags enabled, then open a New Tab Page in Duck.ai mode.
3. Select a model that does not support image generation, then choose **Tools → Create Image**. Verify that the model switches and the native-localized notice appears.
4. Dismiss the notice and submit an image prompt. Verify that the notice closes and Create Image remains active.

### Impact

Medium. The native and frontend contracts must remain aligned; the behavior is gated by the existing feature flags.

---

###### Internal references:
[Definition of Done](https://app.asana.com/0/1204186595873227/1204186896266138/f) | [Engineering Expectations](https://app.asana.com/0/481882893211075/1202500774821704/f) | [Tech Design Template](https://app.asana.com/0/481882893211075/1202500774821700/f)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes model selection, omnibar bridge payloads, and chat submission parameters behind feature flags, but native and web must stay in sync and wrong model resolution could send prompts on an unexpected model.
> 
> **Overview**
> **Adds a native-driven “updated Create Image” path for the macOS New Tab Page Duck.ai omnibar**, gated by `aiChatNtpImageGeneration` plus `updatedCreateImage`. When the web enables Create Image, native can pick an accessible image-generation model, persist the selection (and clear reasoning effort the new model does not support), and push a **localized model-switch notice** back through omnibar config for the frontend to show and dismiss.
> 
> The **native ↔ web contract** grows with `enableUpdatedCreateImage`, `createImageModelSwitch`, `omnibar_setImageGenerationActive`, and `omnibar_dismissCreateImageModelSwitch`. **Submissions** in image-generation mode under the new flow use the natively resolved model id and `imageGeneration` tool choice instead of legacy `mode`, with a fallback to the old behavior when no model resolves. **Analytics** count image-generation submits when `toolChoice` includes image generation, not only when `mode` is set.
> 
> Copy for the switch notice is centralized on `AIChatCreateImageModelSwitchNotice` (`localizedTitle` / `localizedSubtitle`), reused by the usage warning card and the NTP config payload. The **NewTabPage** package now depends on **AIChat** for those submission types.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8104c2841fd9ad81751a2e544c9d48e39967205c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->