### PR TITLE
iOS: Increase fire tab address bar contrast in dark mode

### DIFF
--- a/SharedPackages/Infrastructure/DesignResourcesKit/Sources/DesignResourcesKit/Colors/ColorPalettes/DefaultColorPalette.swift
+++ b/SharedPackages/Infrastructure/DesignResourcesKit/Sources/DesignResourcesKit/Colors/ColorPalettes/DefaultColorPalette.swift
@@ -42,6 +42,7 @@ struct DefaultColorPalette: ColorPaletteDefinition {
 
     // New dark mode colors
     private static let x080808 = Color(0x080808)
+    private static let x090909 = Color(0x090909)
     private static let x282828 = Color(0x282828)
     private static let x373737 = Color(0x373737)
     private static let x3D3D3D = Color(0x3D3D3D)
@@ -111,6 +112,7 @@ struct DefaultColorPalette: ColorPaletteDefinition {
     private static let fireModeAccentTertiary = DynamicColor(lightColor: RebrandingColor.Mandarin.mandarin70, darkColor: RebrandingColor.Mandarin.mandarin60)
     private static let fireModeBackground = DynamicColor(lightColor: x3D3D3D, darkColor: x080808)
     private static let fireModeCardBackground = DynamicColor(lightColor: x3D3D3D, darkColor: x1C1C1C)
+    private static let fireModeFieldBackground = DynamicColor(lightColor: x3D3D3D, darkColor: x090909)
 
     // DuckAI Cells
     private static let duckAIVoiceCellBackground = DynamicColor(staticColor: RebrandingColor.Pondwater.pondwater90)
@@ -357,6 +359,7 @@ struct DefaultColorPalette: ColorPaletteDefinition {
         case .fireModeAccentTertiary: return fireModeAccentTertiary
         case .fireModeBackground: return fireModeBackground
         case .fireModeCardBackground: return fireModeCardBackground
+        case .fireModeFieldBackground: return fireModeFieldBackground
         case .duckAIVoiceCellBackground: return duckAIVoiceCellBackground
         }
     }

--- a/SharedPackages/Infrastructure/DesignResourcesKit/Sources/DesignResourcesKit/Colors/SingleUseColor.swift
+++ b/SharedPackages/Infrastructure/DesignResourcesKit/Sources/DesignResourcesKit/Colors/SingleUseColor.swift
@@ -75,6 +75,9 @@ public enum SingleUseColor {
     case fireModeBackground
     case fireModeCardBackground
 
+    /// Fire Mode address bar field fill (Figma: Unified-Input-Fire/Field)
+    case fireModeFieldBackground
+
     // Duck.ai Grid Cell
     case duckAIVoiceCellBackground
 

--- a/iOS/DuckDuckGo/DefaultOmniBarView.swift
+++ b/iOS/DuckDuckGo/DefaultOmniBarView.swift
@@ -1311,11 +1311,9 @@ final class DefaultOmniBarView: UIView, OmniBarView, ExpandableOmniBarView {
                 ? UIColor(singleUseColor: .fireModeAccent).cgColor
                 : UIColor(designSystemColor: .accentPrimary).cgColor
         } else {
-            // Floating UI off (production): preserve the original fire-mode fill so the
-            // fire-mode omnibar colour is unchanged from `main`.
-            setFieldBackgroundColor(fireMode
-                ? UIColor(singleUseColor: .fireModeCardBackground)
-                : restingFieldBackgroundColor)
+            // Floating UI off (production): use the same fire-mode fill as the floating field so the
+            // field stays legible against the surrounding chrome in dark mode.
+            setFieldBackgroundColor(opaqueFieldBackgroundColor)
             activeOutlineView.layer.borderColor = fireMode
                 ? UIColor(singleUseColor: .fireModeAccent).cgColor
                 : UIColor(designSystemColor: .accentPrimary).cgColor
@@ -1756,7 +1754,7 @@ private extension DefaultOmniBarView {
 
     var opaqueFieldBackgroundColor: UIColor {
         fireMode
-            ? UIColor(singleUseColor: .fireModeBackground)
+            ? UIColor(singleUseColor: .fireModeFieldBackground)
             : restingFieldBackgroundColor
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414709148257752/task/1217661540050115?focus=true
Tech Design URL:
CC:

### Description

This PR updates the background colour of the address bar in fire tabs in dark mode.

| Before | After |
|--------|--------|
| <img alt="simulator_screenshot_5E927234-7EE3-4D49-AC3B-15E09DEF12CB" src="https://github.com/user-attachments/assets/6e82bf7e-cc31-4e06-b46b-f7a40e28aac8" /> | <img alt="simulator_screenshot_F6E7FB9E-DF40-4A84-88C8-D741E334352C" src="https://github.com/user-attachments/assets/47a28110-1a35-4c0c-81c5-864dd379922d" /> | 

### Testing Steps

1. Build and run on iOS
2. Entire fire mode
3. Ensure the address bar background (unfocused) looks good in both light and dark mode
4. Note that the background colour when the field is expanded should be unchanged

### Impact

Low: Minor visual changes, small bug fixes, improvement to existing features

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped visual token and omnibar background color changes for fire mode only; no auth, data, or business-logic impact.
> 
> **Overview**
> Adds a dedicated **`fireModeFieldBackground`** design token (Figma Unified-Input-Fire/Field: `#3D3D3D` light, `#090909` dark) and wires the iOS omnibar to use it for the fire-tab address field fill instead of **`fireModeBackground`**.
> 
> When **floating UI is off** (current production path), the resting fire-tab field now uses the same **`opaqueFieldBackgroundColor`** path as the floating field rather than **`fireModeCardBackground`**, so the unfocused bar reads clearly against surrounding chrome in dark mode. Expanded/active field styling is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e61cd4a13c64b55a790643f3c095f43f0742c6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->