### PR TITLE
EventHub metrics: hub-level de-duplication and experiment metrics

### DIFF
--- a/DuckDuckGo.xcworkspace/contents.xcworkspacedata
+++ b/DuckDuckGo.xcworkspace/contents.xcworkspacedata
@@ -31,6 +31,9 @@
       <FileRef
          location = "group:DDGError">
       </FileRef>
+      <FileRef
+         location = "group:EventHub">
+      </FileRef>
       <FileSystemSynchronizedGroup
          location = "group:Infrastructure"
          name = "Infrastructure">

--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/AppPrivacyConfiguration.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/AppPrivacyConfiguration.swift
@@ -336,6 +336,10 @@ public struct AppPrivacyConfiguration: PrivacyConfiguration {
         return subfeatureData.settings
     }
 
+    public func allSubfeatureSettings(for feature: PrivacyFeature) -> [SubfeatureID: PrivacyConfigurationData.PrivacyFeature.SubfeatureSettings] {
+        subfeatures(for: feature).compactMapValues(\.settings)
+    }
+
     public func userEnabledProtection(forDomain domain: String) {
         let domainToRemove = locallyUnprotected.unprotectedDomains.first { unprotectedDomain in
             unprotectedDomain.punycodeEncodedHostname.lowercased() == domain

--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/PrivacyConfiguration.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/PrivacyConfiguration.swift
@@ -109,6 +109,13 @@ public protocol PrivacyConfiguration {
     /// Returns settings for a specified subfeature.
     func settings(for subfeature: any PrivacySubfeature) -> PrivacyConfigurationData.PrivacyFeature.SubfeatureSettings?
 
+    /// Returns the raw `settings` JSON of every subfeature of `feature`, keyed by subfeature ID.
+    ///
+    /// Unlike `settings(for: any PrivacySubfeature)` this needs no compile-time subfeature enum, so it
+    /// reaches subfeatures whose IDs only exist in remote config — experiment subfeatures such as
+    /// `contentScopeExperiment1` or `tdsNextExperiment007`. Subfeatures with no `settings` are omitted.
+    func allSubfeatureSettings(for feature: PrivacyFeature) -> [SubfeatureID: PrivacyConfigurationData.PrivacyFeature.SubfeatureSettings]
+
     /// Removes given domain from locally unprotected list.
     func userEnabledProtection(forDomain: String)
     /// Adds given domain to locally unprotected list.

--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfigTestsUtils/MockPrivacyConfiguration.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfigTestsUtils/MockPrivacyConfiguration.swift
@@ -62,6 +62,10 @@ public class MockPrivacyConfiguration: PrivacyConfiguration {
         subfeatureSettings
     }
 
+    public func allSubfeatureSettings(for feature: PrivacyFeature) -> [SubfeatureID: PrivacyConfigurationData.PrivacyFeature.SubfeatureSettings] {
+        [:]
+    }
+
     public var exceptionsListClosure: (PrivacyFeature) -> [String] = { _ in [] }
     public var featureSettings: PrivacyConfigurationData.PrivacyFeature.FeatureSettings = [:]
     public var subfeatureSettings: PrivacyConfigurationData.PrivacyFeature.SubfeatureSettings?

--- a/SharedPackages/BrowserServicesKit/Tests/BrokenSitePromptTests/PrivacyConfigurationManagerMock.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/BrokenSitePromptTests/PrivacyConfigurationManagerMock.swift
@@ -89,6 +89,10 @@ class PrivacyConfigurationMock: PrivacyConfiguration {
         return nil
     }
 
+    func allSubfeatureSettings(for feature: PrivacyFeature) -> [SubfeatureID: PrivacyConfigurationData.PrivacyFeature.SubfeatureSettings] {
+        [:]
+    }
+
     var userUnprotected = Set<String>()
     func userEnabledProtection(forDomain domain: String) {
         userUnprotected.remove(domain)

--- a/SharedPackages/BrowserServicesKit/Tests/BrowserServicesKitTests/ContentBlocker/UserContentControllerTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/BrowserServicesKitTests/ContentBlocker/UserContentControllerTests.swift
@@ -344,6 +344,10 @@ class PrivacyConfigurationMock: PrivacyConfiguration {
         return nil
     }
 
+    func allSubfeatureSettings(for feature: PrivacyFeature) -> [SubfeatureID: PrivacyConfigurationData.PrivacyFeature.SubfeatureSettings] {
+        [:]
+    }
+
     var identifier: String = "abcd"
     var version: String? = "123456789"
     var userUnprotectedDomains: [String] = []

--- a/SharedPackages/BrowserServicesKit/Tests/ConfigurationTests/TrackerDataURLOverriderTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/ConfigurationTests/TrackerDataURLOverriderTests.swift
@@ -234,6 +234,10 @@ class MockPrivacyConfiguration: PrivacyConfiguration {
         return subfeatureSettings ?? mockSubfeatureSettings[subfeature.rawValue]
     }
 
+    func allSubfeatureSettings(for feature: PrivacyFeature) -> [SubfeatureID: PrivacyConfigurationData.PrivacyFeature.SubfeatureSettings] {
+        [:]
+    }
+
     func exceptionsList(forFeature featureKey: PrivacyFeature) -> [String] { exceptionsList(featureKey) }
     var isFeatureKeyEnabled: ((PrivacyFeature, AppVersionProvider) -> Bool)?
     func isEnabled(featureKey: PrivacyFeature, versionProvider: AppVersionProvider, defaultValue: Bool) -> Bool {

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/Mocks/Mocks.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/Mocks/Mocks.swift
@@ -215,6 +215,10 @@ class MockPrivacyConfiguration: PrivacyConfiguration {
         return nil
     }
 
+    func allSubfeatureSettings(for feature: PrivacyFeature) -> [SubfeatureID: PrivacyConfigurationData.PrivacyFeature.SubfeatureSettings] {
+        [:]
+    }
+
     var identifier: String = "abcd"
     var version: String? = "123456789"
     var userUnprotectedDomains: [String] = []

--- a/SharedPackages/BrowserServicesKit/Tests/MaliciousSiteProtectionTests/Mocks/PrivacyConfigurationManagerMock.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/MaliciousSiteProtectionTests/Mocks/PrivacyConfigurationManagerMock.swift
@@ -89,6 +89,10 @@ class PrivacyConfigurationMock: PrivacyConfiguration {
         return nil
     }
 
+    func allSubfeatureSettings(for feature: PrivacyFeature) -> [SubfeatureID: PrivacyConfigurationData.PrivacyFeature.SubfeatureSettings] {
+        [:]
+    }
+
     var userUnprotected = Set<String>()
     func userEnabledProtection(forDomain domain: String) {
         userUnprotected.remove(domain)

--- a/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCoreTestsUtils/Mocks.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCoreTestsUtils/Mocks.swift
@@ -261,6 +261,10 @@ public final class PrivacyConfigurationMock: PrivacyConfiguration {
         return nil
     }
 
+    public func allSubfeatureSettings(for feature: PrivacyFeature) -> [SubfeatureID: PrivacyConfigurationData.PrivacyFeature.SubfeatureSettings] {
+        [:]
+    }
+
     public func userEnabledProtection(forDomain: String) {
 
     }

--- a/SharedPackages/EventHub/Package.swift
+++ b/SharedPackages/EventHub/Package.swift
@@ -45,9 +45,13 @@ let package = Package(
                 .product(name: "Common", package: "Common"),
                 .product(name: "Persistence", package: "Persistence"),
                 .product(name: "UserScript", package: "BrowserServicesKit"),
+                .product(name: "PrivacyConfig", package: "BrowserServicesKit"),
             ]),
         .testTarget(
             name: "EventHubTests",
-            dependencies: ["EventHub"]),
+            dependencies: [
+                "EventHub",
+                .product(name: "PrivacyConfigTestsUtils", package: "BrowserServicesKit"),
+            ]),
     ]
 )

--- a/SharedPackages/EventHub/Sources/EventHub/Config/EventHubConfig.swift
+++ b/SharedPackages/EventHub/Sources/EventHub/Config/EventHubConfig.swift
@@ -20,11 +20,16 @@ import Foundation
 
 /// When a pixel fires. Raw values are the strings remote config authors and the persisted config
 /// snapshot carries, so they must not change.
+///
+/// The one exception, deliberate: the immediate trigger was renamed from `immediate` to
+/// `immediate_v2` when web events began de-duplicating at the hub. Clients already in the wild parse
+/// `immediate` and would fire on every occurrence, so config carrying the new semantics needs a name
+/// they ignore. Safe for the persisted snapshot too: only `period` pixels ever have state to persist.
 public enum TelemetryTriggerType: String, Equatable, Sendable {
     /// Aggregated over a period, and the default when config omits the type.
     case period
-    /// One pixel per event.
-    case immediate
+    /// One pixel per delivered event.
+    case immediateV2 = "immediate_v2"
 }
 
 /// What a parameter measures. Raw values are the strings remote config authors and the persisted config

--- a/SharedPackages/EventHub/Sources/EventHub/Config/EventHubConfig.swift
+++ b/SharedPackages/EventHub/Sources/EventHub/Config/EventHubConfig.swift
@@ -90,6 +90,35 @@ public struct TelemetryPixelConfig: Equatable, Sendable {
     public var isEnabled: Bool { state == "enabled" }
 }
 
+/// One experiment-metric conversion request — the whole of what the metrics handler hands to the
+/// Native Apps experiment framework, and the unit the cross-platform specification asserts against.
+///
+/// Flattened at parse time. Config groups a metric's conversions as `windows × thresholds`, but that
+/// product is an authoring convenience with no meaning once an event arrives (M-FAN-P1), so the parser
+/// multiplies it out once and the event-time job is left as a filter over a flat list.
+public struct MetricRequest: Equatable, Sendable {
+    /// The experiment (subfeature) ID whose `settings.metrics` declared this metric. Declaration is
+    /// attachment: a request always belongs to the declaring experiment and is never fanned out by
+    /// metric name alone, so two experiments declaring the same name stay independent (M-SEL-P1/P2).
+    public let experiment: String
+    /// The event type that triggers this metric.
+    public let event: String
+    public let metric: String
+    /// Inclusive day bounds after enrollment. Whether the user is inside the window is the experiment
+    /// framework's decision, not the hub's — the hub only reports.
+    public let windowDays: ClosedRange<Int>
+    /// Occurrence count at which the framework converts.
+    public let threshold: Int
+
+    public init(experiment: String, event: String, metric: String, windowDays: ClosedRange<Int>, threshold: Int) {
+        self.experiment = experiment
+        self.event = event
+        self.metric = metric
+        self.windowDays = windowDays
+        self.threshold = threshold
+    }
+}
+
 /// Runtime state for a single parameter within a pixel's active period.
 public struct ParamState: Codable, Equatable, Sendable {
     public var value: Int

--- a/SharedPackages/EventHub/Sources/EventHub/Config/EventHubConfigParser.swift
+++ b/SharedPackages/EventHub/Sources/EventHub/Config/EventHubConfigParser.swift
@@ -55,6 +55,60 @@ public final class EventHubConfigParser {
         }
     }
 
+    /// Parses the `metrics` map out of one experiment subfeature's raw `settings` JSON, returning the
+    /// flattened conversion requests it declares. Malformed or invalid input yields an empty list and
+    /// never throws, as with `parseTelemetry`.
+    ///
+    /// Metrics live in the settings of CSS and TDS experiment subfeatures rather than in the `eventHub`
+    /// feature, so — unlike `parseTelemetry`, which is handed the dictionary remote config already
+    /// holds — this takes the raw JSON string, which is how `PrivacyConfigurationData` carries
+    /// subfeature settings.
+    ///
+    /// One bad metric is isolated rather than fatal: its siblings in the same experiment still parse.
+    public func parseMetrics(experiment: String, settingsJSON: String) -> [MetricRequest] {
+        guard let data = settingsJSON.data(using: .utf8) else { return [] }
+        let settings: SubfeatureSettingsDTO
+        do {
+            settings = try JSONDecoder().decode(SubfeatureSettingsDTO.self, from: data)
+        } catch {
+            Logger.eventHub.error("config: experiment \(experiment, privacy: .public) settings could not be decoded, no metrics configured: \(error.localizedDescription, privacy: .public)")
+            return []
+        }
+        // An absent `metrics` key is the normal case — the key is optional and most experiments declare
+        // none — so it must stay distinguishable from the decode failure above.
+        guard let metrics = settings.metrics else { return [] }
+        return metrics.flatMap { name, dto in
+            Self.toRequests(experiment: experiment, metric: name, dto)
+        }
+    }
+
+    private static func toRequests(experiment: String, metric: String, _ dto: MetricDTO) -> [MetricRequest] {
+        guard let event = dto.event, !event.isEmpty else {
+            Logger.eventHub.error("config: metric \(experiment, privacy: .public)/\(metric, privacy: .public) skipped, missing event")
+            return []
+        }
+        var requests: [MetricRequest] = []
+        for conversion in dto.conversions ?? [] {
+            for window in conversion.windows ?? [] {
+                // The one guard that has to exist: `ClosedRange` traps on an inverted range. Negative
+                // day bounds are meaningless, and a threshold below 1 would have the framework convert
+                // on every occurrence — a config typo would become pixel spam. Config validation
+                // rejects all three upstream (remote-config repo tests, so out of specification
+                // scope); this is defence, and it drops only the offending window or threshold.
+                guard window.count == 2, let low = window.first, let high = window.last,
+                      low >= 0, low <= high else {
+                    Logger.eventHub.error("config: metric \(experiment, privacy: .public)/\(metric, privacy: .public) dropped a conversion window that was not an ordered, non-negative pair")
+                    continue
+                }
+                for threshold in conversion.thresholds ?? [] where threshold >= 1 {
+                    requests.append(MetricRequest(experiment: experiment, event: event, metric: metric,
+                                                  windowDays: low...high, threshold: threshold))
+                }
+            }
+        }
+        return requests
+    }
+
     /// Parses a single serialised pixel config (as produced by `serializePixelConfig`), returning `nil`
     /// if it is malformed or invalid.
     public func parseSinglePixelConfig(name: String, json: String) -> TelemetryPixelConfig? {
@@ -165,6 +219,25 @@ public final class EventHubConfigParser {
         let state: String?
         let trigger: TriggerDTO?
         let parameters: [String: ParameterDTO]?
+    }
+
+    /// An experiment subfeature's `settings`, of which only the optional `metrics` map concerns us —
+    /// TDS experiments also carry `controlUrl`/`treatmentUrl` there, which decode away harmlessly.
+    private struct SubfeatureSettingsDTO: Codable {
+        let metrics: [String: MetricDTO]?
+    }
+
+    /// Every field optional so one malformed metric is skipped with its siblings intact; a
+    /// non-optional field would fail the whole `settings` decode instead.
+    private struct MetricDTO: Codable {
+        let event: String?
+        let conversions: [ConversionDTO]?
+    }
+
+    private struct ConversionDTO: Codable {
+        /// `[[low, high], …]` — inclusive day bounds, which may freely overlap.
+        let windows: [[Int]]?
+        let thresholds: [Int]?
     }
 
     private struct TriggerDTO: Codable {

--- a/SharedPackages/EventHub/Sources/EventHub/Config/EventHubConfigParser.swift
+++ b/SharedPackages/EventHub/Sources/EventHub/Config/EventHubConfigParser.swift
@@ -89,17 +89,19 @@ public final class EventHubConfigParser {
 
     private static func toTrigger(_ dto: TriggerDTO, pixelName: String) -> TelemetryTriggerConfig? {
         // An omitted type means `period`; a present but unrecognised one is a config we cannot honour.
+        // That includes the retired `immediate`, which this client no longer understands — see
+        // `TelemetryTriggerType`.
         guard let type = dto.type.map(TelemetryTriggerType.init(rawValue:)) ?? .period else {
             Logger.eventHub.error("config: pixel \(pixelName, privacy: .public) skipped, unknown trigger type \(dto.type ?? "<none>", privacy: .public)")
             return nil
         }
         switch type {
-        case .immediate:
+        case .immediateV2:
             guard let source = dto.source, !source.isEmpty else {
                 Logger.eventHub.error("config: pixel \(pixelName, privacy: .public) skipped, immediate trigger with no source")
                 return nil
             }
-            return TelemetryTriggerConfig(type: .immediate, source: source)
+            return TelemetryTriggerConfig(type: .immediateV2, source: source)
         case .period:
             guard let period = dto.period, period.seconds > 0 else {
                 Logger.eventHub.error("config: pixel \(pixelName, privacy: .public) skipped, period seconds missing or not positive")

--- a/SharedPackages/EventHub/Sources/EventHub/Core/DedupStore.swift
+++ b/SharedPackages/EventHub/Sources/EventHub/Core/DedupStore.swift
@@ -17,27 +17,49 @@
 //
 
 import Foundation
+import os.log
 
-/// Per-tab de-duplication state, keyed pixel×param×source within a tab.
+/// Per-tab de-duplication state for web events, keyed `event type × event data` within a tab.
 ///
-/// Owned by `EventHub` rather than by the parameters that consult it, because dedup is *page*-scoped,
-/// not *period*-scoped: it must survive both a period rollover and the window where a period fires
-/// while backgrounded, each of which destroys the owning `Telemetry` and its parameters. It is cleared
-/// only when a tab navigates to a genuinely different URL, when a tab closes, or when the whole feature
-/// is disabled — never at a period boundary, which would let a long-lived page inflate the first count
-/// of every new period.
+/// Owned and consulted by `EventHub` itself: the decision is taken once at ingestion, before any
+/// handler runs, so a duplicate reaches no handler at all and a first occurrence reaches every one of
+/// them. That is deliberately *not* per-handler — handlers must not each reimplement it, and a single
+/// page load firing the same event from several frames would otherwise inflate every consumer's count.
+///
+/// State is *page*-scoped, not *period*-scoped: it survives both a period rollover and the window
+/// where a period fires while backgrounded. It is cleared only when a tab navigates to a genuinely
+/// different URL, when a tab closes, or when the whole feature is disabled — never at a period
+/// boundary, which would let a long-lived page inflate the first count of every new period.
+///
+/// The per-tab key set is unbounded, since it is cleared on every navigation and tab close: the
+/// ceiling is the distinct `(type, data)` pairs one page emits before it navigates away.
 ///
 /// In-memory only, never persisted: after a restart a page counts once more, which is intended.
 ///
 /// Not thread-safe on its own — like all other EventHub state, access is confined to the hub's serial
 /// queue.
 final class DedupStore {
-    private var seenByTab: [EventHubTabID: Set<String>] = [:]
+    /// A struct rather than a joined string: event types come from remote config, so any separator
+    /// character could in principle appear in one and collide with a different `(type, data)` pair.
+    private struct Key: Hashable {
+        let type: String
+        /// The payload as canonical JSON, or `""` when there is no payload. See `canonicalPayload`.
+        let payload: String
+    }
 
-    /// Records `key` as seen for `tabID`, returning `true` when it was *not* already present — i.e.
-    /// this is the first occurrence on the tab's current page, so the caller should count it.
-    func markSeen(key: String, tabID: EventHubTabID) -> Bool {
-        seenByTab[tabID, default: []].insert(key).inserted
+    private var seenByTab: [EventHubTabID: Set<Key>] = [:]
+
+    /// Records this event as seen for `tabID`, returning `true` when it was *not* already present —
+    /// i.e. this is the first occurrence on the tab's current page, so the caller should deliver it.
+    func markSeen(type: String, data: [String: Any]?, tabID: EventHubTabID) -> Bool {
+        guard let payload = Self.canonicalPayload(data) else {
+            // A payload we cannot canonicalise is delivered but not recorded. Under-de-duplicating is
+            // the safe failure here: payloads reach us as JSON from the content-scope-scripts bridge,
+            // so this is defence only, and dropping the event would lose data outright.
+            Logger.eventHub.error("event \(type, privacy: .private) payload could not be canonicalised, event not de-duplicated")
+            return true
+        }
+        return seenByTab[tabID, default: []].insert(Key(type: type, payload: payload)).inserted
     }
 
     /// Drops everything recorded for a tab — used on navigation to a different URL and on tab close.
@@ -47,5 +69,18 @@ final class DedupStore {
 
     func clearAll() {
         seenByTab.removeAll()
+    }
+
+    /// Payloads equal as JSON values are one key: `.sortedKeys` orders object members (recursively,
+    /// so nested objects compare irrespective of order too) while leaving array elements in place. An
+    /// omitted payload and an empty one are both `""`, so they are the same key.
+    ///
+    /// `nil` means "not canonicalisable", which is distinct from the empty `""` payload.
+    private static func canonicalPayload(_ data: [String: Any]?) -> String? {
+        guard let data, !data.isEmpty else { return "" }
+        guard let encoded = try? JSONSerialization.data(withJSONObject: data, options: [.sortedKeys]) else {
+            return nil
+        }
+        return String(data: encoded, encoding: .utf8)
     }
 }

--- a/SharedPackages/EventHub/Sources/EventHub/Core/EventHub.swift
+++ b/SharedPackages/EventHub/Sources/EventHub/Core/EventHub.swift
@@ -31,15 +31,13 @@ public protocol EventHubManaging: AnyObject {
     /// repeat reaches no handler, a first occurrence reaches every handler. See `DedupStore`.
     func handleWebEvent(_ webEventData: [String: Any], tabID: EventHubTabID)
 
-    /// Fires any enabled immediate-trigger telemetry whose `trigger.source` equals `type`. For
-    /// browser-native events (not content-scope-scripts): there is no tab context, so no page to
-    /// de-duplicate against, and every call is a genuine occurrence.
-    func handleImmediateEvent(_ type: String, data: Encodable?)
-
-    /// Counts a browser-native event toward any enabled period/aggregated telemetry whose parameter
-    /// `source` equals `type`. Like `handleImmediateEvent`, and unlike web events, this never passes
-    /// through de-duplication: each call is a genuine occurrence.
-    func handleAggregatedEvent(_ type: String, data: Encodable?)
+    /// Processes a browser-native event (not content-scope-scripts): fires matching immediate
+    /// telemetry, counts it toward matching period telemetry, and reports any experiment metrics bound
+    /// to it — the same fan-out a web event gets.
+    ///
+    /// There is no tab context, so no page to de-duplicate against, and every call is a genuine
+    /// occurrence delivered to every handler. See `DedupStore`.
+    func handleNativeEvent(_ type: String, data: Encodable?)
 
     /// Signals that the given tab has navigated to `url` (clears per-tab dedup on URL change).
     func onNavigationStarted(tabID: EventHubTabID, url: String)
@@ -58,8 +56,7 @@ public protocol EventHubManaging: AnyObject {
 }
 
 public extension EventHubManaging {
-    func handleImmediateEvent(_ type: String) { handleImmediateEvent(type, data: nil) }
-    func handleAggregatedEvent(_ type: String) { handleAggregatedEvent(type, data: nil) }
+    func handleNativeEvent(_ type: String) { handleNativeEvent(type, data: nil) }
 }
 
 /// Real `EventHubManaging` implementation. All mutable state is confined to one serial `DispatchQueue`
@@ -71,8 +68,8 @@ public extension EventHubManaging {
 /// back into EventHub merely enqueues instead of deadlocking.
 ///
 /// Because the body runs later, anything that must be sampled at the moment of the *call* is captured
-/// before dispatching — see `nowMillis` in `handleWebEvent`/`handleAggregatedEvent`, and the payload
-/// encoding in `handleImmediateEvent`.
+/// before dispatching — see `nowMillis` in `handleWebEvent`/`handleNativeEvent`, and the payload
+/// encoding in `handleNativeEvent`.
 ///
 /// The four remaining uses of `queue.sync` are deliberate. None can deadlock: none is reachable from
 /// inside the queue, and a serial queue is FIFO, so a `sync` enqueued after the caller's own `async`
@@ -90,6 +87,7 @@ public final class EventHub: EventHubManaging {
     private let parser: EventHubConfigParser
     private let scheduler: EventHubScheduler
     private let pixelFiring: EventHubPixelFiring
+    private let conversionReporting: EventHubConversionReporting?
     private let queue: DispatchQueue
 
     private var telemetries: [String: Telemetry] = [:]
@@ -99,6 +97,10 @@ public final class EventHub: EventHubManaging {
     /// and hub-lifetime, so it outlives the `Telemetry` objects a period rollover replaces — dedup is
     /// page-scoped, not period-scoped. See `DedupStore`.
     private let dedupStore = DedupStore()
+    /// Every conversion request every experiment currently declares, flat and already multiplied out.
+    /// Rebuilt wholesale from config, like `latestConfigs`, and deliberately never persisted: it is a
+    /// derived view of remote config, so storing it would only duplicate what config already holds.
+    private var metricRequests: [MetricRequest] = []
     private var latestConfigs: [TelemetryPixelConfig] = []
     private var latestEnabled = false
     private var isForeground = false
@@ -131,12 +133,15 @@ public final class EventHub: EventHubManaging {
         settings: EventHubSettingsProviding,
         scheduler: EventHubScheduler,
         pixelFiring: EventHubPixelFiring,
+        conversionReporting: EventHubConversionReporting? = nil,
+        experimentSettings: AnyPublisher<[String: String], Never> = Just([:]).eraseToAnyPublisher(),
         queue: DispatchQueue = DispatchQueue(label: "com.duckduckgo.eventhub")
     ) {
         self.store = store
         self.parser = parser
         self.scheduler = scheduler
         self.pixelFiring = pixelFiring
+        self.conversionReporting = conversionReporting
         self.queue = queue
 
         // Both subscriptions re-apply the config themselves, so any change in enablement *or* in the
@@ -160,6 +165,26 @@ public final class EventHub: EventHubManaging {
                     self.latestConfigs = settings.map { self.parser.parseTelemetry($0) } ?? []
                     Logger.eventHub.info("parsed \(self.latestConfigs.count, privacy: .public) telemetry config(s) from settings")
                     if self.hasConsumedInitialSettings { self.applyConfigLocked() }
+                }
+            }
+            .store(in: &subscriptions)
+        // Deliberately its own parameter rather than a third member of `EventHubSettingsProviding`:
+        // that protocol means "feature enablement plus the telemetry settings, consent-stripped", and
+        // metrics are neither. They live in the settings of the CSS and TDS experiment subfeatures, and
+        // a conversion request carries no event payload — only experiment, metric, window and
+        // threshold — so there is nothing in one for a consent gate to strip.
+        //
+        // Unlike the two above this needs no `hasConsumedInitialSettings` gate: the registry is
+        // in-memory and derived, so a transient empty value during launch costs nothing and cannot wipe
+        // persisted state the way a transient `enabled == false` could.
+        experimentSettings
+            .sink { [weak self] settingsByExperiment in
+                guard let self else { return }
+                queue.async {
+                    self.metricRequests = settingsByExperiment.flatMap { experiment, json in
+                        self.parser.parseMetrics(experiment: experiment, settingsJSON: json)
+                    }
+                    Logger.eventHub.info("parsed \(self.metricRequests.count, privacy: .public) metric conversion request(s) from \(settingsByExperiment.count, privacy: .public) experiment(s)")
                 }
             }
             .store(in: &subscriptions)
@@ -195,39 +220,38 @@ public final class EventHub: EventHubManaging {
                 Logger.eventHub.debug("[EventHub] \(type, privacy: .private) dropped, already seen on this tab's current page")
                 return
             }
-            fireImmediateLocked(source: type, data: data)
-            countPeriodLocked(source: type, data: data, nowMillis: nowMillis)
+            deliverLocked(type: type, data: data, nowMillis: nowMillis)
         }
     }
 
-    public func handleImmediateEvent(_ type: String, data: Encodable?) {
+    /// The single delivery point: one event reaches every handler, exactly once. Web events get here
+    /// only after the de-duplication gate in `handleWebEvent`; native events, having no page to
+    /// de-duplicate against, get here directly. That gate is the *only* difference between the two
+    /// paths, which is precisely what the specification says it is — so the handler list lives here
+    /// once rather than being repeated per entry point.
+    private func deliverLocked(type: String, data: [String: Any]?, nowMillis: Int64) {
+        fireImmediateLocked(source: type, data: data)
+        countPeriodLocked(source: type, data: data, nowMillis: nowMillis)
+        reportMetricsLocked(source: type)
+    }
+
+    public func handleNativeEvent(_ type: String, data: Encodable?) {
         guard !type.isEmpty else { return }
+        Logger.eventHub.debug("[EventHub] native event received: \(type, privacy: .public)")
         // Encoded here, not in the block: `data` is a caller-owned `Encodable` that may be a reference
         // type, and the caller is free to mutate it the moment this returns. The cost is encoding a
-        // payload that a disabled feature then discards — native immediate events are rare enough that
-        // this is cheaper than the alternatives for reading `latestEnabled` off-queue.
-        Logger.eventHub.debug("[EventHub] native immediate event received: \(type, privacy: .public)")
+        // payload that a disabled feature then discards — native events are rare enough that this is
+        // cheaper than the alternatives for reading `latestEnabled` off-queue.
         let encoded = Self.encode(data)
-        queue.async { [self] in
-            guard latestEnabled else {
-                Logger.eventHub.debug("[EventHub] \(type, privacy: .public) dropped, the eventHub feature is disabled")
-                return
-            }
-            fireImmediateLocked(source: type, data: encoded)
-        }
-    }
-
-    public func handleAggregatedEvent(_ type: String, data: Encodable?) {
-        guard !type.isEmpty else { return }
-        Logger.eventHub.debug("[EventHub] native aggregated event received: \(type, privacy: .public)")
-        let encoded = Self.encode(data)
+        // Sampled here for the same reason as in `handleWebEvent`: `now` decides whether the event
+        // still belongs to the running period, so it has to be the arrival time.
         let nowMillis = scheduler.nowMillis()
         queue.async { [self] in
             guard latestEnabled else {
                 Logger.eventHub.debug("[EventHub] \(type, privacy: .public) dropped, the eventHub feature is disabled")
                 return
             }
-            countPeriodLocked(source: type, data: encoded, nowMillis: nowMillis)
+            deliverLocked(type: type, data: encoded, nowMillis: nowMillis)
         }
     }
 
@@ -291,6 +315,33 @@ public final class EventHub: EventHubManaging {
             : outcomes.joined(separator: "; ")
         Logger.eventHub.debug("[EventHub] period routing for \(source, privacy: .private) → \(summary, privacy: .public)")
         rearmSchedulerLocked()
+    }
+
+    /// Reports one conversion request per (experiment, metric, window, threshold) that names this event
+    /// type. Stateless by design: no counting, no window arithmetic, no enrollment check, nothing
+    /// persisted — the experiment framework owns all of that, and no-ops a request for an experiment
+    /// the user is not enrolled in.
+    ///
+    /// A linear scan because `metricRequests` is already flat and tiny (the whole cross-platform
+    /// reference fixture, ten experiments, is fifteen requests). If that ever stops holding, grouping
+    /// it by event type is a one-line change.
+    private func reportMetricsLocked(source: String) {
+        guard let conversionReporting else { return }
+        var reported: [String] = []
+        for request in metricRequests where request.event == source {
+            conversionReporting.reportConversion(experiment: request.experiment,
+                                                 metric: request.metric,
+                                                 windowDays: request.windowDays,
+                                                 threshold: request.threshold)
+            reported.append("\(request.experiment)/\(request.metric) \(request.windowDays.lowerBound)-\(request.windowDays.upperBound)×\(request.threshold)")
+        }
+        // One line per event, as with the period routing above, so "the metric never converted" can be
+        // answered from a single entry: whether anything was declared for this event, and what was
+        // handed to the framework if so.
+        let summary = reported.isEmpty
+            ? "no metric is declared for it (\(metricRequests.count) request(s) loaded)"
+            : reported.joined(separator: "; ")
+        Logger.eventHub.debug("[EventHub] metric routing for \(source, privacy: .private) → \(summary, privacy: .public)")
     }
 
     public func onConfigChanged() {

--- a/SharedPackages/EventHub/Sources/EventHub/Core/EventHub.swift
+++ b/SharedPackages/EventHub/Sources/EventHub/Core/EventHub.swift
@@ -26,15 +26,19 @@ import os.log
 public protocol EventHubManaging: AnyObject {
     /// Processes an incoming `webEvent` envelope (`{ "type": ..., "data": ... }`) from the tab
     /// identified by `tabID` against the active telemetry configs.
+    ///
+    /// De-duplicated once at ingestion, keyed `type × data × tabID` against the tab's current page: a
+    /// repeat reaches no handler, a first occurrence reaches every handler. See `DedupStore`.
     func handleWebEvent(_ webEventData: [String: Any], tabID: EventHubTabID)
 
     /// Fires any enabled immediate-trigger telemetry whose `trigger.source` equals `type`. For
-    /// browser-native events (not content-scope-scripts); there is no tab context.
+    /// browser-native events (not content-scope-scripts): there is no tab context, so no page to
+    /// de-duplicate against, and every call is a genuine occurrence.
     func handleImmediateEvent(_ type: String, data: Encodable?)
 
     /// Counts a browser-native event toward any enabled period/aggregated telemetry whose parameter
-    /// `source` equals `type`. Unlike web events there is no per-tab dedup: each call is a genuine
-    /// occurrence.
+    /// `source` equals `type`. Like `handleImmediateEvent`, and unlike web events, this never passes
+    /// through de-duplication: each call is a genuine occurrence.
     func handleAggregatedEvent(_ type: String, data: Encodable?)
 
     /// Signals that the given tab has navigated to `url` (clears per-tab dedup on URL change).
@@ -91,8 +95,9 @@ public final class EventHub: EventHubManaging {
     private var telemetries: [String: Telemetry] = [:]
     private var dirtyNames: Set<String> = []
     private var tabURLs: [EventHubTabID: String] = [:]
-    /// Hub-lifetime so per-tab dedup outlives the `Telemetry` objects that consult it — a period
-    /// rollover, and a period firing while backgrounded, both replace those. See `DedupStore`.
+    /// The one de-duplication decision, taken in `handleWebEvent` before any handler runs. Hub-owned
+    /// and hub-lifetime, so it outlives the `Telemetry` objects a period rollover replaces — dedup is
+    /// page-scoped, not period-scoped. See `DedupStore`.
     private let dedupStore = DedupStore()
     private var latestConfigs: [TelemetryPixelConfig] = []
     private var latestEnabled = false
@@ -171,8 +176,8 @@ public final class EventHub: EventHubManaging {
             Logger.eventHub.debug("[EventHub] web event ignored, `type` was missing or empty")
             return
         }
-        Logger.eventHub.debug("[EventHub] web event received: \(type, privacy: .private), tab \(tabID.rawValue.uuidString, privacy: .private)")
         let data = webEventData["data"] as? [String: Any]
+        Logger.eventHub.debug("[EventHub] web event received: \(type, privacy: .private), tab \(tabID.rawValue.uuidString, privacy: .private), data \(Self.payloadDescription(data), privacy: .private)")
         // Sampled here, not in the block: `now` decides whether the event still belongs to the running
         // period, so it has to be the arrival time. Read on the queue it would be the drain time, and an
         // event arriving just before `periodEnd` could be dropped for landing in no period at all.
@@ -182,8 +187,16 @@ public final class EventHub: EventHubManaging {
                 Logger.eventHub.debug("[EventHub] \(type, privacy: .private) dropped, the eventHub feature is disabled")
                 return
             }
+            // The single de-duplication decision, taken before fan-out: a duplicate reaches no
+            // handler at all, a first occurrence reaches every one of them. Deliberately after the
+            // `latestEnabled` guard — an event dropped because the feature is off must not record a
+            // key that would then suppress the real occurrence once it is switched back on.
+            guard dedupStore.markSeen(type: type, data: data, tabID: tabID) else {
+                Logger.eventHub.debug("[EventHub] \(type, privacy: .private) dropped, already seen on this tab's current page")
+                return
+            }
             fireImmediateLocked(source: type, data: data)
-            countPeriodLocked(source: type, data: data, tabID: tabID, nowMillis: nowMillis)
+            countPeriodLocked(source: type, data: data, nowMillis: nowMillis)
         }
     }
 
@@ -214,22 +227,29 @@ public final class EventHub: EventHubManaging {
                 Logger.eventHub.debug("[EventHub] \(type, privacy: .public) dropped, the eventHub feature is disabled")
                 return
             }
-            countPeriodLocked(source: type, data: encoded, tabID: .empty, nowMillis: nowMillis)
+            countPeriodLocked(source: type, data: encoded, nowMillis: nowMillis)
         }
     }
 
     private func fireImmediateLocked(source: String, data: [String: Any]?) {
-        let matching = latestConfigs.filter { $0.isEnabled && $0.trigger.type == .immediate && $0.trigger.source == source }
+        let matching = latestConfigs.filter { $0.isEnabled && $0.trigger.type == .immediateV2 && $0.trigger.source == source }
         Logger.eventHub.debug("[EventHub] immediate routing for \(source, privacy: .private) → \(matching.isEmpty ? "no immediate telemetry is triggered by it" : matching.map(\.name).joined(separator: ", "), privacy: .public)")
         for config in matching {
             var params: [String: String] = [:]
+            var declaresDataParameters = false
             for (paramName, paramConfig) in config.parameters where paramConfig.template == .data {
-                // Transient: an immediate pixel has no period and no dedup, so this parameter reports the
-                // triggering event's own payload and is discarded straight after firing.
+                declaresDataParameters = true
+                // Transient: an immediate pixel has no period, so this parameter reports the triggering
+                // event's own payload and is discarded straight after firing.
                 let parameter = DataParameter(dataKey: paramConfig.dataKey)
-                if parameter.handle(data: data, tabID: .empty), let value = parameter.queryValue() {
-                    params[paramName] = value
-                }
+                parameter.handle(data: data)
+                if let value = parameter.queryValue() { params[paramName] = value }
+            }
+            // A pixel that declares data parameters but resolved none of them has nothing to report, so
+            // it does not fire. A pixel declaring no parameters at all still fires on the event alone.
+            guard !declaresDataParameters || !params.isEmpty else {
+                Logger.eventHub.debug("[EventHub] \(config.name, privacy: .public) not fired, none of its data parameters resolved")
+                continue
             }
             pixelFiring.enqueueFirePixel(named: config.name, parameters: params)
         }
@@ -244,7 +264,7 @@ public final class EventHub: EventHubManaging {
     ///   onto the queue. The timer is best-effort, so it can legitimately be past `periodEnd` before the
     ///   sweep has run (notably on macOS, where a period can end while the app runs unfocused). An event
     ///   arriving in that window belongs to no period and must not be counted into the elapsed one.
-    private func countPeriodLocked(source: String, data: [String: Any]?, tabID: EventHubTabID, nowMillis now: Int64) {
+    private func countPeriodLocked(source: String, data: [String: Any]?, nowMillis now: Int64) {
         // Every period telemetry this event was offered to, and what became of it. Logged as one line so
         // "the pixel never fired" can be answered from a single entry: whether anything was listening,
         // and if so why it did or did not count.
@@ -259,11 +279,11 @@ public final class EventHub: EventHubManaging {
                 outcomes.append("\(config.name): period already ended")
                 continue
             }
-            if telemetry.handleEvent(source: source, data: data, tabID: tabID) {
+            if telemetry.handleEvent(source: source, data: data) {
                 dirtyNames.insert(config.name)
                 outcomes.append("\(config.name): counted")
             } else {
-                outcomes.append("\(config.name): no change (already counted on this tab, or the counter is capped)")
+                outcomes.append("\(config.name): no change (the counter is capped, or no parameter had a value to record)")
             }
         }
         let summary = outcomes.isEmpty
@@ -298,7 +318,7 @@ public final class EventHub: EventHubManaging {
 
     private func startNewPeriodLocked(_ config: TelemetryPixelConfig) {
         guard isForeground, latestEnabled, config.isEnabled, config.trigger.periodSeconds != nil else { return }
-        let telemetry = Telemetry(config: config, periodStartMillis: scheduler.nowMillis(), dedupStore: dedupStore)
+        let telemetry = Telemetry(config: config, periodStartMillis: scheduler.nowMillis())
         telemetries[config.name] = telemetry
         dirtyNames.insert(config.name)
     }
@@ -338,7 +358,7 @@ public final class EventHub: EventHubManaging {
     private func checkPixelsLocked() {
         guard latestEnabled else { return }
         for stored in store.allPixelStates() where telemetries[stored.pixelName] == nil {
-            telemetries[stored.pixelName] = Telemetry(restoring: stored, dedupStore: dedupStore)
+            telemetries[stored.pixelName] = Telemetry(restoring: stored)
         }
         let now = scheduler.nowMillis()
         // Snapshot the values: fireLocked mutates `telemetries` (removes the fired entry and may add a
@@ -443,6 +463,17 @@ public final class EventHub: EventHubManaging {
             tabURLs.removeValue(forKey: tabID)
             dedupStore.clear(tabID: tabID)
         }
+    }
+
+    /// The payload rendered for the debug log, in the same canonical form `DedupStore` keys on — so a
+    /// "dropped, already seen" line can be read against the event that first claimed that key.
+    ///
+    /// Page-derived, so it is only ever interpolated as `.private` and only at `debug` level.
+    private static func payloadDescription(_ data: [String: Any]?) -> String {
+        guard let data, !data.isEmpty else { return "<none>" }
+        guard let encoded = try? JSONSerialization.data(withJSONObject: data, options: [.sortedKeys]),
+              let json = String(data: encoded, encoding: .utf8) else { return "<unserialisable>" }
+        return json
     }
 
     private static func encode(_ data: Encodable?) -> [String: Any]? {

--- a/SharedPackages/EventHub/Sources/EventHub/Core/Parameter.swift
+++ b/SharedPackages/EventHub/Sources/EventHub/Core/Parameter.swift
@@ -20,13 +20,13 @@ import Foundation
 import os.log
 
 /// A single pixel parameter's runtime behavior. `CounterParameter` owns its counter value and the
-/// stop-at-max-bucket logic, and makes the per-tab dedup decision against the hub-owned `DedupStore`
-/// (native/`.empty`-tab events are never deduped). `DataParameter` owns only its last-seen value.
+/// stop-at-max-bucket logic; `DataParameter` owns only its last-seen value. Neither de-duplicates:
+/// the hub takes that decision once at ingestion, so everything reaching a parameter is a delivery.
 protocol Parameter: AnyObject {
     /// Processes an event whose source already matched this parameter's config source (or, for an
     /// immediate-trigger's data param, the triggering event itself). Returns `true` if state changed.
     @discardableResult
-    func handle(data: [String: Any]?, tabID: EventHubTabID) -> Bool
+    func handle(data: [String: Any]?) -> Bool
 
     var state: ParamState { get }
     func restoreState(_ state: ParamState)
@@ -37,11 +37,10 @@ protocol Parameter: AnyObject {
 }
 
 enum ParameterFactory {
-    /// Builds the parameter for a pixel's running period. `dedupKey` identifies this parameter within
-    /// its pixel (pixel×param×source) for `dedupStore` lookups.
-    static func make(_ config: TelemetryParameterConfig, dedupKey: String, dedupStore: DedupStore) -> Parameter? {
+    /// Builds the parameter for a pixel's running period.
+    static func make(_ config: TelemetryParameterConfig) -> Parameter? {
         if config.template == .counter, let buckets = config.buckets {
-            return CounterParameter(buckets: buckets, dedupKey: dedupKey, dedupStore: dedupStore)
+            return CounterParameter(buckets: buckets)
         }
         if config.template == .data {
             return DataParameter(dataKey: config.dataKey)
@@ -53,28 +52,18 @@ enum ParameterFactory {
 
 final class CounterParameter: Parameter {
     private let buckets: BucketList
-    /// Identifies this parameter (pixel×param×source) inside the shared, tab-keyed `DedupStore`.
-    private let dedupKey: String
-    /// Hub-owned, so dedup outlives this parameter — see `DedupStore`.
-    private let dedupStore: DedupStore
     private var value: Int
     private var stopCounting: Bool
 
-    init(buckets: BucketList, dedupKey: String, dedupStore: DedupStore, initialState: ParamState = ParamState(value: 0)) {
+    init(buckets: BucketList, initialState: ParamState = ParamState(value: 0)) {
         self.buckets = buckets
-        self.dedupKey = dedupKey
-        self.dedupStore = dedupStore
         self.value = initialState.value
         self.stopCounting = initialState.stopCounting
     }
 
     @discardableResult
-    func handle(data: [String: Any]?, tabID: EventHubTabID) -> Bool {
+    func handle(data: [String: Any]?) -> Bool {
         guard !stopCounting else { return false }
-        // Native events (tabID == .empty) opt out of dedup: every call is a genuine occurrence.
-        if tabID != .empty {
-            guard dedupStore.markSeen(key: dedupKey, tabID: tabID) else { return false }
-        }
         if BucketCounter.shouldStopCounting(value, buckets: buckets) {
             stopCounting = true
         } else {
@@ -106,15 +95,28 @@ final class DataParameter: Parameter {
         self.lastValue = initialState.lastDataValue
     }
 
+    /// Every event of the parameter's source assigns, so an event whose payload lacks `dataKey`
+    /// leaves the parameter with *no* value rather than the previous one — the pixel then reports what
+    /// the latest event carried, not a stale reading from an earlier one.
     @discardableResult
-    func handle(data: [String: Any]?, tabID: EventHubTabID) -> Bool {
-        guard let dataKey, let data, let raw = data[dataKey] else { return false }
+    func handle(data: [String: Any]?) -> Bool {
+        guard let dataKey else { return false }
+        guard let raw = data?[dataKey] else { return clear() }
         guard let encoded = try? JSONSerialization.data(withJSONObject: raw, options: [.fragmentsAllowed]),
               let compact = String(data: encoded, encoding: .utf8) else {
             Logger.eventHub.error("data parameter for key \(dataKey, privacy: .public) is not JSON-serialisable, value dropped")
-            return false
+            return clear()
         }
-        lastValue = compact.addingPercentEncoding(withAllowedCharacters: Self.unreservedCharacters)
+        let encodedValue = compact.addingPercentEncoding(withAllowedCharacters: Self.unreservedCharacters)
+        guard lastValue != encodedValue else { return false }
+        lastValue = encodedValue
+        return true
+    }
+
+    /// Drops any recorded value, reporting whether that was a change.
+    private func clear() -> Bool {
+        guard lastValue != nil else { return false }
+        lastValue = nil
         return true
     }
 

--- a/SharedPackages/EventHub/Sources/EventHub/Core/Parameter.swift
+++ b/SharedPackages/EventHub/Sources/EventHub/Core/Parameter.swift
@@ -78,15 +78,14 @@ final class CounterParameter: Parameter {
     func queryValue() -> String? { BucketCounter.bucketCount(value, buckets: buckets) }
 }
 
+/// Carries a value forwarded from an event payload, as compact JSON (`overlay` → `"overlay"`,
+/// `{"a": true}` → `{"a":true}`).
+///
+/// Percent-encoding belongs to the pixel transport, not here — `URL.appendingParameters` →
+/// `URLQueryItem(percentEncodingName:)` on macOS, `APIRequestV2`'s `URLComponents.queryItems` on iOS.
+/// Both encode with an allowed set that excludes `%`, so any escaping applied to the value here would
+/// be escaped again and the endpoint would need two decodes to reach the payload.
 final class DataParameter: Parameter {
-    /// RFC 3986 "unreserved" characters (alphanumerics plus `-._~`) are left unescaped; everything
-    /// else — including `"`, `{`, `}`, `:`, and space — is percent-encoded. This matches the
-    /// compact-JSON-then-percent-encode format the ported `EventHubDataParameterTests` expect once
-    /// `DataParameter` is wired into `EventHub` (e.g. `"logged-in"` → `%22logged-in%22`,
-    /// `{"a": true}` → `%7B%22a%22%3Atrue%7D`). `CharacterSet.alphanumerics` alone is not enough: it
-    /// excludes `-`, which would wrongly turn `logged-in` into `logged%2Din`.
-    private static let unreservedCharacters = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-._~"))
-
     private let dataKey: String?
     private var lastValue: String?
 
@@ -107,9 +106,8 @@ final class DataParameter: Parameter {
             Logger.eventHub.error("data parameter for key \(dataKey, privacy: .public) is not JSON-serialisable, value dropped")
             return clear()
         }
-        let encodedValue = compact.addingPercentEncoding(withAllowedCharacters: Self.unreservedCharacters)
-        guard lastValue != encodedValue else { return false }
-        lastValue = encodedValue
+        guard lastValue != compact else { return false }
+        lastValue = compact
         return true
     }
 

--- a/SharedPackages/EventHub/Sources/EventHub/Core/Telemetry.swift
+++ b/SharedPackages/EventHub/Sources/EventHub/Core/Telemetry.swift
@@ -28,22 +28,22 @@ final class Telemetry {
     private var parameters: [String: Parameter]
 
     /// Starts a fresh period from `config`, beginning at `periodStartMillis`.
-    init(config: TelemetryPixelConfig, periodStartMillis: Int64, dedupStore: DedupStore) {
+    init(config: TelemetryPixelConfig, periodStartMillis: Int64) {
         self.name = config.name
         self.config = config
         self.periodStartMillis = periodStartMillis
         self.periodEndMillis = periodStartMillis + (config.trigger.periodSeconds ?? 0) * 1000
-        self.parameters = Self.makeParameters(config: config, dedupStore: dedupStore)
+        self.parameters = Self.makeParameters(config: config)
     }
 
-    /// Rehydrates from persisted state (restart / foreground catch-up). Dedup is deliberately not
-    /// restored: it is in-memory only, so after a restart a page legitimately counts once more.
-    init(restoring persisted: PixelState, dedupStore: DedupStore) {
+    /// Rehydrates from persisted state (restart / foreground catch-up). The hub's de-duplication state
+    /// is deliberately not restored: it is in-memory only, so after a restart a page counts once more.
+    init(restoring persisted: PixelState) {
         self.name = persisted.pixelName
         self.config = persisted.config
         self.periodStartMillis = persisted.periodStartMillis
         self.periodEndMillis = persisted.periodEndMillis
-        self.parameters = Self.makeParameters(config: persisted.config, dedupStore: dedupStore)
+        self.parameters = Self.makeParameters(config: persisted.config)
         for (paramName, parameter) in parameters {
             if let restored = persisted.params[paramName] {
                 parameter.restoreState(restored)
@@ -51,13 +51,10 @@ final class Telemetry {
         }
     }
 
-    /// Builds this pixel's parameters, giving each counter a dedup key scoped to pixel×param×source so
-    /// two pixels sharing a parameter name and source still de-duplicate independently.
-    private static func makeParameters(config: TelemetryPixelConfig, dedupStore: DedupStore) -> [String: Parameter] {
+    private static func makeParameters(config: TelemetryPixelConfig) -> [String: Parameter] {
         var result: [String: Parameter] = [:]
         for (paramName, paramConfig) in config.parameters {
-            let dedupKey = "\(config.name):\(paramName):\(paramConfig.source ?? "")"
-            if let parameter = ParameterFactory.make(paramConfig, dedupKey: dedupKey, dedupStore: dedupStore) {
+            if let parameter = ParameterFactory.make(paramConfig) {
                 result[paramName] = parameter
             }
         }
@@ -73,14 +70,15 @@ final class Telemetry {
         config.parameters.values.contains { $0.source == source }
     }
 
-    /// Routes a matching event to every parameter whose config `source` equals `source`. Returns
-    /// `true` if any parameter's state changed.
+    /// Routes a delivered event to every parameter whose config `source` equals `source`. Returns
+    /// `true` if any parameter's state changed. De-duplication has already happened at the hub, so
+    /// every event reaching here is a genuine occurrence.
     @discardableResult
-    func handleEvent(source: String, data: [String: Any]?, tabID: EventHubTabID) -> Bool {
+    func handleEvent(source: String, data: [String: Any]?) -> Bool {
         var changed = false
         for (paramName, paramConfig) in config.parameters where paramConfig.source == source {
             guard let parameter = parameters[paramName] else { continue }
-            if parameter.handle(data: data, tabID: tabID) { changed = true }
+            if parameter.handle(data: data) { changed = true }
         }
         return changed
     }

--- a/SharedPackages/EventHub/Sources/EventHub/EventHubTabID.swift
+++ b/SharedPackages/EventHub/Sources/EventHub/EventHubTabID.swift
@@ -18,8 +18,8 @@
 
 import Foundation
 
-/// Identifies a browser tab for EventHub's per-tab web-event dedup. `.empty` stands in for "no tab"
-/// (used by native/aggregated events, which have no page/tab lifecycle to dedup against).
+/// Identifies a browser tab for EventHub's per-tab web-event de-duplication. Native events carry no
+/// tab at all — they never reach the code that takes a tab, rather than passing a placeholder.
 public struct EventHubTabID: Hashable, Sendable {
     public let rawValue: UUID
 
@@ -28,6 +28,4 @@ public struct EventHubTabID: Hashable, Sendable {
     }
 
     public static func new() -> EventHubTabID { EventHubTabID() }
-
-    public static let empty = EventHubTabID(rawValue: UUID(uuidString: "00000000-0000-0000-0000-000000000000")!)
 }

--- a/SharedPackages/EventHub/Sources/EventHub/Logger+EventHub.swift
+++ b/SharedPackages/EventHub/Sources/EventHub/Logger+EventHub.swift
@@ -27,7 +27,8 @@ public extension Logger {
     /// activity filterable as one stream.
     ///
     /// Only config-governed identifiers (pixel names, parameter names, bucket names, data keys) and
-    /// error descriptions are interpolated as `.public`; web-page-derived event payloads are never
-    /// logged at all, at any privacy level.
+    /// error descriptions are interpolated as `.public`. Web-page-derived values — event types, event
+    /// payloads and tab identifiers — are interpolated as `.private` and only at `debug` level, so they
+    /// are redacted unless someone deliberately enables private-data logging on a development device.
     static let eventHub = Logger(subsystem: "EventHub", category: "")
 }

--- a/SharedPackages/EventHub/Sources/EventHub/Wiring/EventHubConversionReporting.swift
+++ b/SharedPackages/EventHub/Sources/EventHub/Wiring/EventHubConversionReporting.swift
@@ -1,0 +1,31 @@
+//
+//  EventHubConversionReporting.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+/// The seam through which EventHub hands experiment-metric conversion requests to the Native Apps
+/// experiment framework, mirroring `EventHubPixelFiring` for telemetry.
+///
+/// Everything past this call belongs to the framework: it resolves enrollment and cohort, decides
+/// window containment, accumulates occurrences against the threshold, suppresses repeats and fires the
+/// pixel. The hub's metrics handler is deliberately stateless — no counting, no window arithmetic, no
+/// enrollment check, nothing persisted — so a request for an experiment the user is not enrolled in is
+/// a no-op rather than something the hub has to filter.
+public protocol EventHubConversionReporting {
+    func reportConversion(experiment: String, metric: String, windowDays: ClosedRange<Int>, threshold: Int)
+}

--- a/SharedPackages/EventHub/Sources/EventHub/Wiring/EventHubExperimentSettings.swift
+++ b/SharedPackages/EventHub/Sources/EventHub/Wiring/EventHubExperimentSettings.swift
@@ -1,0 +1,46 @@
+//
+//  EventHubExperimentSettings.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import PrivacyConfig
+
+/// Reads the experiment subfeature settings that `EventHub`'s metrics registry is built from.
+///
+/// Shared by both platform integrations rather than duplicated in each: which parent features are read
+/// is a correctness-relevant list, and iOS and macOS silently disagreeing about it would mean metrics
+/// attaching under one parent and not the other.
+public enum EventHubExperimentSettings {
+
+    /// The parent features whose subfeatures may declare `settings.metrics`: Content Scope Scripts
+    /// experiments and — on Apple and the extension, where TDS experiments live under content
+    /// blocking rather than Android's `blockList` — TDS experiments. Both are read, so a metric
+    /// attaches under either parent (M-SEL-8).
+    public static let parentFeatures: [PrivacyFeature] = [.contentScopeExperiments, .contentBlocking]
+
+    /// The raw `settings` JSON of every experiment subfeature that may declare metrics, keyed by
+    /// subfeature ID — the shape `EventHub`'s `experimentSettings` publisher expects.
+    ///
+    /// Subfeature IDs are unique across the two parents in practice; on a collision the first parent
+    /// listed wins, which is arbitrary but harmless — nothing depends on which parent a metric came
+    /// from once it is parsed, since a conversion request names only the subfeature.
+    public static func current(_ config: PrivacyConfiguration) -> [String: String] {
+        parentFeatures.reduce(into: [:]) { result, feature in
+            result.merge(config.allSubfeatureSettings(for: feature)) { existing, _ in existing }
+        }
+    }
+}

--- a/SharedPackages/EventHub/Sources/EventHubTests/Functional/EventHubFunctionalTests.swift
+++ b/SharedPackages/EventHub/Sources/EventHubTests/Functional/EventHubFunctionalTests.swift
@@ -64,7 +64,7 @@ struct EventHubFunctionalTests {
     static let immediateConfig = """
     { "telemetry": { "webEvent_impression": {
         "state": "enabled",
-        "trigger": { "type": "immediate", "source": "impression" },
+        "trigger": { "type": "immediate_v2", "source": "impression" },
         "parameters": {}
     } } }
     """

--- a/SharedPackages/EventHub/Sources/EventHubTests/Spec/DeduplicationSpecTests.swift
+++ b/SharedPackages/EventHub/Sources/EventHubTests/Spec/DeduplicationSpecTests.swift
@@ -24,6 +24,13 @@ import Foundation
 /// (`docs/event-hub/tests/deduplication.md` in `duckduckgo/ddg-workflow`). Each case ID from that
 /// document leads the test name so coverage is greppable and a failure names the spec case.
 ///
+/// **Complete case roster.** Every ID the document defines appears below, so this file can be diffed
+/// against the document in one place:
+///
+/// - One decision before fan-out — D-DEL-1, D-DEL-2, D-DEL-3, D-DEL-4, D-DEL-5, D-DEL-6
+/// - Navigation resets the page — D-NAV-1, D-NAV-2, D-NAV-3, D-NAV-4
+/// - Native events are exempt — D-NAT-1
+///
 /// The properties the cases evidence:
 /// - **D-DEL-P1** — for every web event the hub makes exactly one de-duplication decision at
 ///   ingestion, keyed `(event type, event data, tab)` against the tab's current page, before any

--- a/SharedPackages/EventHub/Sources/EventHubTests/Spec/DeduplicationSpecTests.swift
+++ b/SharedPackages/EventHub/Sources/EventHubTests/Spec/DeduplicationSpecTests.swift
@@ -1,0 +1,270 @@
+//
+//  DeduplicationSpecTests.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Testing
+import Foundation
+@testable import EventHub
+
+/// Apple's coverage of the cross-platform de-duplication specification
+/// (`docs/event-hub/tests/deduplication.md` in `duckduckgo/ddg-workflow`). Each case ID from that
+/// document leads the test name so coverage is greppable and a failure names the spec case.
+///
+/// The properties the cases evidence:
+/// - **D-DEL-P1** — for every web event the hub makes exactly one de-duplication decision at
+///   ingestion, keyed `(event type, event data, tab)` against the tab's current page, before any
+///   handler is invoked. The first occurrence of a key on a page goes to every handler, later ones to
+///   none. Payloads equal as JSON values are one key.
+/// - **D-NAV-P1** — that state is scoped to a tab's *current* page: cleared on navigation to a
+///   different URL, untouched by a same-URL reload, independent between tabs.
+/// - **D-NAT-P1** — events with no tab context are never de-duplicated.
+///
+/// De-duplication is observed through telemetry pixels, per the suite's assertion-boundary
+/// convention: the immediate pixels are the direct delivery observer (one pixel per delivered event)
+/// and `dedupProbe_day` is a counter on the same stream, showing the fan-out sharing one decision.
+@Suite("Spec: hub de-duplication")
+struct DeduplicationSpecTests {
+
+    /// The specification's fixture, verbatim. `dedupProbe_day` deliberately has **no zero bucket**, so
+    /// it is silent in any case where nothing was counted.
+    static let config = """
+    { "telemetry": {
+        "dedupProbe_immediate": {
+            "state": "enabled",
+            "trigger": { "type": "immediate_v2", "source": "probeDetected" },
+            "parameters": { "reason": { "template": "data", "dataKey": "reason" } }
+        },
+        "dedupProbe_day": {
+            "state": "enabled",
+            "trigger": { "period": { "seconds": 86400 } },
+            "parameters": { "count": { "template": "counter", "source": "probeDetected", "buckets": {
+                "1":  {"gte": 1, "lt": 2},
+                "2":  {"gte": 2, "lt": 3},
+                "3+": {"gte": 3}
+            } } }
+        },
+        "dedupOther_immediate": {
+            "state": "enabled",
+            "trigger": { "type": "immediate_v2", "source": "otherDetected" },
+            "parameters": { "reason": { "template": "data", "dataKey": "reason" } }
+        },
+        "dedupAppLaunch_immediate": {
+            "state": "enabled",
+            "trigger": { "type": "immediate_v2", "source": "appLaunch" },
+            "parameters": { "launchType": { "template": "data", "dataKey": "launchType" } }
+        }
+    } }
+    """
+
+    static let periodSeconds: TimeInterval = 86400
+
+    // MARK: One decision before fan-out
+
+    @Test("D-DEL-1: repeated occurrences on one page are delivered once")
+    func repeatedOccurrencesOnOnePageAreDeliveredOnce() {
+        let f = SpecFixture(Self.config)
+        let page = f.openPage()
+        // Three frames of one page each report the same thing; the hub sees three identical events.
+        f.send("probeDetected", reason: "overlay", on: page)
+        f.send("probeDetected", reason: "overlay", on: page)
+        f.send("probeDetected", reason: "overlay", on: page)
+
+        f.endPeriod()
+
+        #expect(f.fired == [
+            "dedupProbe_day?count=1",
+            #"dedupProbe_immediate?reason="overlay""#,
+        ])
+    }
+
+    @Test("D-DEL-2: the payload is part of the key")
+    func thePayloadIsPartOfTheKey() {
+        let f = SpecFixture(Self.config)
+        let page = f.openPage()
+        f.send("probeDetected", reason: "overlay", on: page)
+        f.send("probeDetected", reason: "redirect", on: page)
+
+        f.endPeriod()
+
+        #expect(f.fired == [
+            "dedupProbe_day?count=2",
+            #"dedupProbe_immediate?reason="overlay""#,
+            #"dedupProbe_immediate?reason="redirect""#,
+        ])
+    }
+
+    @Test("D-DEL-3: event types de-duplicate independently")
+    func eventTypesDeduplicateIndependently() {
+        let f = SpecFixture(Self.config)
+        let page = f.openPage()
+        f.send("probeDetected", reason: "overlay", on: page)
+        f.send("otherDetected", reason: "overlay", on: page)
+        f.send("probeDetected", reason: "overlay", on: page)
+
+        f.endPeriod()
+
+        #expect(f.fired == [
+            #"dedupOther_immediate?reason="overlay""#,
+            "dedupProbe_day?count=1",
+            #"dedupProbe_immediate?reason="overlay""#,
+        ])
+    }
+
+    @Test("D-DEL-4: every handler observes the same single delivery")
+    func everyHandlerObservesTheSameSingleDelivery() {
+        // The immediate pixel fires exactly once *and* the counter reports exactly one: both handlers
+        // act on one decision rather than each taking their own. The metrics handler's leg of this
+        // evidence is the metrics suite, M-DED-1.
+        let f = SpecFixture(Self.config)
+        let page = f.openPage()
+        f.send("probeDetected", reason: "overlay", on: page)
+        f.send("probeDetected", reason: "overlay", on: page)
+
+        f.endPeriod()
+
+        #expect(f.fired == [
+            "dedupProbe_day?count=1",
+            #"dedupProbe_immediate?reason="overlay""#,
+        ])
+    }
+
+    @Test("D-DEL-5: payload member order does not change the key")
+    func payloadMemberOrderDoesNotChangeTheKey() {
+        // Built from two JSON strings whose members are written in opposite orders. Swift's
+        // `[String: Any]` is unordered, so the *authored* order is already lost by the time the hub
+        // sees it — but two dictionaries with the same contents and different insertion history can
+        // still iterate differently, so this pins that the key is built from sorted members rather
+        // than from iteration order.
+        let f = SpecFixture(Self.config)
+        let page = f.openPage()
+        f.sendRaw("probeDetected", dataJSON: #"{ "reason": "overlay", "stage": 1 }"#, on: page)
+        f.sendRaw("probeDetected", dataJSON: #"{ "stage": 1, "reason": "overlay" }"#, on: page)
+
+        f.endPeriod()
+
+        #expect(f.fired == [
+            "dedupProbe_day?count=1",
+            #"dedupProbe_immediate?reason="overlay""#,
+        ])
+    }
+
+    @Test("D-DEL-6: an omitted payload and an empty payload are one key")
+    func omittedAndEmptyPayloadAreOneKey() {
+        let f = SpecFixture(Self.config)
+        let page = f.openPage()
+        f.sendWithoutData("probeDetected", on: page)
+        f.sendRaw("probeDetected", dataJSON: "{}", on: page)
+
+        f.endPeriod()
+
+        // No immediate pixel fires: its only parameter reads `reason`, which resolves to nothing.
+        #expect(f.fired == ["dedupProbe_day?count=1"])
+    }
+
+    // MARK: Navigation resets the page
+
+    @Test("D-NAV-1: navigating to a different URL makes the next occurrence deliverable")
+    func navigatingToADifferentURLMakesTheNextOccurrenceDeliverable() {
+        let f = SpecFixture(Self.config)
+        let page = f.openPage()
+        f.send("probeDetected", reason: "overlay", on: page)
+        f.navigate(page, to: "https://example.com/second")
+        f.send("probeDetected", reason: "overlay", on: page)
+        f.navigate(page, to: "https://example.com/third")
+        f.send("probeDetected", reason: "overlay", on: page)
+
+        f.endPeriod()
+
+        #expect(f.fired == [
+            "dedupProbe_day?count=3+",
+            #"dedupProbe_immediate?reason="overlay""#,
+            #"dedupProbe_immediate?reason="overlay""#,
+            #"dedupProbe_immediate?reason="overlay""#,
+        ])
+    }
+
+    @Test("D-NAV-2: a same-URL reload does not start a new page")
+    func aSameURLReloadDoesNotStartANewPage() {
+        let f = SpecFixture(Self.config)
+        let page = f.openPage(url: "https://example.com/first")
+        f.send("probeDetected", reason: "overlay", on: page)
+        f.navigate(page, to: "https://example.com/first")
+        f.send("probeDetected", reason: "overlay", on: page)
+
+        f.endPeriod()
+
+        #expect(f.fired == [
+            "dedupProbe_day?count=1",
+            #"dedupProbe_immediate?reason="overlay""#,
+        ])
+    }
+
+    @Test("D-NAV-3: returning to a previously seen URL delivers again")
+    func returningToAPreviouslySeenURLDeliversAgain() {
+        // State is per current page, not per URL ever seen.
+        let f = SpecFixture(Self.config)
+        let page = f.openPage(url: "https://example.com/a")
+        f.send("probeDetected", reason: "overlay", on: page)
+        f.navigate(page, to: "https://example.com/b")
+        f.navigate(page, to: "https://example.com/a")
+        f.send("probeDetected", reason: "overlay", on: page)
+
+        f.endPeriod()
+
+        #expect(f.fired == [
+            "dedupProbe_day?count=2",
+            #"dedupProbe_immediate?reason="overlay""#,
+            #"dedupProbe_immediate?reason="overlay""#,
+        ])
+    }
+
+    @Test("D-NAV-4: separate tabs are independent")
+    func separateTabsAreIndependent() {
+        let f = SpecFixture(Self.config)
+        let url = "https://example.com/shared"
+        for _ in 0..<3 {
+            f.send("probeDetected", reason: "overlay", on: f.openPage(url: url))
+        }
+
+        f.endPeriod()
+
+        #expect(f.fired == [
+            "dedupProbe_day?count=3+",
+            #"dedupProbe_immediate?reason="overlay""#,
+            #"dedupProbe_immediate?reason="overlay""#,
+            #"dedupProbe_immediate?reason="overlay""#,
+        ])
+    }
+
+    // MARK: Native events are exempt
+
+    @Test("D-NAT-1: repeated native events are all delivered")
+    func repeatedNativeEventsAreAllDelivered() {
+        // No tab and no URL, so "once per page" has no meaning: every occurrence is delivered. The
+        // counter is a web-event stream and has no zero bucket, so it stays silent.
+        let f = SpecFixture(Self.config)
+        f.sendNative("appLaunch", payload: ["launchType": "cold"])
+        f.sendNative("appLaunch", payload: ["launchType": "warm"])
+
+        f.endPeriod()
+
+        #expect(f.fired == [
+            #"dedupAppLaunch_immediate?launchType="cold""#,
+            #"dedupAppLaunch_immediate?launchType="warm""#,
+        ])
+    }
+}

--- a/SharedPackages/EventHub/Sources/EventHubTests/Spec/MetricsSpecTests.swift
+++ b/SharedPackages/EventHub/Sources/EventHubTests/Spec/MetricsSpecTests.swift
@@ -1,0 +1,396 @@
+//
+//  MetricsSpecTests.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+import Testing
+import Foundation
+@testable import EventHub
+
+/// Apple's coverage of the cross-platform experiment-metrics specification
+/// (`docs/event-hub/tests/metrics.md` in `duckduckgo/ddg-workflow`).
+///
+/// **Complete case roster.** Every ID the document defines appears below, so this file can be diffed
+/// against the document in one place:
+///
+/// - Binding — M-SEL-1, M-SEL-2, M-SEL-3, M-SEL-4, M-SEL-5, M-SEL-6, M-SEL-7, M-SEL-8, M-SEL-9,
+///   M-SEL-10 (M-SEL-8's parent-feature-reading clause is covered by
+///   `EventHubExperimentSettingsTests`, since this suite bypasses the config-reading step)
+/// - Fan-out — M-FAN-1
+/// - Web-event de-duplication — M-DED-1
+/// - Configuration lifecycle — M-LIF-1, M-LIF-2, M-LIF-3, M-LIF-4, M-LIF-5, M-LIF-6
+///
+/// The properties they evidence:
+/// - **M-SEL-P1/P2** — declaration is attachment. Requests are produced per (experiment, metric), so
+///   two experiments declaring the same metric name stay independent and neither borrows the other's
+///   event.
+/// - **M-FAN-P1** — within a conversion group `windows × thresholds` form a product; a metric's request
+///   set is the union of its groups' products. Apple's framework API takes one window and one threshold
+///   per call, so the fan-out is asserted here directly rather than at an absorbing seam.
+/// - **M-DED-P1** — metrics consume the hub's de-duplicated stream, the decision being taken once
+///   before fan-out.
+/// - **M-LIF-P1** — declarations are read live, per event, from current config.
+/// - **M-LIF-P2** — events reach metrics only through the hub, so disabling `eventHub` stops them.
+///
+/// The assertion boundary is the conversion request — `(experiment, metric, conversionWindowDays,
+/// threshold)` — observed just past the experiment framework's enrollment gate. See
+/// `SpyConversionReporting` for why that is the honest seam on Apple.
+@Suite("Spec: experiment metrics")
+struct MetricsSpecTests {
+
+    // MARK: The specification's fixture
+
+    /// `contentScopeExperiment1`, the experiment most cases use: four metrics, one of them on a native
+    /// event, and `searchLike` carrying two conversion groups so the fan-out is observable.
+    static let experiment1 = """
+    { "metrics": {
+        "captchaSeen": { "event": "captchaDetected", "conversions": [
+            { "windows": [[0, 7]], "thresholds": [1, 3] } ] },
+        "searchLike": { "event": "searchPerformed", "conversions": [
+            { "windows": [[0, 0], [1, 1]], "thresholds": [1] },
+            { "windows": [[0, 7]], "thresholds": [2, 3] } ] },
+        "pageLoad": { "event": "pageLoaded", "conversions": [
+            { "windows": [[0, 5]], "thresholds": [1] } ] },
+        "appLaunched": { "event": "appLaunch", "conversions": [
+            { "windows": [[0, 7]], "thresholds": [1, 2] } ] }
+    } }
+    """
+
+    /// Two windows in one group, both at threshold 1.
+    static let experiment3 = """
+    { "metrics": { "reloadLoop": { "event": "reloadLoopDetected", "conversions": [
+        { "windows": [[0, 0], [0, 7]], "thresholds": [1] } ] } } }
+    """
+
+    /// Declares `captchaSeen` on the same event as experiment 1, at a different threshold set.
+    static let experiment10 = """
+    { "metrics": { "captchaSeen": { "event": "captchaDetected", "conversions": [
+        { "windows": [[0, 7]], "thresholds": [1] } ] } } }
+    """
+
+    /// An enrolled experiment declaring no metrics at all.
+    static let experiment19 = "{}"
+
+    /// Declares `captchaSeen` — the same *name* as experiments 1 and 10 — bound to a different event.
+    static let experiment21 = """
+    { "metrics": { "captchaSeen": { "event": "reloadLoopDetected", "conversions": [
+        { "windows": [[0, 7]], "thresholds": [1] } ] } } }
+    """
+
+    /// A TDS experiment, under the other parent feature. Its `settings` also carry the control and
+    /// treatment URLs a real TDS experiment has, which must decode away without disturbing `metrics`.
+    static let tdsExperiment007 = """
+    { "controlUrl": "v5/experiments/control.json",
+      "treatmentUrl": "v5/experiments/treatment.json",
+      "metrics": {
+        "blocklistFailure": { "event": "tdsDownloadFailed", "conversions": [
+            { "windows": [[0, 7]], "thresholds": [1] } ] },
+        "pageLoad": { "event": "pageLoaded", "conversions": [
+            { "windows": [[0, 5]], "thresholds": [1] } ] }
+    } }
+    """
+
+    static let reference: [String: String] = [
+        "contentScopeExperiment1": experiment1,
+        "contentScopeExperiment3": experiment3,
+        "contentScopeExperiment10": experiment10,
+        "contentScopeExperiment19": experiment19,
+        "contentScopeExperiment21": experiment21,
+        "tdsNextExperiment007": tdsExperiment007,
+    ]
+
+    /// The fixture with a given experiment's settings replaced — how the lifecycle cases apply a config
+    /// that has dropped a metric.
+    static func reference(_ experiment: String, replacedWith settings: String) -> [String: String] {
+        var config = reference
+        config[experiment] = settings
+        return config
+    }
+
+    /// Experiment 1 with `captchaSeen` removed and its other three metrics untouched (M-LIF-2).
+    static let experiment1WithoutCaptchaSeen = """
+    { "metrics": {
+        "searchLike": { "event": "searchPerformed", "conversions": [
+            { "windows": [[0, 0], [1, 1]], "thresholds": [1] },
+            { "windows": [[0, 7]], "thresholds": [2, 3] } ] },
+        "pageLoad": { "event": "pageLoaded", "conversions": [
+            { "windows": [[0, 5]], "thresholds": [1] } ] },
+        "appLaunched": { "event": "appLaunch", "conversions": [
+            { "windows": [[0, 7]], "thresholds": [1, 2] } ] }
+    } }
+    """
+
+    /// The metrics suite configures no telemetry: it asserts conversion requests, not pixels.
+    private static func fixture(enrolled: Set<String>, experiments: [String: String] = reference) -> SpecFixture {
+        SpecFixture("{}", experiments: experiments, enrolled: enrolled)
+    }
+
+    // MARK: Binding — metrics attach to the experiment that declares them
+
+    @Test("M-SEL-1: each experiment declaring a metric requests it")
+    func eachExperimentDeclaringAMetricRequestsIt() {
+        // Experiments 1 and 10 bind `captchaSeen` to the same event, at different threshold sets.
+        let f = Self.fixture(enrolled: ["contentScopeExperiment1", "contentScopeExperiment10"])
+        f.send("captchaDetected", reason: "any", on: f.openPage())
+
+        #expect(f.requested == [
+            "contentScopeExperiment1/captchaSeen/0-7/1",
+            "contentScopeExperiment1/captchaSeen/0-7/3",
+            "contentScopeExperiment10/captchaSeen/0-7/1",
+        ])
+    }
+
+    @Test("M-SEL-2: only the declaring experiment requests")
+    func onlyTheDeclaringExperimentRequests() {
+        let f = Self.fixture(enrolled: ["contentScopeExperiment1", "contentScopeExperiment3"])
+        f.send("reloadLoopDetected", reason: "any", on: f.openPage())
+
+        #expect(f.requested == [
+            "contentScopeExperiment3/reloadLoop/0-7/1",
+            "contentScopeExperiment3/reloadLoop/0/1",
+        ])
+    }
+
+    @Test("M-SEL-3: a shared metric name bound to different events requests per experiment")
+    func aSharedMetricNameBoundToDifferentEventsRequestsPerExperiment() {
+        // `captchaSeen` is bound to `captchaDetected` in experiment 1 but to `reloadLoopDetected` in
+        // experiment 21, so this event reaches 21's copy of the name and not 1's.
+        let f = Self.fixture(enrolled: ["contentScopeExperiment1", "contentScopeExperiment3", "contentScopeExperiment21"])
+        f.send("reloadLoopDetected", reason: "any", on: f.openPage())
+
+        #expect(f.requested == [
+            "contentScopeExperiment21/captchaSeen/0-7/1",
+            "contentScopeExperiment3/reloadLoop/0-7/1",
+            "contentScopeExperiment3/reloadLoop/0/1",
+        ])
+    }
+
+    @Test("M-SEL-4: the event named by another experiment's identically-named metric requests nothing here")
+    func theEventNamedByAnotherExperimentsIdenticallyNamedMetricRequestsNothingHere() {
+        // The mirror of M-SEL-3: experiment 21's `captchaSeen` does not answer to `captchaDetected`.
+        let f = Self.fixture(enrolled: ["contentScopeExperiment1", "contentScopeExperiment21"])
+        f.send("captchaDetected", reason: "any", on: f.openPage())
+
+        #expect(f.requested == [
+            "contentScopeExperiment1/captchaSeen/0-7/1",
+            "contentScopeExperiment1/captchaSeen/0-7/3",
+        ])
+    }
+
+    @Test("M-SEL-5: an enrolled experiment declaring no metrics requests nothing")
+    func anEnrolledExperimentDeclaringNoMetricsRequestsNothing() {
+        let f = Self.fixture(enrolled: ["contentScopeExperiment19"])
+        let page = f.openPage()
+        f.send("reloadLoopDetected", reason: "any", on: page)
+        f.send("captchaDetected", reason: "any", on: page)
+
+        #expect(f.requested.isEmpty)
+    }
+
+    @Test("M-SEL-6: a declared metric whose experiment is not enrolled requests nothing")
+    func aDeclaredMetricWhoseExperimentIsNotEnrolledRequestsNothing() {
+        // `tdsDownloadFailed` is declared only by tdsNextExperiment007, which the user is not in.
+        let f = Self.fixture(enrolled: ["contentScopeExperiment1"])
+        f.send("tdsDownloadFailed", reason: "any", on: f.openPage())
+
+        #expect(f.requested.isEmpty)
+    }
+
+    @Test("M-SEL-7: a user enrolled in no experiments requests nothing")
+    func aUserEnrolledInNoExperimentsRequestsNothing() {
+        let f = Self.fixture(enrolled: [])
+        let page = f.openPage()
+        f.send("captchaDetected", reason: "any", on: page)
+        f.send("reloadLoopDetected", reason: "any", on: page)
+        f.send("searchPerformed", reason: "any", on: page)
+        f.sendNative("appLaunch", payload: ["launchType": "cold"])
+
+        #expect(f.requested.isEmpty)
+    }
+
+    @Test("M-SEL-8: metrics attach under both experiment parent features")
+    func metricsAttachUnderBothExperimentParentFeatures() {
+        // contentScopeExperiment1 sits under `contentScopeExperiments`, tdsNextExperiment007 under
+        // `contentBlocking`, so both experiments' `pageLoad` is requested.
+        //
+        // This suite injects its experiment settings straight into the hub, so the case's other
+        // clause — that both parent features are *read* — cannot be observed here: nothing below runs
+        // the config-reading step. `EventHubExperimentSettingsTests` pins that leg.
+        let f = Self.fixture(enrolled: ["contentScopeExperiment1", "tdsNextExperiment007"])
+        f.send("pageLoaded", reason: "any", on: f.openPage())
+
+        #expect(f.requested == [
+            "contentScopeExperiment1/pageLoad/0-5/1",
+            "tdsNextExperiment007/pageLoad/0-5/1",
+        ])
+    }
+
+    @Test("M-SEL-9: an event matching no declared metric is ignored")
+    func anEventMatchingNoDeclaredMetricIsIgnored() {
+        let f = Self.fixture(enrolled: ["contentScopeExperiment1"])
+        f.send("somethingUnrelated", reason: "any", on: f.openPage())
+
+        #expect(f.requested.isEmpty)
+    }
+
+    @Test("M-SEL-10: a native event with no tab context produces requests")
+    func aNativeEventWithNoTabContextProducesRequests() {
+        let f = Self.fixture(enrolled: ["contentScopeExperiment1"])
+        f.sendNative("appLaunch", payload: ["launchType": "cold"])
+
+        #expect(f.requested == [
+            "contentScopeExperiment1/appLaunched/0-7/1",
+            "contentScopeExperiment1/appLaunched/0-7/2",
+        ])
+    }
+
+    // MARK: Fan-out — a declaration is a set of requests
+
+    @Test("M-FAN-1: windows and thresholds multiply out within a group; groups do not combine")
+    func windowsAndThresholdsMultiplyOutWithinAGroupAndGroupsDoNotCombine() {
+        // `searchLike` group 1 is [0,0] and [1,1] at threshold 1; group 2 is [0,7] at thresholds 2 and
+        // 3. Four requests, not the six a cross-group product would give.
+        let f = Self.fixture(enrolled: ["contentScopeExperiment1"])
+        f.send("searchPerformed", reason: "any", on: f.openPage())
+
+        #expect(f.requested == [
+            "contentScopeExperiment1/searchLike/0-7/2",
+            "contentScopeExperiment1/searchLike/0-7/3",
+            "contentScopeExperiment1/searchLike/0/1",
+            "contentScopeExperiment1/searchLike/1/1",
+        ])
+    }
+
+    // MARK: Web-event de-duplication
+
+    @Test("M-DED-1: repeated occurrences on one page request once")
+    func repeatedOccurrencesOnOnePageRequestOnce() {
+        // The metrics leg of D-DEL-4: the hub takes one decision before fan-out, so the second and
+        // third occurrences reach no handler at all.
+        let f = Self.fixture(enrolled: ["contentScopeExperiment1"])
+        let page = f.openPage()
+        f.send("captchaDetected", reason: "overlay", on: page)
+        f.send("captchaDetected", reason: "overlay", on: page)
+        f.send("captchaDetected", reason: "overlay", on: page)
+
+        #expect(f.requested == [
+            "contentScopeExperiment1/captchaSeen/0-7/1",
+            "contentScopeExperiment1/captchaSeen/0-7/3",
+        ])
+    }
+
+    // MARK: Configuration lifecycle
+
+    @Test("M-LIF-1: a metric and its experiment enabled in one config change both take effect")
+    func aMetricAndItsExperimentEnabledInOneConfigChangeBothTakeEffect() {
+        // Phase 1: experiment 3 is in config but declares no metrics, and the user is not enrolled.
+        // The event is sent anyway — stricter than the document, which only describes phase 2's event.
+        let f = Self.fixture(enrolled: [], experiments: Self.reference("contentScopeExperiment3", replacedWith: "{}"))
+        f.send("reloadLoopDetected", reason: "any", on: f.openPage())
+        #expect(f.requested.isEmpty)
+
+        // Phase 2: the metrics arrive and the user enrolls in the same config change.
+        f.setExperiments(Self.reference)
+        f.enroll(in: ["contentScopeExperiment3"])
+        f.send("reloadLoopDetected", reason: "any", on: f.openPage())
+
+        #expect(f.requested == [
+            "contentScopeExperiment3/reloadLoop/0-7/1",
+            "contentScopeExperiment3/reloadLoop/0/1",
+        ])
+    }
+
+    @Test("M-LIF-2: a removed metric stops requesting when the new config applies")
+    func aRemovedMetricStopsRequestingWhenTheNewConfigApplies() {
+        let f = Self.fixture(enrolled: ["contentScopeExperiment1"])
+        f.send("captchaDetected", reason: "any", on: f.openPage())
+
+        // Removal is the kill switch: effective as soon as the config applies.
+        f.setExperiments(Self.reference("contentScopeExperiment1", replacedWith: Self.experiment1WithoutCaptchaSeen))
+        f.send("captchaDetected", reason: "any", on: f.openPage())
+
+        #expect(f.requested == [
+            "contentScopeExperiment1/captchaSeen/0-7/1",
+            "contentScopeExperiment1/captchaSeen/0-7/3",
+        ])
+    }
+
+    @Test("M-LIF-3: a metric declared before its experiment enrolls is inert, then requests on enrollment")
+    func aMetricDeclaredBeforeItsExperimentEnrollsIsInertThenRequestsOnEnrollment() {
+        let f = Self.fixture(enrolled: [])
+        f.send("captchaDetected", reason: "any", on: f.openPage())
+        #expect(f.requested.isEmpty)
+
+        f.enroll(in: ["contentScopeExperiment1"])
+        f.send("captchaDetected", reason: "any", on: f.openPage())
+
+        #expect(f.requested == [
+            "contentScopeExperiment1/captchaSeen/0-7/1",
+            "contentScopeExperiment1/captchaSeen/0-7/3",
+        ])
+    }
+
+    @Test("M-LIF-4: removing a shared-name metric from one experiment stops that experiment only")
+    func removingASharedNameMetricFromOneExperimentStopsThatExperimentOnly() {
+        let f = Self.fixture(enrolled: ["contentScopeExperiment1", "contentScopeExperiment10"])
+        f.send("captchaDetected", reason: "any", on: f.openPage())
+
+        // Only experiment 10 loses the metric, so experiment 1 requests a second time and 10 stays
+        // silent. Requests accumulate across phases, hence experiment 1's pair appearing twice.
+        f.setExperiments(Self.reference("contentScopeExperiment10", replacedWith: "{}"))
+        f.send("captchaDetected", reason: "any", on: f.openPage())
+
+        #expect(f.requested == [
+            "contentScopeExperiment1/captchaSeen/0-7/1",
+            "contentScopeExperiment1/captchaSeen/0-7/1",
+            "contentScopeExperiment1/captchaSeen/0-7/3",
+            "contentScopeExperiment1/captchaSeen/0-7/3",
+            "contentScopeExperiment10/captchaSeen/0-7/1",
+        ])
+    }
+
+    @Test("M-LIF-5: a disabled experiment stops requesting when the new config applies")
+    func aDisabledExperimentStopsRequestingWhenTheNewConfigApplies() {
+        let f = Self.fixture(enrolled: ["contentScopeExperiment1"])
+        f.send("captchaDetected", reason: "any", on: f.openPage())
+
+        // The experiment-level kill switch, distinct from removing the metric (M-LIF-2): its metrics
+        // stay declared. A `state: disabled` experiment leaves `allActiveExperiments`, which is what
+        // dropping it from the enrolled set models here.
+        f.enroll(in: [])
+        f.send("captchaDetected", reason: "any", on: f.openPage())
+
+        #expect(f.requested == [
+            "contentScopeExperiment1/captchaSeen/0-7/1",
+            "contentScopeExperiment1/captchaSeen/0-7/3",
+        ])
+    }
+
+    @Test("M-LIF-6: disabling the eventHub feature stops events reaching metrics")
+    func disablingTheEventHubFeatureStopsEventsReachingMetrics() {
+        let f = Self.fixture(enrolled: ["contentScopeExperiment1"])
+        f.send("captchaDetected", reason: "any", on: f.openPage())
+
+        // Evidence for M-LIF-P2: events reach metrics only through the hub. The experiment, its
+        // metrics and the enrollment are all untouched — only the feature's own state changes.
+        f.setFeatureEnabled(false)
+        f.send("captchaDetected", reason: "any", on: f.openPage())
+
+        #expect(f.requested == [
+            "contentScopeExperiment1/captchaSeen/0-7/1",
+            "contentScopeExperiment1/captchaSeen/0-7/3",
+        ])
+    }
+}

--- a/SharedPackages/EventHub/Sources/EventHubTests/Spec/TelemetrySpecTests.swift
+++ b/SharedPackages/EventHub/Sources/EventHubTests/Spec/TelemetrySpecTests.swift
@@ -1,0 +1,138 @@
+//
+//  TelemetrySpecTests.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+import Testing
+import Foundation
+@testable import EventHub
+
+/// Apple's coverage of the cross-platform telemetry specification
+/// (`docs/event-hub/tests/telemetry.md` in `duckduckgo/ddg-workflow`), for the cases that exist
+/// because telemetry now consumes the hub's de-duplicated stream.
+///
+/// The properties they evidence:
+/// - **T-IMM-P1** — immediate pixels fire once per *delivered* event. Because the hub de-duplicates
+///   before fan-out (D-DEL-P1), repeats of an event type carrying the same payload on one page fire
+///   once, while each distinct payload fires.
+/// - **T-DAT-P1** — a data parameter carries the payload value of the most recent delivered event
+///   whose type equals its `source`. Every such event assigns, so an event whose payload lacks the
+///   key leaves the parameter with no value, and a parameter with no value is omitted from the pixel.
+///
+/// The rest of this suite is not de-duplication behaviour and lands with the telemetry conformance
+/// pass. Only IDs appearing in a `@Test` name are covered here.
+@Suite("Spec: telemetry")
+struct TelemetrySpecTests {
+
+    /// The specification's fixture, less the two `state: disabled` entries, which only T-GEN-P1,
+    /// T-CNT-4 and T-IMM-3 need. `webTelemetry_adwallDetection_day` deliberately has **no zero
+    /// bucket**.
+    static let config = """
+    { "telemetry": {
+        "webTelemetry_captchaDetection_day": {
+            "state": "enabled",
+            "trigger": { "period": { "seconds": 86400 } },
+            "parameters": { "count": { "template": "counter", "source": "captchaDetected", "buckets": {
+                "0": {"gte": 0, "lt": 1}, "1-2": {"gte": 1, "lt": 3}, "3-5": {"gte": 3, "lt": 6}, "6+": {"gte": 6}
+            } } }
+        },
+        "webTelemetry_captchaDetection_week": {
+            "state": "enabled",
+            "trigger": { "period": { "seconds": 604800 } },
+            "parameters": { "count": { "template": "counter", "source": "captchaDetected", "buckets": {
+                "0": {"gte": 0, "lt": 1}, "1-2": {"gte": 1, "lt": 3}, "3-5": {"gte": 3, "lt": 6}, "6+": {"gte": 6}
+            } } }
+        },
+        "webTelemetry_adwallDetection_day": {
+            "state": "enabled",
+            "trigger": { "period": { "seconds": 86400 } },
+            "parameters": {
+                "count": { "template": "counter", "source": "adwallDetected", "buckets": {
+                    "1-2": {"gte": 1, "lt": 3}, "3+": {"gte": 3}
+                } },
+                "reason": { "template": "data", "source": "adwallDetected", "dataKey": "reason" }
+            }
+        },
+        "webTelemetry_adwallDetection_immediate": {
+            "state": "enabled",
+            "trigger": { "type": "immediate_v2", "source": "adwallDetected" },
+            "parameters": { "reason": { "template": "data", "dataKey": "reason" } }
+        }
+    } }
+    """
+
+    /// Cases observe the day boundary, where the day pixels' current period ends exactly once.
+    /// `webTelemetry_captchaDetection_week` is correctly still running at that point and so does not
+    /// appear in any expected set below; the week leg of these cases arrives with the counter case
+    /// that exercises day and week counters side by side.
+    private static func fixture() -> SpecFixture {
+        SpecFixture(config, periodSeconds: 86400)
+    }
+
+    @Test("T-IMM-1: one immediate pixel per event type and payload per page")
+    func oneImmediatePixelPerEventTypeAndPayloadPerPage() {
+        // The second occurrence is dropped at the hub (D-DEL-1), so the immediate pixel fires once and
+        // the day pixel counts the page once.
+        let f = Self.fixture()
+        let page = f.openPage()
+        f.send("adwallDetected", reason: "overlay", on: page)
+        f.send("adwallDetected", reason: "overlay", on: page)
+
+        f.endPeriod()
+
+        #expect(f.fired == [
+            #"webTelemetry_adwallDetection_day?count=1-2&reason="overlay""#,
+            #"webTelemetry_adwallDetection_immediate?reason="overlay""#,
+            "webTelemetry_captchaDetection_day?count=0",
+        ])
+    }
+
+    @Test("T-IMM-4: distinct payloads on one page each fire")
+    func distinctPayloadsOnOnePageEachFire() {
+        // Both occurrences are delivered (D-DEL-2), and the day pixel's data parameter keeps the last.
+        let f = Self.fixture()
+        let page = f.openPage()
+        f.send("adwallDetected", reason: "overlay", on: page)
+        f.send("adwallDetected", reason: "redirect", on: page)
+
+        f.endPeriod()
+
+        #expect(f.fired == [
+            #"webTelemetry_adwallDetection_day?count=1-2&reason="redirect""#,
+            #"webTelemetry_adwallDetection_immediate?reason="overlay""#,
+            #"webTelemetry_adwallDetection_immediate?reason="redirect""#,
+            "webTelemetry_captchaDetection_day?count=0",
+        ])
+    }
+
+    @Test("T-DAT-2: a matching event without the key leaves no value")
+    func aMatchingEventWithoutTheKeyLeavesNoValue() {
+        // On distinct pages, so de-duplication does not collapse the two. The second event assigns
+        // like any other, and assigns nothing — so the day pixel reports no `reason` at all rather
+        // than the first event's. Its own immediate pixel does not fire: the only parameter that
+        // pixel declares produces no value.
+        let f = Self.fixture()
+        f.send("adwallDetected", reason: "overlay", on: f.openPage())
+        f.sendRaw("adwallDetected", dataJSON: "{}", on: f.openPage())
+
+        f.endPeriod()
+
+        #expect(f.fired == [
+            "webTelemetry_adwallDetection_day?count=1-2",
+            #"webTelemetry_adwallDetection_immediate?reason="overlay""#,
+            "webTelemetry_captchaDetection_day?count=0",
+        ])
+    }
+}

--- a/SharedPackages/EventHub/Sources/EventHubTests/Spec/TelemetrySpecTests.swift
+++ b/SharedPackages/EventHub/Sources/EventHubTests/Spec/TelemetrySpecTests.swift
@@ -20,25 +20,44 @@ import Foundation
 @testable import EventHub
 
 /// Apple's coverage of the cross-platform telemetry specification
-/// (`docs/event-hub/tests/telemetry.md` in `duckduckgo/ddg-workflow`), for the cases that exist
-/// because telemetry now consumes the hub's de-duplicated stream.
+/// (`docs/event-hub/tests/telemetry.md` in `duckduckgo/ddg-workflow`).
+///
+/// **Complete case roster.** Every ID the document defines appears below, so this file can be diffed
+/// against the document in one place:
+///
+/// - Counters — T-CNT-1, T-CNT-2, T-CNT-3, T-CNT-4
+/// - Data parameters — T-DAT-1, T-DAT-2, T-DAT-3, T-DAT-4, T-DAT-5
+/// - Immediate pixels — T-IMM-1, T-IMM-2, T-IMM-3, T-IMM-4
+///
+/// Every case lives here rather than in the narrower unit suites, which is what lets the roster above
+/// be checked against the document at a glance. Two component-level behaviours sit in
+/// `EventHubDataParameterTests` instead — a `null` data value, and the "no parameter resolved, so no
+/// fire" guard — because neither is a case in this document.
 ///
 /// The properties they evidence:
+/// - **T-GEN-P1** — only pixels enabled in the current config may fire, whatever their trigger type
+///   (T-CNT-4, T-IMM-3).
+/// - **T-CNT-P1** — counters count events as delivered by the hub, bucket at period end (first match
+///   wins) and fire one pixel per period; a pixel whose parameters produce no values does not fire.
+/// - **T-DAT-P1** — a data parameter carries the payload value of the most recent delivered event whose
+///   type equals its `source`. Every such event assigns, so an event whose payload lacks the key leaves
+///   the parameter with no value, and a parameter with no value is omitted.
+/// - **T-DAT-P2** — the value survives the round trip: percent-decoding yields compact JSON, and
+///   JSON-decoding that yields the payload value exactly.
 /// - **T-IMM-P1** — immediate pixels fire once per *delivered* event. Because the hub de-duplicates
 ///   before fan-out (D-DEL-P1), repeats of an event type carrying the same payload on one page fire
 ///   once, while each distinct payload fires.
-/// - **T-DAT-P1** — a data parameter carries the payload value of the most recent delivered event
-///   whose type equals its `source`. Every such event assigns, so an event whose payload lacks the
-///   key leaves the parameter with no value, and a parameter with no value is omitted from the pixel.
 ///
-/// The rest of this suite is not de-duplication behaviour and lands with the telemetry conformance
-/// pass. Only IDs appearing in a `@Test` name are covered here.
+/// Out of scope here, and covered by platform unit tests instead: persistence and restart, foreground
+/// gating of new periods, multi-period cadence, and mid-cycle config snapshots.
 @Suite("Spec: telemetry")
 struct TelemetrySpecTests {
 
-    /// The specification's fixture, less the two `state: disabled` entries, which only T-GEN-P1,
-    /// T-CNT-4 and T-IMM-3 need. `webTelemetry_adwallDetection_day` deliberately has **no zero
-    /// bucket**.
+    /// The specification's fixture, complete — including the two `state: disabled` entries that
+    /// T-GEN-P1, T-CNT-4 and T-IMM-3 need. `webTelemetry_adwallDetection_day` deliberately has **no
+    /// zero bucket**, so it is silent in any case where nothing was counted, and
+    /// `webTelemetry_disabledPixel_day` deliberately has a catch-all one, so its silence can only be
+    /// explained by its state.
     static let config = """
     { "telemetry": {
         "webTelemetry_captchaDetection_day": {
@@ -69,43 +88,107 @@ struct TelemetrySpecTests {
             "state": "enabled",
             "trigger": { "type": "immediate_v2", "source": "adwallDetected" },
             "parameters": { "reason": { "template": "data", "dataKey": "reason" } }
+        },
+        "webTelemetry_disabledPixel_day": {
+            "state": "disabled",
+            "trigger": { "period": { "seconds": 86400 } },
+            "parameters": { "count": { "template": "counter", "source": "captchaDetected", "buckets": {
+                "0+": {"gte": 0}
+            } } }
+        },
+        "webTelemetry_disabledPixel_immediate": {
+            "state": "disabled",
+            "trigger": { "type": "immediate_v2", "source": "adwallDetected" },
+            "parameters": { "reason": { "template": "data", "dataKey": "reason" } }
         }
     } }
     """
 
-    /// Cases observe the day boundary, where the day pixels' current period ends exactly once.
-    /// `webTelemetry_captchaDetection_week` is correctly still running at that point and so does not
-    /// appear in any expected set below; the week leg of these cases arrives with the counter case
-    /// that exercises day and week counters side by side.
+    /// Both the day and the week period end once per `endPeriod()`, so every case states the week leg
+    /// alongside the day leg and the expected set stays exhaustive.
     private static func fixture() -> SpecFixture {
-        SpecFixture(config, periodSeconds: 86400)
+        SpecFixture(config, longestPeriodSeconds: 604800)
     }
 
-    @Test("T-IMM-1: one immediate pixel per event type and payload per page")
-    func oneImmediatePixelPerEventTypeAndPayloadPerPage() {
-        // The second occurrence is dropped at the hub (D-DEL-1), so the immediate pixel fires once and
-        // the day pixel counts the page once.
+    /// The captcha counters' contribution when no `captchaDetected` was delivered. Both have a zero
+    /// bucket, so both fire; the adwall day pixel has none, so it does not.
+    private static let captchaZero = [
+        "webTelemetry_captchaDetection_day?count=0",
+        "webTelemetry_captchaDetection_week?count=0",
+    ]
+
+    /// The value as it reaches the endpoint: EventHub's output encoded once by the transport.
+    ///
+    /// Uses the allowed set both pixel transports use — `CharacterSet.urlQueryAllowed` minus the
+    /// reserved characters, as `Common`'s `urlQueryParameterAllowed` defines it. Spelled out here
+    /// rather than imported so the test states exactly what it assumes of the transport.
+    private static func onTheWire(_ value: String) -> String {
+        let reserved = CharacterSet(charactersIn: ":/?#[]@!$&'()*+,;=")
+        return value.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed.subtracting(reserved))!
+    }
+
+    // MARK: Counters — aggregation and bucketing
+
+    @Test("T-CNT-1: occurrences across pages bucket at period end")
+    func occurrencesAcrossPagesBucketAtPeriodEnd() {
+        // Distinct pages, so de-duplication does not collapse them. Counters are independent per
+        // pixel: the day and the week counter each see all three.
         let f = Self.fixture()
-        let page = f.openPage()
-        f.send("adwallDetected", reason: "overlay", on: page)
-        f.send("adwallDetected", reason: "overlay", on: page)
+        f.send("captchaDetected", reason: "any", on: f.openPage())
+        f.send("captchaDetected", reason: "any", on: f.openPage())
+        f.send("captchaDetected", reason: "any", on: f.openPage())
 
         f.endPeriod()
 
         #expect(f.fired == [
-            #"webTelemetry_adwallDetection_day?count=1-2&reason="overlay""#,
-            #"webTelemetry_adwallDetection_immediate?reason="overlay""#,
-            "webTelemetry_captchaDetection_day?count=0",
+            "webTelemetry_captchaDetection_day?count=3-5",
+            "webTelemetry_captchaDetection_week?count=3-5",
         ])
     }
 
-    @Test("T-IMM-4: distinct payloads on one page each fire")
-    func distinctPayloadsOnOnePageEachFire() {
-        // Both occurrences are delivered (D-DEL-2), and the day pixel's data parameter keeps the last.
+    @Test("T-CNT-2: a zero count fires when a zero bucket exists")
+    func aZeroCountFiresWhenAZeroBucketExists() {
         let f = Self.fixture()
-        let page = f.openPage()
-        f.send("adwallDetected", reason: "overlay", on: page)
-        f.send("adwallDetected", reason: "redirect", on: page)
+
+        f.endPeriod()
+
+        #expect(f.fired == Self.captchaZero)
+    }
+
+    @Test("T-CNT-3: a count matching no bucket does not fire")
+    func aCountMatchingNoBucketDoesNotFire() {
+        // The adwall day pixel's lowest bucket starts at 1, so a zero count matches nothing and it
+        // does not fire at all — not even with its `reason` parameter, which also resolved nothing.
+        let f = Self.fixture()
+        f.send("somethingUnrelated", reason: "any", on: f.openPage())
+
+        f.endPeriod()
+
+        #expect(f.fired == Self.captchaZero)
+    }
+
+    @Test("T-CNT-4: a disabled pixel never fires")
+    func aDisabledPixelNeverFires() {
+        // Evidence for T-GEN-P1: `webTelemetry_disabledPixel_day` counts the same source as the captcha
+        // pixels and has a catch-all bucket, so only its state can explain its silence.
+        let f = Self.fixture()
+        f.send("captchaDetected", reason: "any", on: f.openPage())
+
+        f.endPeriod()
+
+        #expect(f.fired == [
+            "webTelemetry_captchaDetection_day?count=1-2",
+            "webTelemetry_captchaDetection_week?count=1-2",
+        ])
+    }
+
+    // MARK: Data parameters
+
+    @Test("T-DAT-1: the last matching event of the period supplies the value")
+    func theLastMatchingEventOfThePeriodSuppliesTheValue() {
+        let f = Self.fixture()
+        f.send("adwallDetected", reason: "overlay", on: f.openPage())
+        f.send("adwallDetected", reason: "redirect", on: f.openPage())
 
         f.endPeriod()
 
@@ -113,8 +196,7 @@ struct TelemetrySpecTests {
             #"webTelemetry_adwallDetection_day?count=1-2&reason="redirect""#,
             #"webTelemetry_adwallDetection_immediate?reason="overlay""#,
             #"webTelemetry_adwallDetection_immediate?reason="redirect""#,
-            "webTelemetry_captchaDetection_day?count=0",
-        ])
+        ] + Self.captchaZero)
     }
 
     @Test("T-DAT-2: a matching event without the key leaves no value")
@@ -132,7 +214,129 @@ struct TelemetrySpecTests {
         #expect(f.fired == [
             "webTelemetry_adwallDetection_day?count=1-2",
             #"webTelemetry_adwallDetection_immediate?reason="overlay""#,
-            "webTelemetry_captchaDetection_day?count=0",
+        ] + Self.captchaZero)
+    }
+
+    @Test("T-DAT-3: a non-string value is carried as compact JSON")
+    func aNonStringValueIsCarriedAsCompactJSON() {
+        let f = Self.fixture()
+        f.sendRaw("adwallDetected", dataJSON: #"{ "reason": { "a": true } }"#, on: f.openPage())
+
+        f.endPeriod()
+
+        #expect(f.fired == [
+            #"webTelemetry_adwallDetection_day?count=1-2&reason={"a":true}"#,
+            #"webTelemetry_adwallDetection_immediate?reason={"a":true}"#,
+        ] + Self.captchaZero)
+        // On the wire that value is `reason=%7B%22a%22%3Atrue%7D`.
+        #expect(Self.onTheWire(#"{"a":true}"#) == "%7B%22a%22%3Atrue%7D")
+    }
+
+    @Test("T-DAT-4: events of other types leave the value alone")
+    func eventsOfOtherTypesLeaveTheValueAlone() {
+        // Only an event whose type equals the parameter's `source` assigns, so the captcha event
+        // leaves `reason` holding the adwall event's value while still counting itself.
+        let f = Self.fixture()
+        f.send("adwallDetected", reason: "overlay", on: f.openPage())
+        f.send("captchaDetected", reason: "any", on: f.openPage())
+
+        f.endPeriod()
+
+        #expect(f.fired == [
+            #"webTelemetry_adwallDetection_day?count=1-2&reason="overlay""#,
+            #"webTelemetry_adwallDetection_immediate?reason="overlay""#,
+            "webTelemetry_captchaDetection_day?count=1-2",
+            "webTelemetry_captchaDetection_week?count=1-2",
         ])
+    }
+
+    @Test("T-DAT-5: a value is encoded once on the wire")
+    func aValueIsEncodedOnceOnTheWire() {
+        // Evidence for T-DAT-P2, asserted as the two-step round trip the property states. EventHub
+        // emits compact JSON and applies no encoding of its own, so the transport's is the only one:
+        // percent-decoding what the endpoint receives yields the compact JSON, and JSON-decoding that
+        // yields the payload value exactly. Encoding the value twice would break the first step.
+        let f = Self.fixture()
+        f.send("adwallDetected", reason: "overlay", on: f.openPage())
+
+        f.endPeriod()
+
+        #expect(f.fired == [
+            #"webTelemetry_adwallDetection_day?count=1-2&reason="overlay""#,
+            #"webTelemetry_adwallDetection_immediate?reason="overlay""#,
+        ] + Self.captchaZero)
+        // Step 1: percent-decoding the parameter the endpoint received yields the compact JSON.
+        let onTheWire = Self.onTheWire(#""overlay""#)
+        #expect(onTheWire == "%22overlay%22")
+        #expect(onTheWire.removingPercentEncoding == #""overlay""#)
+        // Step 2: JSON-decoding that yields the payload value from the event exactly.
+        let decoded = try? JSONDecoder().decode(String.self, from: Data(#""overlay""#.utf8))
+        #expect(decoded == "overlay")
+    }
+
+    // MARK: Immediate pixels
+
+    @Test("T-IMM-1: one immediate pixel per event type and payload per page")
+    func oneImmediatePixelPerEventTypeAndPayloadPerPage() {
+        // The second occurrence is dropped at the hub (D-DEL-1), so the immediate pixel fires once and
+        // the day pixel counts the page once.
+        let f = Self.fixture()
+        let page = f.openPage()
+        f.send("adwallDetected", reason: "overlay", on: page)
+        f.send("adwallDetected", reason: "overlay", on: page)
+
+        f.endPeriod()
+
+        #expect(f.fired == [
+            #"webTelemetry_adwallDetection_day?count=1-2&reason="overlay""#,
+            #"webTelemetry_adwallDetection_immediate?reason="overlay""#,
+        ] + Self.captchaZero)
+    }
+
+    @Test("T-IMM-2: an event with no matching immediate trigger fires nothing immediately")
+    func anEventWithNoMatchingImmediateTriggerFiresNothingImmediately() {
+        // No immediate pixel is triggered by `captchaDetected`, and the expected set being exhaustive
+        // is what asserts that: the counters report the event at period end and nothing fires inline.
+        let f = Self.fixture()
+        f.send("captchaDetected", reason: "any", on: f.openPage())
+
+        f.endPeriod()
+
+        #expect(f.fired == [
+            "webTelemetry_captchaDetection_day?count=1-2",
+            "webTelemetry_captchaDetection_week?count=1-2",
+        ])
+    }
+
+    @Test("T-IMM-3: a disabled immediate pixel never fires")
+    func aDisabledImmediatePixelNeverFires() {
+        // Evidence for T-GEN-P1 on the immediate leg: `webTelemetry_disabledPixel_immediate` shares
+        // the trigger and the parameter, so only its state can explain its silence.
+        let f = Self.fixture()
+        f.send("adwallDetected", reason: "overlay", on: f.openPage())
+
+        f.endPeriod()
+
+        #expect(f.fired == [
+            #"webTelemetry_adwallDetection_day?count=1-2&reason="overlay""#,
+            #"webTelemetry_adwallDetection_immediate?reason="overlay""#,
+        ] + Self.captchaZero)
+    }
+
+    @Test("T-IMM-4: distinct payloads on one page each fire")
+    func distinctPayloadsOnOnePageEachFire() {
+        // Both occurrences are delivered (D-DEL-2), and the day pixel's data parameter keeps the last.
+        let f = Self.fixture()
+        let page = f.openPage()
+        f.send("adwallDetected", reason: "overlay", on: page)
+        f.send("adwallDetected", reason: "redirect", on: page)
+
+        f.endPeriod()
+
+        #expect(f.fired == [
+            #"webTelemetry_adwallDetection_day?count=1-2&reason="redirect""#,
+            #"webTelemetry_adwallDetection_immediate?reason="overlay""#,
+            #"webTelemetry_adwallDetection_immediate?reason="redirect""#,
+        ] + Self.captchaZero)
     }
 }

--- a/SharedPackages/EventHub/Sources/EventHubTests/TestSupport/EventHubFixture.swift
+++ b/SharedPackages/EventHub/Sources/EventHubTests/TestSupport/EventHubFixture.swift
@@ -38,6 +38,7 @@ final class EventHubFixture {
     private let backingStore: InMemoryKeyValueStore
     private let backingRepository: EventHubKeyValueStore
     private let spyPixelFiring = SpyPixelFiring()
+    private let spyConversionReporting = SpyConversionReporting()
 
     // The manager mutates all three of these on its own queue, asynchronously, so every test-side read
     // fences first. Reading `state(of:)`/`count(of:)` needs no such treatment: `activePixelStates` is
@@ -45,12 +46,15 @@ final class EventHubFixture {
     var store: InMemoryKeyValueStore { manager.settle(); return backingStore }
     var repository: EventHubKeyValueStore { manager.settle(); return backingRepository }
     var fired: [FiredPixel] { manager.settle(); return spyPixelFiring.fired }
+    var requested: [String] { manager.settle(); return spyConversionReporting.requested }
 
     private let enabledSubject: CurrentValueSubject<Bool, Never>
     private let settingsSubject: CurrentValueSubject<[String: Any]?, Never>
+    private let experimentSettingsSubject: CurrentValueSubject<[String: String], Never>
     private let settingsJSON: String
 
-    private init(store: InMemoryKeyValueStore, settingsJSON: String, enabled: Bool, hasSettings: Bool) {
+    private init(store: InMemoryKeyValueStore, settingsJSON: String, enabled: Bool, hasSettings: Bool,
+                 experimentSettings: [String: String], enrolled: Set<String>) {
         self.backingStore = store
         self.settingsJSON = settingsJSON
         self.scheduler = ManualEventHubScheduler(startMillis: Int64(Self.start.timeIntervalSince1970 * 1000))
@@ -59,17 +63,29 @@ final class EventHubFixture {
         self.backingRepository = EventHubKeyValueStore(store: store, parser: parser)
         self.enabledSubject = CurrentValueSubject(enabled)
         self.settingsSubject = CurrentValueSubject(hasSettings ? settingsDictionary(settingsJSON) : nil)
+        self.experimentSettingsSubject = CurrentValueSubject(experimentSettings)
+        self.spyConversionReporting.enrolled = enrolled
 
         let settingsProvider = TestSettingsProviding(enabled: enabledSubject.eraseToAnyPublisher(), settings: settingsSubject.eraseToAnyPublisher())
 
         self.manager = EventHub(store: backingRepository, parser: parser, settings: settingsProvider,
-                                 scheduler: scheduler, pixelFiring: spyPixelFiring)
+                                 scheduler: scheduler, pixelFiring: spyPixelFiring,
+                                 conversionReporting: spyConversionReporting,
+                                 experimentSettings: experimentSettingsSubject.eraseToAnyPublisher())
         scheduler.settle = { [weak manager = self.manager] in manager?.settle() }
     }
 
     /// A foregrounded fixture with config applied — the common "active period" starting point.
-    static func active(_ settingsJSON: String, enabled: Bool = true, hasSettings: Bool = true) -> EventHubFixture {
-        let fixture = EventHubFixture(store: InMemoryKeyValueStore(), settingsJSON: settingsJSON, enabled: enabled, hasSettings: hasSettings)
+    ///
+    /// - Parameters:
+    ///   - experimentSettings: the raw `settings` JSON of each experiment subfeature, keyed by
+    ///     subfeature ID, that experiment metrics are parsed out of. Empty for telemetry-only tests.
+    ///   - enrolled: the experiments the (simulated) experiment framework considers active. Requests
+    ///     for anything else are dropped by `SpyConversionReporting`, as the real framework drops them.
+    static func active(_ settingsJSON: String, enabled: Bool = true, hasSettings: Bool = true,
+                       experimentSettings: [String: String] = [:], enrolled: Set<String> = []) -> EventHubFixture {
+        let fixture = EventHubFixture(store: InMemoryKeyValueStore(), settingsJSON: settingsJSON, enabled: enabled,
+                                      hasSettings: hasSettings, experimentSettings: experimentSettings, enrolled: enrolled)
         fixture.manager.onAppForegrounded()
         fixture.manager.onConfigChanged()
         return fixture
@@ -77,7 +93,8 @@ final class EventHubFixture {
 
     /// A backgrounded fixture (config not yet applied) — for foreground-gating scenarios.
     static func background(_ settingsJSON: String, enabled: Bool = true, hasSettings: Bool = true) -> EventHubFixture {
-        EventHubFixture(store: InMemoryKeyValueStore(), settingsJSON: settingsJSON, enabled: enabled, hasSettings: hasSettings)
+        EventHubFixture(store: InMemoryKeyValueStore(), settingsJSON: settingsJSON, enabled: enabled,
+                        hasSettings: hasSettings, experimentSettings: [:], enrolled: [])
     }
 
     static func webEvent(_ type: String) -> [String: Any] {
@@ -110,6 +127,22 @@ final class EventHubFixture {
 
     func setSettings(_ json: String) { settingsSubject.send(settingsDictionary(json)) }
 
+    /// Replaces the experiment settings, as a remote-config update would — the metrics registry is
+    /// rebuilt wholesale, so removing a metric here is the kill switch M-LIF-2 and M-LIF-4 exercise.
+    func setExperimentSettings(_ settings: [String: String]) { experimentSettingsSubject.send(settings) }
+
+    /// Replaces the set of experiments the framework considers active, as an enrollment (M-LIF-1,
+    /// M-LIF-3) or an experiment being disabled in config (M-LIF-5) would.
+    ///
+    /// Fences first, unlike `setSettings`/`setEnabled`: those reach the manager through a publisher and
+    /// so land on its queue *behind* any event already dispatched, whereas this mutates the spy
+    /// directly from the test thread. Without the fence an event from a previous phase could still be
+    /// in flight and be judged against the new enrollment.
+    func setEnrolled(_ experiments: Set<String>) {
+        manager.settle()
+        spyConversionReporting.enrolled = experiments
+    }
+
     func advance(by interval: TimeInterval) { scheduler.advance(by: interval) }
 
     /// Moves virtual time forward but leaves the armed period-end callback pending, so a test can act
@@ -131,7 +164,9 @@ final class EventHubFixture {
         manager.onAppBackgrounded()
         scheduler.advance(by: Self.writeBehindFlush)
 
-        let fixture = EventHubFixture(store: backingStore, settingsJSON: settingsJSON, enabled: enabledSubject.value, hasSettings: true)
+        let fixture = EventHubFixture(store: backingStore, settingsJSON: settingsJSON, enabled: enabledSubject.value,
+                                      hasSettings: true, experimentSettings: experimentSettingsSubject.value,
+                                      enrolled: spyConversionReporting.enrolled)
         fixture.manager.onAppForegrounded()
         fixture.manager.onConfigChanged()
         return fixture

--- a/SharedPackages/EventHub/Sources/EventHubTests/TestSupport/SpecFixture.swift
+++ b/SharedPackages/EventHub/Sources/EventHubTests/TestSupport/SpecFixture.swift
@@ -24,11 +24,20 @@ import Foundation
 /// pages, events, payloads, period end — so a spec case reads as the document writes it.
 final class SpecFixture {
     private let fixture: EventHubFixture
-    private let periodSeconds: TimeInterval
+    private let longestPeriodSeconds: TimeInterval
 
-    init(_ settingsJSON: String, periodSeconds: TimeInterval = 86400) {
-        self.fixture = EventHubFixture.active(settingsJSON)
-        self.periodSeconds = periodSeconds
+    /// - Parameters:
+    ///   - settingsJSON: the `eventHub` feature settings, i.e. the telemetry configuration. `"{}"` for
+    ///     the metrics suite, which configures no telemetry at all.
+    ///   - experiments: the raw `settings` JSON of each experiment subfeature, keyed by subfeature ID —
+    ///     where `metrics` is declared.
+    ///   - enrolled: the experiments the framework considers active.
+    ///   - longestPeriodSeconds: how far `endPeriod()` advances the clock — the longest period the
+    ///     config declares, so that every running period ends.
+    init(_ settingsJSON: String, longestPeriodSeconds: TimeInterval = 86400,
+         experiments: [String: String] = [:], enrolled: Set<String> = []) {
+        self.fixture = EventHubFixture.active(settingsJSON, experimentSettings: experiments, enrolled: enrolled)
+        self.longestPeriodSeconds = longestPeriodSeconds
     }
 
     var manager: EventHub { fixture.manager }
@@ -71,33 +80,60 @@ final class SpecFixture {
 
     /// A browser-native event: no tab, no URL, and so never de-duplicated.
     func sendNative(_ type: String, payload: [String: String]) {
-        fixture.manager.handleImmediateEvent(type, data: payload)
+        fixture.manager.handleNativeEvent(type, data: payload)
+    }
+
+    // MARK: Configuration lifecycle
+
+    /// Enrols the user in `experiments`, replacing any previous enrollment.
+    func enroll(in experiments: Set<String>) {
+        fixture.setEnrolled(experiments)
+    }
+
+    /// Applies a new remote config for the experiment subfeatures, replacing the previous one.
+    func setExperiments(_ experiments: [String: String]) {
+        fixture.setExperimentSettings(experiments)
+    }
+
+    /// Turns the `eventHub` feature itself on or off, as its remote `state` would (M-LIF-6, T-GEN-P1).
+    func setFeatureEnabled(_ enabled: Bool) {
+        fixture.setEnabled(enabled)
     }
 
     // MARK: Observation
 
-    /// Ends each running period once, per the suites' model: events are delivered, then the current
-    /// period ends.
+    /// Ends each running period exactly once, per the suites' model: events are delivered, then each
+    /// period pixel's current period ends.
+    ///
+    /// One clock jump suffices however many period lengths are configured, and however far apart they
+    /// are. A rollover starts the replacement period at `now` rather than at the boundary just passed,
+    /// so a pixel whose period elapsed during the jump fires once and its new period is then still
+    /// running — a 1-day and a 7-day pixel both end once here, and neither ends twice.
     func endPeriod() {
-        fixture.advance(by: periodSeconds)
+        fixture.advance(by: longestPeriodSeconds)
     }
 
     /// Every pixel fired, written as the specifications write them — `name?param=value`, sorted so a
     /// case can state its complete expected set and an over-fire fails as loudly as a missing pixel.
     ///
-    /// Data values are percent-decoded back to the compact JSON the cases quote (`reason="overlay"`
-    /// rather than `reason=%22overlay%22`); the encoding itself is pinned separately, by
-    /// `EventHubDataParameterTests`. The time-derived `attributionPeriod` is excluded, as the suites
-    /// specify.
+    /// Values appear exactly as EventHub emits them, which for a data parameter is the compact JSON the
+    /// cases quote (`reason="overlay"`). Deliberately no percent-decoding: nothing here is encoded, and
+    /// decoding would corrupt a payload value that legitimately contains a `%`. The time-derived
+    /// `attributionPeriod` is excluded, as the suites specify.
     var fired: [String] {
         fixture.fired.map { pixel in
             let parameters = pixel.parameters
                 .filter { $0.key != "attributionPeriod" }
                 .sorted { $0.key < $1.key }
-                .map { "\($0.key)=\($0.value.removingPercentEncoding ?? $0.value)" }
+                .map { "\($0.key)=\($0.value)" }
                 .joined(separator: "&")
             return parameters.isEmpty ? pixel.name : "\(pixel.name)?\(parameters)"
         }
         .sorted()
     }
+
+    /// Every conversion request handed to the experiment framework and accepted by it, written as
+    /// `experiment/metric/window/threshold` and sorted — the shape of the metrics specification's
+    /// derived-request table, so a case can state its complete expected set.
+    var requested: [String] { fixture.requested }
 }

--- a/SharedPackages/EventHub/Sources/EventHubTests/TestSupport/SpecFixture.swift
+++ b/SharedPackages/EventHub/Sources/EventHubTests/TestSupport/SpecFixture.swift
@@ -1,0 +1,103 @@
+//
+//  SpecFixture.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+@testable import EventHub
+
+/// Harness for the cross-platform behavioural specifications in `docs/event-hub/tests/`
+/// (`duckduckgo/ddg-workflow`). Wraps `EventHubFixture` in the vocabulary those documents use —
+/// pages, events, payloads, period end — so a spec case reads as the document writes it.
+final class SpecFixture {
+    private let fixture: EventHubFixture
+    private let periodSeconds: TimeInterval
+
+    init(_ settingsJSON: String, periodSeconds: TimeInterval = 86400) {
+        self.fixture = EventHubFixture.active(settingsJSON)
+        self.periodSeconds = periodSeconds
+    }
+
+    var manager: EventHub { fixture.manager }
+
+    // MARK: Pages
+
+    /// Opens `url` in a new tab and returns it.
+    ///
+    /// Every case starts a page this way, and that matters: the hub's tab→URL map begins empty, so a
+    /// tab's *first* navigation records the URL without clearing anything. That is right in
+    /// production, where a page loads before any content script can fire, but it means an event sent
+    /// before a tab's first navigation would be wrongly treated as a repeat by the navigation that
+    /// follows it. Opening the page first models the real sequence.
+    func openPage(url: String = "https://example.com/page") -> EventHubTabID {
+        let tab = EventHubTabID.new()
+        navigate(tab, to: url)
+        return tab
+    }
+
+    func navigate(_ tab: EventHubTabID, to url: String) {
+        fixture.manager.onNavigationStarted(tabID: tab, url: url)
+    }
+
+    // MARK: Events
+
+    /// A web event carrying a single `reason` payload member — the shape most cases use.
+    func send(_ type: String, reason: String, on tab: EventHubTabID) {
+        sendRaw(type, dataJSON: #"{ "reason": "\#(reason)" }"#, on: tab)
+    }
+
+    /// A web event whose payload is written out as JSON, for cases that care about its exact shape.
+    func sendRaw(_ type: String, dataJSON: String, on tab: EventHubTabID) {
+        fixture.manager.handleWebEvent(EventHubFixture.eventWithData(type, dataJSON: dataJSON), tabID: tab)
+    }
+
+    /// A web event with the `data` member absent altogether, as distinct from present and empty.
+    func sendWithoutData(_ type: String, on tab: EventHubTabID) {
+        fixture.manager.handleWebEvent(EventHubFixture.webEvent(type), tabID: tab)
+    }
+
+    /// A browser-native event: no tab, no URL, and so never de-duplicated.
+    func sendNative(_ type: String, payload: [String: String]) {
+        fixture.manager.handleImmediateEvent(type, data: payload)
+    }
+
+    // MARK: Observation
+
+    /// Ends each running period once, per the suites' model: events are delivered, then the current
+    /// period ends.
+    func endPeriod() {
+        fixture.advance(by: periodSeconds)
+    }
+
+    /// Every pixel fired, written as the specifications write them — `name?param=value`, sorted so a
+    /// case can state its complete expected set and an over-fire fails as loudly as a missing pixel.
+    ///
+    /// Data values are percent-decoded back to the compact JSON the cases quote (`reason="overlay"`
+    /// rather than `reason=%22overlay%22`); the encoding itself is pinned separately, by
+    /// `EventHubDataParameterTests`. The time-derived `attributionPeriod` is excluded, as the suites
+    /// specify.
+    var fired: [String] {
+        fixture.fired.map { pixel in
+            let parameters = pixel.parameters
+                .filter { $0.key != "attributionPeriod" }
+                .sorted { $0.key < $1.key }
+                .map { "\($0.key)=\($0.value.removingPercentEncoding ?? $0.value)" }
+                .joined(separator: "&")
+            return parameters.isEmpty ? pixel.name : "\(pixel.name)?\(parameters)"
+        }
+        .sorted()
+    }
+}

--- a/SharedPackages/EventHub/Sources/EventHubTests/TestSupport/SpyConversionReporting.swift
+++ b/SharedPackages/EventHub/Sources/EventHubTests/TestSupport/SpyConversionReporting.swift
@@ -1,0 +1,77 @@
+//
+//  SpyConversionReporting.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+@testable import EventHub
+
+/// Test double for `EventHubConversionReporting`: records every conversion request the hub hands to the
+/// Native Apps experiment framework. `EventHubFixture` exposes the recording as `.requested`.
+///
+/// It replicates exactly one line of the real framework — the enrollment gate that opens
+/// `PixelKit.fireExperimentPixelIfThresholdReached`:
+///
+///     guard let experimentData = featureFlagger.allActiveExperiments[subfeatureID] else { return }
+///
+/// That gate belongs to the framework, not the hub: per the Tech Design the metrics handler is
+/// stateless, with no enrollment check of its own. Observing requests just *after* it is what makes
+/// M-SEL-6 and M-SEL-7 ("an unenrolled experiment requests nothing") assertable without dragging
+/// PixelKit's window arithmetic, enrollment dates and event store into a specification test.
+///
+/// `allActiveExperiments` already excludes an experiment whose config `state` is `disabled`, keeping
+/// only `.enabled` and `.disabled(.targetDoesNotMatch)`, so removing an ID from `enrolled` models both
+/// un-enrolling and disabling in config (M-LIF-5).
+final class SpyConversionReporting: EventHubConversionReporting {
+    /// The experiments the user is currently enrolled in and which are currently enabled. Settable
+    /// mid-test, so a case can enroll between phases (M-LIF-1, M-LIF-3).
+    var enrolled: Set<String> = []
+
+    /// One recorded request. A local type rather than `MetricRequest`, whose `event` field the
+    /// reporting seam deliberately does not carry: by the time a request is made the event has already
+    /// done its job of selecting it.
+    struct Recorded: Equatable {
+        let experiment: String
+        let metric: String
+        let windowDays: ClosedRange<Int>
+        let threshold: Int
+    }
+
+    private(set) var requests: [Recorded] = []
+
+    func reportConversion(experiment: String, metric: String, windowDays: ClosedRange<Int>, threshold: Int) {
+        guard enrolled.contains(experiment) else { return }
+        requests.append(Recorded(experiment: experiment, metric: metric,
+                                 windowDays: windowDays, threshold: threshold))
+    }
+
+    /// Every request accepted, written as `experiment/metric/window/threshold` and sorted, so a case can
+    /// state its complete expected set and an over-request fails as loudly as a missing one.
+    ///
+    /// The window is rendered the way the specification's derived-request table writes it — and the way
+    /// PixelKit's own `conversionWindowDays` pixel parameter does — `"N"` for a single-day window and
+    /// `"low-high"` otherwise.
+    var requested: [String] {
+        requests
+            .map { request in
+                let window = request.windowDays.lowerBound == request.windowDays.upperBound
+                    ? "\(request.windowDays.lowerBound)"
+                    : "\(request.windowDays.lowerBound)-\(request.windowDays.upperBound)"
+                return "\(request.experiment)/\(request.metric)/\(window)/\(request.threshold)"
+            }
+            .sorted()
+    }
+}

--- a/SharedPackages/EventHub/Sources/EventHubTests/Unit/Config/EventHubConfigParserTests.swift
+++ b/SharedPackages/EventHub/Sources/EventHubTests/Unit/Config/EventHubConfigParserTests.swift
@@ -308,4 +308,95 @@ struct EventHubConfigParserTests {
 
         #expect(parser.serializePixelConfig(config) != nil)
     }
+
+    // MARK: parseMetrics
+
+    /// A flattened request rendered as `metric/event/window/threshold`, so expectations read compactly.
+    private func requests(_ json: String, experiment: String = "exp1") -> [String] {
+        parser.parseMetrics(experiment: experiment, settingsJSON: json)
+            .map { "\($0.metric)/\($0.event)/\($0.windowDays.lowerBound)-\($0.windowDays.upperBound)/\($0.threshold)" }
+            .sorted()
+    }
+
+    @Test("parseMetrics multiplies windows by thresholds within a group and unions groups")
+    func parseMetricsMultipliesWindowsByThresholds() {
+        let json = """
+        { "metrics": { "searchLike": { "event": "searchPerformed", "conversions": [
+            { "windows": [[0, 0], [1, 1]], "thresholds": [1] },
+            { "windows": [[0, 7]], "thresholds": [2, 3] } ] } } }
+        """
+        #expect(requests(json) == [
+            "searchLike/searchPerformed/0-0/1",
+            "searchLike/searchPerformed/0-7/2",
+            "searchLike/searchPerformed/0-7/3",
+            "searchLike/searchPerformed/1-1/1",
+        ])
+    }
+
+    @Test("parseMetrics carries the declaring experiment on every request")
+    func parseMetricsCarriesDeclaringExperiment() {
+        let json = """
+        { "metrics": { "m": { "event": "e", "conversions": [ { "windows": [[0, 7]], "thresholds": [1] } ] } } }
+        """
+        let parsed = parser.parseMetrics(experiment: "contentScopeExperiment1", settingsJSON: json)
+        #expect(parsed == [MetricRequest(experiment: "contentScopeExperiment1", event: "e", metric: "m",
+                                         windowDays: 0...7, threshold: 1)])
+    }
+
+    @Test("parseMetrics returns nothing when the settings declare no metrics")
+    func parseMetricsReturnsNothingWithoutMetricsKey() {
+        // The normal case: `metrics` is optional and most experiments declare none.
+        #expect(requests("{}").isEmpty)
+        #expect(requests(#"{ "controlUrl": "a.json", "treatmentUrl": "b.json" }"#).isEmpty)
+    }
+
+    @Test("parseMetrics ignores the other settings a TDS experiment carries")
+    func parseMetricsIgnoresOtherSettings() {
+        let json = """
+        { "controlUrl": "a.json", "treatmentUrl": "b.json",
+          "metrics": { "m": { "event": "e", "conversions": [ { "windows": [[0, 7]], "thresholds": [1] } ] } } }
+        """
+        #expect(requests(json) == ["m/e/0-7/1"])
+    }
+
+    @Test("parseMetrics returns nothing for settings that are not JSON")
+    func parseMetricsReturnsNothingForMalformedJSON() {
+        #expect(requests("not json at all").isEmpty)
+    }
+
+    @Test("parseMetrics skips a metric with no event and keeps its siblings")
+    func parseMetricsSkipsMetricWithNoEvent() {
+        let json = """
+        { "metrics": {
+            "broken": { "conversions": [ { "windows": [[0, 7]], "thresholds": [1] } ] },
+            "fine": { "event": "e", "conversions": [ { "windows": [[0, 7]], "thresholds": [1] } ] }
+        } }
+        """
+        #expect(requests(json) == ["fine/e/0-7/1"])
+    }
+
+    @Test("parseMetrics drops an unusable window and keeps the rest", arguments: [
+        "[7, 0]",       // inverted: `ClosedRange` would trap
+        "[-1, 7]",      // negative day bound
+        "[0]",          // not a pair
+        "[0, 1, 2]",    // not a pair
+    ])
+    func parseMetricsDropsUnusableWindow(window: String) {
+        let json = """
+        { "metrics": { "m": { "event": "e", "conversions": [
+            { "windows": [\(window), [0, 7]], "thresholds": [1] } ] } } }
+        """
+        #expect(requests(json) == ["m/e/0-7/1"])
+    }
+
+    @Test("parseMetrics drops a threshold below one", arguments: [0, -1])
+    func parseMetricsDropsThresholdBelowOne(threshold: Int) {
+        // A threshold below 1 would have the framework convert on every occurrence, so a config typo
+        // would become pixel spam.
+        let json = """
+        { "metrics": { "m": { "event": "e", "conversions": [
+            { "windows": [[0, 7]], "thresholds": [\(threshold), 2] } ] } } }
+        """
+        #expect(requests(json) == ["m/e/0-7/2"])
+    }
 }

--- a/SharedPackages/EventHub/Sources/EventHubTests/Unit/Config/EventHubConfigParserTests.swift
+++ b/SharedPackages/EventHub/Sources/EventHubTests/Unit/Config/EventHubConfigParserTests.swift
@@ -209,6 +209,35 @@ struct EventHubConfigParserTests {
         #expect(parser.parseTelemetry(json).isEmpty)
     }
 
+    @Test("the retired immediate trigger type is skipped")
+    func retiredImmediateTriggerTypeIsSkipped() {
+        // `immediate` was renamed to `immediate_v2` when web events began de-duplicating at the hub.
+        // Config still written for the old name belongs to clients that fire on every occurrence, so
+        // this client must not honour it — see `TelemetryTriggerType`.
+        let json = settingsDictionary("""
+        { "telemetry": { "test": {
+            "state": "enabled",
+            "trigger": { "type": "immediate", "source": "e" },
+            "parameters": { "d": { "template": "data", "dataKey": "k" } }
+        } } }
+        """)
+
+        #expect(parser.parseTelemetry(json).isEmpty)
+    }
+
+    @Test("the immediate_v2 trigger type is parsed")
+    func immediateV2TriggerTypeIsParsed() {
+        let json = settingsDictionary("""
+        { "telemetry": { "test": {
+            "state": "enabled",
+            "trigger": { "type": "immediate_v2", "source": "e" },
+            "parameters": { "d": { "template": "data", "dataKey": "k" } }
+        } } }
+        """)
+
+        #expect(parser.parseTelemetry(json).first?.trigger.type == .immediateV2)
+    }
+
     @Test("parseSinglePixelConfig with malformed JSON returns nil")
     func parseSinglePixelConfigWithMalformedJSONReturnsNil() {
         #expect(parser.parseSinglePixelConfig(name: "test", json: "not json") == nil)
@@ -260,12 +289,12 @@ struct EventHubConfigParserTests {
         let config = TelemetryPixelConfig(
             name: "test",
             state: "enabled",
-            trigger: TelemetryTriggerConfig(type: .immediate, source: "e"),
+            trigger: TelemetryTriggerConfig(type: .immediateV2, source: "e"),
             parameters: ["d": TelemetryParameterConfig(template: .data, dataKey: "k")])
 
         let json = try #require(parser.serializePixelConfig(config))
 
-        #expect(json.contains("\"type\":\"immediate\""))
+        #expect(json.contains("\"type\":\"immediate_v2\""))
         #expect(json.contains("\"template\":\"data\""))
     }
 

--- a/SharedPackages/EventHub/Sources/EventHubTests/Unit/Core/EventHubDataParameterTests.swift
+++ b/SharedPackages/EventHub/Sources/EventHubTests/Unit/Core/EventHubDataParameterTests.swift
@@ -19,6 +19,9 @@
 import Testing
 @testable import EventHub
 
+/// Component-level data-parameter behaviour that the telemetry specification does not state as a case:
+/// a `null` value, and the guard that stops a pixel firing when none of its data parameters resolve.
+/// The specification's own data-parameter cases, T-DAT-1 to T-DAT-5, live in `TelemetrySpecTests`.
 @Suite("EventHub data parameters")
 struct EventHubDataParameterTests {
     static let immediateDataConfig = """
@@ -28,29 +31,6 @@ struct EventHubDataParameterTests {
         "parameters": { "loginState": { "template": "data", "dataKey": "loginState" } }
     } } }
     """
-
-    @Test("immediate data param encodes a string value")
-    func immediateDataParamEncodesStringValue() {
-        let f = EventHubFixture.active(Self.immediateDataConfig)
-        f.manager.handleWebEvent(EventHubFixture.eventWithData("login", dataJSON: #"{ "loginState": "logged-in" }"#), tabID: .new())
-        #expect(f.fired.count == 1)
-        #expect(f.fired.first?.parameters["loginState"] == "%22logged-in%22")
-    }
-
-    @Test("immediate data param encodes an object value")
-    func immediateDataParamEncodesObjectValue() {
-        let config = """
-        { "telemetry": { "webEvent_login": {
-            "state": "enabled",
-            "trigger": { "type": "immediate_v2", "source": "login" },
-            "parameters": { "payload": { "template": "data", "dataKey": "payload" } }
-        } } }
-        """
-        let f = EventHubFixture.active(config)
-        f.manager.handleWebEvent(EventHubFixture.eventWithData("login", dataJSON: #"{ "payload": { "a": true } }"#), tabID: .new())
-        #expect(f.fired.count == 1)
-        #expect(f.fired.first?.parameters["payload"] == "%7B%22a%22%3Atrue%7D")
-    }
 
     @Test("immediate data param encodes a null value")
     func immediateDataParamEncodesNullValue() {
@@ -70,24 +50,4 @@ struct EventHubDataParameterTests {
         #expect(f.fired.isEmpty)
     }
 
-    @Test("aggregate data param uses the last value from a matching source")
-    func aggregateDataParamUsesLastValueFromMatchingSource() {
-        let config = """
-        { "telemetry": { "yt": {
-            "state": "enabled",
-            "trigger": { "period": { "seconds": 60 } },
-            "parameters": {
-                "count": { "template": "counter", "source": "yt", "buckets": {"0-9": {"gte": 0, "lt": 10}, "10+": {"gte": 10}} },
-                "loginState": { "template": "data", "source": "yt", "dataKey": "loginState" }
-            }
-        } } }
-        """
-        let f = EventHubFixture.active(config)
-        f.manager.handleWebEvent(EventHubFixture.eventWithData("yt", dataJSON: #"{ "loginState": "a" }"#), tabID: .new())
-        f.manager.handleWebEvent(EventHubFixture.eventWithData("yt", dataJSON: #"{ "loginState": "b" }"#), tabID: .new())
-        f.advance(by: 60)
-
-        #expect(f.fired.count == 1)
-        #expect(f.fired.first?.parameters["loginState"] == "%22b%22")
-    }
 }

--- a/SharedPackages/EventHub/Sources/EventHubTests/Unit/Core/EventHubDataParameterTests.swift
+++ b/SharedPackages/EventHub/Sources/EventHubTests/Unit/Core/EventHubDataParameterTests.swift
@@ -24,7 +24,7 @@ struct EventHubDataParameterTests {
     static let immediateDataConfig = """
     { "telemetry": { "webEvent_login": {
         "state": "enabled",
-        "trigger": { "type": "immediate", "source": "login" },
+        "trigger": { "type": "immediate_v2", "source": "login" },
         "parameters": { "loginState": { "template": "data", "dataKey": "loginState" } }
     } } }
     """
@@ -42,7 +42,7 @@ struct EventHubDataParameterTests {
         let config = """
         { "telemetry": { "webEvent_login": {
             "state": "enabled",
-            "trigger": { "type": "immediate", "source": "login" },
+            "trigger": { "type": "immediate_v2", "source": "login" },
             "parameters": { "payload": { "template": "data", "dataKey": "payload" } }
         } } }
         """
@@ -60,12 +60,14 @@ struct EventHubDataParameterTests {
         #expect(f.fired.first?.parameters["loginState"] == "null")
     }
 
-    @Test("immediate data param is omitted when the key is absent")
-    func immediateDataParamOmittedWhenKeyAbsent() {
+    @Test("an immediate pixel does not fire when its only data param is absent")
+    func immediatePixelDoesNotFireWhenOnlyDataParamAbsent() {
+        // A pixel that declares data parameters but resolves none of them has nothing to report. A
+        // pixel declaring no parameters at all still fires on the event alone — see
+        // `EventHubImmediatePixelTests`.
         let f = EventHubFixture.active(Self.immediateDataConfig)
         f.manager.handleWebEvent(EventHubFixture.eventWithData("login", dataJSON: #"{ "other": "x" }"#), tabID: .new())
-        #expect(f.fired.count == 1)
-        #expect(f.fired.first?.parameters["loginState"] == nil)
+        #expect(f.fired.isEmpty)
     }
 
     @Test("aggregate data param uses the last value from a matching source")

--- a/SharedPackages/EventHub/Sources/EventHubTests/Unit/Core/EventHubImmediatePixelTests.swift
+++ b/SharedPackages/EventHub/Sources/EventHubTests/Unit/Core/EventHubImmediatePixelTests.swift
@@ -24,7 +24,7 @@ struct EventHubImmediatePixelTests {
     static let immediateConfig = """
     { "telemetry": { "webEvent_impression": {
         "state": "enabled",
-        "trigger": { "type": "immediate", "source": "impression" },
+        "trigger": { "type": "immediate_v2", "source": "impression" },
         "parameters": {}
     } } }
     """
@@ -37,14 +37,18 @@ struct EventHubImmediatePixelTests {
         #expect(f.fired.first?.name == "webEvent_impression")
     }
 
-    @Test("immediate pixels are not deduplicated")
-    func immediatePixelsAreNotDeduplicated() {
+    @Test("immediate pixels are de-duplicated per page")
+    func immediatePixelsAreDeduplicatedPerPage() {
+        // The hub de-duplicates before fan-out, so immediate pixels are subject to it like any other
+        // handler. Covers the parameterless config specifically — the spec fixtures all carry a data
+        // parameter, so the empty-payload key path is only exercised here.
         let f = EventHubFixture.active(Self.immediateConfig)
         let tab = EventHubTabID.new()
+        f.manager.onNavigationStarted(tabID: tab, url: "https://example.com/page")
         f.manager.handleWebEvent(EventHubFixture.webEvent("impression"), tabID: tab)
         f.manager.handleWebEvent(EventHubFixture.webEvent("impression"), tabID: tab)
         f.manager.handleWebEvent(EventHubFixture.webEvent("impression"), tabID: tab)
-        #expect(f.fired.count == 3)
+        #expect(f.fired.count == 1)
     }
 
     @Test("immediate pixels fire without the app being foregrounded")

--- a/SharedPackages/EventHub/Sources/EventHubTests/Unit/Core/EventHubNativeIngressTests.swift
+++ b/SharedPackages/EventHub/Sources/EventHubTests/Unit/Core/EventHubNativeIngressTests.swift
@@ -56,8 +56,8 @@ struct EventHubNativeIngressTests {
     } } }
     """
 
-    // One immediate pixel and one period counter sharing the same source ("test"), so each native
-    // method can be shown to drive only its own trigger type.
+    // One immediate pixel and one period counter sharing the same source ("test"), so a single native
+    // event can be shown to reach both trigger types.
     static let bothConfig = """
     { "telemetry": {
         "imm": { "state": "enabled", "trigger": { "type": "immediate_v2", "source": "test" }, "parameters": {} },
@@ -77,6 +77,9 @@ struct EventHubNativeIngressTests {
     } } }
     """
 
+    /// A native event payload, for the cases that check one reaches `data`-template parameters.
+    private struct LoginPayload: Encodable { let loginState: String }
+
     /// A payload whose encoding throws, to exercise the serialisation fail-safe.
     private struct ThrowingData: Encodable {
         func encode(to encoder: Encoder) throws {
@@ -84,118 +87,92 @@ struct EventHubNativeIngressTests {
         }
     }
 
-    // MARK: handleImmediateEvent
-
-    @Test("handleImmediateEvent fires the matching immediate pixel")
-    func handleImmediateEventFiresMatchingImmediatePixel() {
+    @Test("handleNativeEvent fires the matching immediate pixel")
+    func handleNativeEventFiresMatchingImmediatePixel() {
         let f = EventHubFixture.active(Self.immediateConfig)
-        f.manager.handleImmediateEvent("impression")
+        f.manager.handleNativeEvent("impression")
         #expect(f.fired.count == 1)
         #expect(f.fired.first?.name == "webEvent_impression")
     }
 
-    @Test("handleImmediateEvent forwards the data object to data-template params")
-    func handleImmediateEventForwardsDataObject() {
-        struct LoginPayload: Encodable { let loginState: String }
+    @Test("handleNativeEvent forwards the data object to data-template params")
+    func handleNativeEventForwardsDataObject() {
         let f = EventHubFixture.active(Self.immediateDataConfig)
-        f.manager.handleImmediateEvent("login", data: LoginPayload(loginState: "logged-in"))
+        f.manager.handleNativeEvent("login", data: LoginPayload(loginState: "logged-in"))
         #expect(f.fired.count == 1)
-        #expect(f.fired.first?.parameters["loginState"] == "%22logged-in%22")
+        // Compact JSON, unencoded: the transport applies the wire's single encoding, not EventHub.
+        #expect(f.fired.first?.parameters["loginState"] == #""logged-in""#)
     }
 
-    @Test("handleImmediateEvent does not count toward a period counter of the same source")
-    func handleImmediateEventDoesNotCountPeriodCounter() {
+    @Test("handleNativeEvent reaches every handler")
+    func handleNativeEventReachesEveryHandler() {
+        // The positive statement of D-NAT-P1: a native occurrence is delivered to *every* handler, so
+        // one call both fires the immediate pixel and counts the period counter.
         let f = EventHubFixture.active(Self.bothConfig)
-        f.manager.handleImmediateEvent("test")
+        f.manager.handleNativeEvent("test")
         #expect(f.fired.count == 1)
         #expect(f.fired.first?.name == "imm")
-        #expect(f.count(of: "per") == 0)
-    }
-
-    @Test("handleImmediateEvent fires nothing when the feature is disabled")
-    func handleImmediateEventFiresNothingWhenDisabled() {
-        let f = EventHubFixture.active(Self.immediateConfig, enabled: false)
-        f.manager.handleImmediateEvent("impression")
-        #expect(f.fired.isEmpty)
-    }
-
-    @Test("handleImmediateEvent fires nothing for an unknown or empty type", arguments: ["unknown", ""])
-    func handleImmediateEventFiresNothingForUnknownOrEmptyType(type: String) {
-        let f = EventHubFixture.active(Self.immediateConfig)
-        f.manager.handleImmediateEvent(type)
-        #expect(f.fired.isEmpty)
-    }
-
-    @Test("handleImmediateEvent ignores unserialisable data and still fires")
-    func handleImmediateEventIgnoresUnserialisableDataAndStillFires() {
-        let f = EventHubFixture.active(Self.immediateConfig)
-        // The payload's encode(to:) throws; the fail-safe path drops the data and a parameter-less
-        // immediate pixel still fires rather than the whole call aborting.
-        f.manager.handleImmediateEvent("impression", data: ThrowingData())
-        #expect(f.fired.count == 1)
-    }
-
-    // MARK: handleAggregatedEvent
-
-    @Test("handleAggregatedEvent increments the matching counter")
-    func handleAggregatedEventIncrementsMatchingCounter() {
-        let f = EventHubFixture.active(Self.periodConfig)
-        f.manager.handleAggregatedEvent("test")
-        #expect(f.count(of: Self.pixel1) == 1)
-    }
-
-    @Test("handleAggregatedEvent counts every call with no per-tab dedup")
-    func handleAggregatedEventCountsEveryCallNoDedup() {
-        let f = EventHubFixture.active(Self.periodConfig)
-        // The differentiator from the web path: three identical native events (no tab) count three
-        // times, whereas three same-tab web events on one page would dedup to one.
-        f.manager.handleAggregatedEvent("test")
-        f.manager.handleAggregatedEvent("test")
-        f.manager.handleAggregatedEvent("test")
-        #expect(f.count(of: Self.pixel1) == 3)
-    }
-
-    @Test("handleAggregatedEvent stops at the open-ended bucket")
-    func handleAggregatedEventStopsAtOpenEndedBucket() throws {
-        let f = EventHubFixture.active(Self.periodConfig)
-        for _ in 0..<41 {
-            f.manager.handleAggregatedEvent("test")
-        }
-        let state = try #require(f.state(of: Self.pixel1))
-        #expect(state.params["count"]?.stopCounting == true)
-        #expect(state.params["count"]?.value == 40)
-    }
-
-    @Test("handleAggregatedEvent records the last data value from a matching source")
-    func handleAggregatedEventRecordsLastDataValue() {
-        struct LoginPayload: Encodable { let loginState: String }
-        let f = EventHubFixture.active(Self.periodDataConfig)
-        f.manager.handleAggregatedEvent("yt", data: LoginPayload(loginState: "a"))
-        f.manager.handleAggregatedEvent("yt", data: LoginPayload(loginState: "b"))
-        f.advance(by: 60)
-        #expect(f.fired.count == 1)
-        #expect(f.fired.first?.parameters["loginState"] == "%22b%22")
-    }
-
-    @Test("handleAggregatedEvent does not fire an immediate pixel of the same source")
-    func handleAggregatedEventDoesNotFireImmediatePixel() {
-        let f = EventHubFixture.active(Self.bothConfig)
-        f.manager.handleAggregatedEvent("test")
-        #expect(f.fired.isEmpty)
         #expect(f.count(of: "per") == 1)
     }
 
-    @Test("handleAggregatedEvent counts nothing when the feature is disabled")
-    func handleAggregatedEventCountsNothingWhenDisabled() {
-        let f = EventHubFixture.active(Self.periodConfig, enabled: false)
-        f.manager.handleAggregatedEvent("test")
-        #expect(f.state(of: Self.pixel1) == nil)
+    @Test("handleNativeEvent increments the matching counter")
+    func handleNativeEventIncrementsMatchingCounter() {
+        let f = EventHubFixture.active(Self.periodConfig)
+        f.manager.handleNativeEvent("test")
+        #expect(f.count(of: Self.pixel1) == 1)
     }
 
-    @Test("handleAggregatedEvent counts nothing for an unknown or empty type", arguments: ["unknown", ""])
-    func handleAggregatedEventCountsNothingForUnknownOrEmptyType(type: String) {
+    @Test("handleNativeEvent counts every call with no per-tab dedup")
+    func handleNativeEventCountsEveryCallNoDedup() {
+        // No tab context means no page to de-duplicate against, so every occurrence counts (D-NAT-P1).
         let f = EventHubFixture.active(Self.periodConfig)
-        f.manager.handleAggregatedEvent(type)
-        #expect(f.count(of: Self.pixel1) == 0)
+        f.manager.handleNativeEvent("test")
+        f.manager.handleNativeEvent("test")
+        f.manager.handleNativeEvent("test")
+        #expect(f.count(of: Self.pixel1) == 3)
+    }
+
+    @Test("handleNativeEvent stops at the open-ended bucket")
+    func handleNativeEventStopsAtOpenEndedBucket() throws {
+        let f = EventHubFixture.active(Self.periodConfig)
+        for _ in 0..<45 {
+            f.manager.handleNativeEvent("test")
+        }
+        let state = try #require(f.state(of: Self.pixel1))
+        #expect(state.params["count"]?.value == 40)
+        #expect(state.params["count"]?.stopCounting == true)
+    }
+
+    @Test("handleNativeEvent records the last data value from a matching source")
+    func handleNativeEventRecordsLastDataValue() {
+        let f = EventHubFixture.active(Self.periodDataConfig)
+        f.manager.handleNativeEvent("yt", data: LoginPayload(loginState: "a"))
+        f.manager.handleNativeEvent("yt", data: LoginPayload(loginState: "b"))
+        f.advance(by: 60)
+        #expect(f.fired.count == 1)
+        #expect(f.fired.first?.parameters["loginState"] == #""b""#)
+    }
+
+    @Test("handleNativeEvent does nothing when the feature is disabled")
+    func handleNativeEventDoesNothingWhenDisabled() {
+        let f = EventHubFixture.active(Self.bothConfig, enabled: false)
+        f.manager.handleNativeEvent("test")
+        #expect(f.fired.isEmpty)
+        #expect(f.state(of: "per") == nil)
+    }
+
+    @Test("handleNativeEvent does nothing for an unknown or empty type", arguments: ["unknown", ""])
+    func handleNativeEventDoesNothingForUnknownOrEmptyType(type: String) {
+        let f = EventHubFixture.active(Self.bothConfig)
+        f.manager.handleNativeEvent(type)
+        #expect(f.fired.isEmpty)
+        #expect(f.count(of: "per") == 0)
+    }
+
+    @Test("handleNativeEvent ignores unserialisable data and still fires")
+    func handleNativeEventIgnoresUnserialisableDataAndStillFires() {
+        let f = EventHubFixture.active(Self.immediateConfig)
+        f.manager.handleNativeEvent("impression", data: ThrowingData())
+        #expect(f.fired.count == 1)
     }
 }

--- a/SharedPackages/EventHub/Sources/EventHubTests/Unit/Core/EventHubNativeIngressTests.swift
+++ b/SharedPackages/EventHub/Sources/EventHubTests/Unit/Core/EventHubNativeIngressTests.swift
@@ -27,7 +27,7 @@ struct EventHubNativeIngressTests {
     static let immediateConfig = """
     { "telemetry": { "webEvent_impression": {
         "state": "enabled",
-        "trigger": { "type": "immediate", "source": "impression" },
+        "trigger": { "type": "immediate_v2", "source": "impression" },
         "parameters": {}
     } } }
     """
@@ -35,7 +35,7 @@ struct EventHubNativeIngressTests {
     static let immediateDataConfig = """
     { "telemetry": { "webEvent_login": {
         "state": "enabled",
-        "trigger": { "type": "immediate", "source": "login" },
+        "trigger": { "type": "immediate_v2", "source": "login" },
         "parameters": { "loginState": { "template": "data", "dataKey": "loginState" } }
     } } }
     """
@@ -60,7 +60,7 @@ struct EventHubNativeIngressTests {
     // method can be shown to drive only its own trigger type.
     static let bothConfig = """
     { "telemetry": {
-        "imm": { "state": "enabled", "trigger": { "type": "immediate", "source": "test" }, "parameters": {} },
+        "imm": { "state": "enabled", "trigger": { "type": "immediate_v2", "source": "test" }, "parameters": {} },
         "per": { "state": "enabled", "trigger": { "period": { "seconds": 86400 } },
             "parameters": { "count": { "template": "counter", "source": "test", "buckets": { "0": {"gte": 0, "lt": 1}, "1+": {"gte": 1} } } } }
     } }

--- a/SharedPackages/EventHub/Sources/EventHubTests/Unit/Core/EventHubTests.swift
+++ b/SharedPackages/EventHub/Sources/EventHubTests/Unit/Core/EventHubTests.swift
@@ -198,21 +198,6 @@ struct EventHubTests {
         #expect(f.fired.isEmpty)
     }
 
-    @Test("skips firing when no bucket matches")
-    func skipsFiringWhenNoBucketMatches() {
-        // Buckets start at 5, so a zero count matches nothing and no pixel is fired.
-        let config = """
-        { "telemetry": { "p": {
-            "state": "enabled",
-            "trigger": { "period": { "seconds": 60 } },
-            "parameters": { "count": { "template": "counter", "source": "test", "buckets": {"5-9": {"gte": 5, "lt": 10}} } }
-        } } }
-        """
-        let f = EventHubFixture.active(config)
-        f.advance(by: 60)
-        #expect(f.fired.isEmpty)
-    }
-
     @Test("resets state and starts a new period after firing")
     func resetsStateAndStartsNewPeriodAfterFiring() throws {
         let f = EventHubFixture.active(Self.dayConfig)

--- a/SharedPackages/EventHub/Sources/EventHubTests/Unit/Core/EventHubTests.swift
+++ b/SharedPackages/EventHub/Sources/EventHubTests/Unit/Core/EventHubTests.swift
@@ -103,45 +103,10 @@ struct EventHubTests {
 
     // MARK: Per-tab de-duplication
 
-    @Test("same tab, same source is deduplicated")
-    func sameTabSameSourceIsDeduplicated() {
-        let f = EventHubFixture.active(Self.dayConfig)
-        let tab = EventHubTabID.new()
-        f.manager.handleWebEvent(EventHubFixture.webEvent("test"), tabID: tab)
-        f.manager.handleWebEvent(EventHubFixture.webEvent("test"), tabID: tab)
-        f.manager.handleWebEvent(EventHubFixture.webEvent("test"), tabID: tab)
-        #expect(f.count(of: Self.pixel1) == 1)
-    }
-
-    @Test("navigation to a new URL resets dedup")
-    func navigationToNewURLResetsDedup() {
-        let f = EventHubFixture.active(Self.dayConfig)
-        let tab = EventHubTabID.new()
-        f.manager.handleWebEvent(EventHubFixture.webEvent("test"), tabID: tab)
-        f.manager.onNavigationStarted(tabID: tab, url: "https://example.com/page1")
-        f.manager.onNavigationStarted(tabID: tab, url: "https://example.com/page2")
-        f.manager.handleWebEvent(EventHubFixture.webEvent("test"), tabID: tab)
-        #expect(f.count(of: Self.pixel1) == 2)
-    }
-
-    @Test("reloading the same URL does not reset dedup")
-    func reloadSameURLDoesNotResetDedup() {
-        let f = EventHubFixture.active(Self.dayConfig)
-        let tab = EventHubTabID.new()
-        f.manager.onNavigationStarted(tabID: tab, url: "https://example.com/page")
-        f.manager.handleWebEvent(EventHubFixture.webEvent("test"), tabID: tab)
-        f.manager.onNavigationStarted(tabID: tab, url: "https://example.com/page")
-        f.manager.handleWebEvent(EventHubFixture.webEvent("test"), tabID: tab)
-        #expect(f.count(of: Self.pixel1) == 1)
-    }
-
-    @Test("different tabs count independently")
-    func differentTabsCountIndependently() {
-        let f = EventHubFixture.active(Self.dayConfig)
-        f.manager.handleWebEvent(EventHubFixture.webEvent("test"), tabID: .new())
-        f.manager.handleWebEvent(EventHubFixture.webEvent("test"), tabID: .new())
-        #expect(f.count(of: Self.pixel1) == 2)
-    }
+    // The page-scoped rules themselves (repeat, navigation, reload, per-tab independence) are the
+    // cross-platform spec's, covered as D-DEL-1 / D-NAV-1 / D-NAV-2 / D-NAV-4 in
+    // `DeduplicationSpecTests`. What remains here is Apple-specific lifecycle: tab close, and dedup
+    // surviving the period machinery.
 
     @Test("closing a tab clears its dedup state")
     func closingATabClearsItsDedupState() {

--- a/SharedPackages/EventHub/Sources/EventHubTests/Unit/Core/ParameterTests.swift
+++ b/SharedPackages/EventHub/Sources/EventHubTests/Unit/Core/ParameterTests.swift
@@ -28,87 +28,41 @@ struct CounterParameterTests {
         OrderedBucket(name: "2+", config: BucketConfig(gte: 2)),
     ]
 
-    /// Builds a parameter alongside the store it dedups against, so a test can clear dedup the way
-    /// `EventHub` does (the parameter consults the store; it no longer owns the state itself).
-    private static func makeParameter() -> (parameter: CounterParameter, dedupStore: DedupStore) {
-        let dedupStore = DedupStore()
-        let parameter = CounterParameter(buckets: buckets, dedupKey: "pixel:count:test", dedupStore: dedupStore)
-        return (parameter, dedupStore)
+    private static func makeParameter() -> CounterParameter {
+        CounterParameter(buckets: buckets)
     }
 
-    @Test("increments on each distinct-tab event")
-    func incrementsOnEachDistinctTabEvent() {
-        let (parameter, _) = Self.makeParameter()
-        #expect(parameter.handle(data: nil, tabID: .new()))
-        #expect(parameter.handle(data: nil, tabID: .new()))
+    @Test("counts every delivered event")
+    func countsEveryDeliveredEvent() {
+        // De-duplication happens at the hub, before fan-out, so everything reaching a parameter is a
+        // genuine occurrence — the parameter itself never suppresses anything. See `DedupStore`.
+        let parameter = Self.makeParameter()
+        #expect(parameter.handle(data: nil))
+        #expect(parameter.handle(data: nil))
         #expect(parameter.state.value == 2)
-    }
-
-    @Test("dedups repeated events on the same tab")
-    func dedupsRepeatedEventsOnSameTab() {
-        let (parameter, _) = Self.makeParameter()
-        let tab = EventHubTabID.new()
-        #expect(parameter.handle(data: nil, tabID: tab))
-        #expect(!parameter.handle(data: nil, tabID: tab))
-        #expect(parameter.state.value == 1)
-    }
-
-    @Test("native events (.empty tab) are never deduped")
-    func nativeEventsAreNeverDeduped() {
-        let (parameter, _) = Self.makeParameter()
-        #expect(parameter.handle(data: nil, tabID: .empty))
-        #expect(parameter.handle(data: nil, tabID: .empty))
-        #expect(parameter.state.value == 2)
-    }
-
-    @Test("clearing the tab's dedup entry lets it count again")
-    func clearingTabDedupLetsItCountAgain() {
-        // `EventHub` clears the store on navigation to a different URL and on tab close; from the
-        // parameter's side both look the same, so one test covers each caller.
-        let (parameter, dedupStore) = Self.makeParameter()
-        let tab = EventHubTabID.new()
-        #expect(parameter.handle(data: nil, tabID: tab))
-        dedupStore.clear(tabID: tab)
-        #expect(parameter.handle(data: nil, tabID: tab))
-        #expect(parameter.state.value == 2)
-    }
-
-    @Test("two parameters sharing a store dedup independently")
-    func parametersSharingStoreDedupIndependently() {
-        // The store is hub-wide, so the dedup key must keep pixels/params from shadowing each other.
-        let dedupStore = DedupStore()
-        let first = CounterParameter(buckets: Self.buckets, dedupKey: "pixelA:count:test", dedupStore: dedupStore)
-        let second = CounterParameter(buckets: Self.buckets, dedupKey: "pixelB:count:test", dedupStore: dedupStore)
-        let tab = EventHubTabID.new()
-
-        #expect(first.handle(data: nil, tabID: tab))
-        #expect(second.handle(data: nil, tabID: tab))
-
-        #expect(first.state.value == 1)
-        #expect(second.state.value == 1)
     }
 
     @Test("stops counting at the open-ended bucket and further events are no-ops")
     func stopsCountingAtOpenEndedBucket() {
-        let (parameter, _) = Self.makeParameter()
-        for _ in 0..<5 { parameter.handle(data: nil, tabID: .new()) }
+        let parameter = Self.makeParameter()
+        for _ in 0..<5 { parameter.handle(data: nil) }
         #expect(parameter.state.stopCounting)
         let valueAtStop = parameter.state.value
-        #expect(!parameter.handle(data: nil, tabID: .new()))
+        #expect(!parameter.handle(data: nil))
         #expect(parameter.state.value == valueAtStop)
     }
 
     @Test("queryValue reflects the matching bucket")
     func queryValueReflectsMatchingBucket() {
-        let (parameter, _) = Self.makeParameter()
+        let parameter = Self.makeParameter()
         #expect(parameter.queryValue() == "0")
-        parameter.handle(data: nil, tabID: .new())
+        parameter.handle(data: nil)
         #expect(parameter.queryValue() == "1")
     }
 
     @Test("restoreState round trips value and stopCounting")
     func restoreStateRoundTrips() {
-        let (parameter, _) = Self.makeParameter()
+        let parameter = Self.makeParameter()
         parameter.restoreState(ParamState(value: 3, stopCounting: true))
         #expect(parameter.state.value == 3)
         #expect(parameter.state.stopCounting)
@@ -120,22 +74,39 @@ struct DataParameterTests {
     @Test("captures and percent-encodes a matching data key")
     func capturesAndEncodesMatchingKey() {
         let parameter = DataParameter(dataKey: "loginState")
-        #expect(parameter.handle(data: ["loginState": "logged-in"], tabID: .new()))
+        #expect(parameter.handle(data: ["loginState": "logged-in"]))
         #expect(parameter.queryValue() != nil)
     }
 
-    @Test("ignores events with no matching data key")
-    func ignoresEventsWithNoMatchingKey() {
+    @Test("an event without the key clears a previously captured value")
+    func eventWithoutKeyClearsPreviousValue() {
+        // Every delivered event of the parameter's source assigns, so the pixel reports what the
+        // latest event carried rather than a stale reading from an earlier one.
         let parameter = DataParameter(dataKey: "loginState")
-        #expect(!parameter.handle(data: ["other": "x"], tabID: .new()))
+        parameter.handle(data: ["loginState": "logged-in"])
+        #expect(parameter.handle(data: ["other": "x"]))
         #expect(parameter.queryValue() == nil)
+    }
+
+    @Test("an event without the key is no change when there is nothing to clear")
+    func eventWithoutKeyIsNoChangeWhenEmpty() {
+        let parameter = DataParameter(dataKey: "loginState")
+        #expect(!parameter.handle(data: ["other": "x"]))
+        #expect(parameter.queryValue() == nil)
+    }
+
+    @Test("re-reporting the same value is no change")
+    func reReportingSameValueIsNoChange() {
+        let parameter = DataParameter(dataKey: "loginState")
+        #expect(parameter.handle(data: ["loginState": "a"]))
+        #expect(!parameter.handle(data: ["loginState": "a"]))
     }
 
     @Test("keeps the last value across multiple matching events")
     func keepsLastValueAcrossMultipleEvents() {
         let parameter = DataParameter(dataKey: "loginState")
-        parameter.handle(data: ["loginState": "a"], tabID: .new())
-        parameter.handle(data: ["loginState": "b"], tabID: .new())
+        parameter.handle(data: ["loginState": "a"])
+        parameter.handle(data: ["loginState": "b"])
         #expect(parameter.queryValue()?.contains("b") == true)
     }
 

--- a/SharedPackages/EventHub/Sources/EventHubTests/Unit/Core/ParameterTests.swift
+++ b/SharedPackages/EventHub/Sources/EventHubTests/Unit/Core/ParameterTests.swift
@@ -112,8 +112,9 @@ struct DataParameterTests {
 
     @Test("restoreState round trips lastDataValue")
     func restoreStateRoundTrips() {
+        // Compact JSON, the form the parameter stores and emits — the transport does the encoding.
         let parameter = DataParameter(dataKey: "loginState")
-        parameter.restoreState(ParamState(value: 0, lastDataValue: "%22a%22"))
-        #expect(parameter.queryValue() == "%22a%22")
+        parameter.restoreState(ParamState(value: 0, lastDataValue: #""a""#))
+        #expect(parameter.queryValue() == #""a""#)
     }
 }

--- a/SharedPackages/EventHub/Sources/EventHubTests/Unit/Core/TelemetryTests.swift
+++ b/SharedPackages/EventHub/Sources/EventHubTests/Unit/Core/TelemetryTests.swift
@@ -35,43 +35,43 @@ struct TelemetryTests {
 
     @Test("computes periodEndMillis from the trigger period")
     func computesPeriodEndFromTriggerPeriod() {
-        let telemetry = Telemetry(config: Self.config, periodStartMillis: 1000, dedupStore: DedupStore())
+        let telemetry = Telemetry(config: Self.config, periodStartMillis: 1000)
         #expect(telemetry.periodEndMillis == 1000 + 60_000)
     }
 
     @Test("isElapsed reflects the current time against periodEndMillis")
     func isElapsedReflectsCurrentTime() {
-        let telemetry = Telemetry(config: Self.config, periodStartMillis: 0, dedupStore: DedupStore())
+        let telemetry = Telemetry(config: Self.config, periodStartMillis: 0)
         #expect(!telemetry.isElapsed(atMillis: 59_999))
         #expect(telemetry.isElapsed(atMillis: 60_000))
     }
 
     @Test("handleEvent routes only to parameters whose source matches")
     func handleEventRoutesOnlyToMatchingSource() {
-        let telemetry = Telemetry(config: Self.config, periodStartMillis: 0, dedupStore: DedupStore())
-        #expect(!telemetry.handleEvent(source: "unrelated", data: nil, tabID: .new()))
-        #expect(telemetry.handleEvent(source: "test", data: nil, tabID: .new()))
+        let telemetry = Telemetry(config: Self.config, periodStartMillis: 0)
+        #expect(!telemetry.handleEvent(source: "unrelated", data: nil))
+        #expect(telemetry.handleEvent(source: "test", data: nil))
     }
 
     @Test("buildPixelParameters reports the matched bucket")
     func buildPixelParametersReportsMatchedBucket() {
-        let telemetry = Telemetry(config: Self.config, periodStartMillis: 0, dedupStore: DedupStore())
-        telemetry.handleEvent(source: "test", data: nil, tabID: .new())
+        let telemetry = Telemetry(config: Self.config, periodStartMillis: 0)
+        telemetry.handleEvent(source: "test", data: nil)
         #expect(telemetry.buildPixelParameters()?["count"] == "1+")
     }
 
     @Test("snapshot round trips through restoring init")
     func snapshotRoundTripsThroughRestoringInit() {
-        let original = Telemetry(config: Self.config, periodStartMillis: 500, dedupStore: DedupStore())
-        original.handleEvent(source: "test", data: nil, tabID: .new())
-        let restored = Telemetry(restoring: original.snapshot(), dedupStore: DedupStore())
+        let original = Telemetry(config: Self.config, periodStartMillis: 500)
+        original.handleEvent(source: "test", data: nil)
+        let restored = Telemetry(restoring: original.snapshot())
         #expect(restored.periodStartMillis == 500)
         #expect(restored.buildPixelParameters()?["count"] == "1+")
     }
 
     @Test("config snapshot is frozen — mutating the source config after construction has no effect")
     func configSnapshotIsFrozen() {
-        let telemetry = Telemetry(config: Self.config, periodStartMillis: 0, dedupStore: DedupStore())
+        let telemetry = Telemetry(config: Self.config, periodStartMillis: 0)
         let originalSource = telemetry.config.parameters["count"]?.source
         // Telemetry copies TelemetryPixelConfig (a value type) at construction; there is no live
         // reference back to a "current" config to mutate — this test documents that guarantee.

--- a/SharedPackages/EventHub/Sources/EventHubTests/Unit/Wiring/EventHubExperimentSettingsTests.swift
+++ b/SharedPackages/EventHub/Sources/EventHubTests/Unit/Wiring/EventHubExperimentSettingsTests.swift
@@ -1,0 +1,153 @@
+//
+//  EventHubExperimentSettingsTests.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Testing
+import Foundation
+import PrivacyConfig
+import PrivacyConfigTestsUtils
+@testable import EventHub
+
+/// The step that finds the experiments declaring metrics, reading a real `AppPrivacyConfiguration`.
+///
+/// The metrics specification suite injects its experiment settings straight into the hub, which is
+/// what keeps those 18 cases readable — but it means the reading itself runs in no case there. In
+/// particular M-SEL-8's claim that *both* experiment parent features are read is invisible to that
+/// suite: removing a parent from `parentFeatures` leaves every spec case green. This is where that
+/// claim is pinned.
+@Suite("EventHubExperimentSettings")
+struct EventHubExperimentSettingsTests {
+
+    /// A privacy config with one experiment under each parent feature that may declare metrics, using
+    /// the specification fixture's own IDs: CSS experiments live under `contentScopeExperiments`, and
+    /// on Apple TDS experiments live under `contentBlocking`.
+    private static let bothParents = """
+    {
+        "readme": "test",
+        "version": 1,
+        "features": {
+            "contentScopeExperiments": {
+                "state": "enabled",
+                "exceptions": [],
+                "features": {
+                    "contentScopeExperiment1": {
+                        "state": "enabled",
+                        "settings": { "metrics": { "captchaSeen": { "event": "captchaDetected" } } }
+                    }
+                }
+            },
+            "contentBlocking": {
+                "state": "enabled",
+                "exceptions": [],
+                "features": {
+                    "tdsNextExperiment007": {
+                        "state": "enabled",
+                        "settings": { "metrics": { "pageLoad": { "event": "pageLoaded" } } }
+                    }
+                }
+            }
+        },
+        "unprotectedTemporary": []
+    }
+    """
+
+    private func configuration(_ json: String) throws -> AppPrivacyConfiguration {
+        let data = try PrivacyConfigurationData(data: Data(json.utf8))
+        return AppPrivacyConfiguration(data: data,
+                                       identifier: "test",
+                                       localProtection: MockDomainsProtectionStore(),
+                                       internalUserDecider: MockInternalUserDecider())
+    }
+
+    @Test("both experiment parent features are read")
+    func bothExperimentParentFeaturesAreRead() throws {
+        // The wiring leg of M-SEL-8. Drop either entry from `parentFeatures` and this fails — which is
+        // exactly what the specification suite cannot see.
+        let result = EventHubExperimentSettings.current(try configuration(Self.bothParents))
+
+        #expect(result.keys.sorted() == ["contentScopeExperiment1", "tdsNextExperiment007"])
+        #expect(result["contentScopeExperiment1"]?.contains("captchaSeen") == true)
+        #expect(result["tdsNextExperiment007"]?.contains("pageLoad") == true)
+    }
+
+    @Test("parentFeatures names exactly the two features metrics may be declared under")
+    func parentFeaturesNamesTheTwoExperimentParents() {
+        // Stated as its own expectation so a change to the list is a deliberate act, not a side effect.
+        #expect(EventHubExperimentSettings.parentFeatures == [.contentScopeExperiments, .contentBlocking])
+    }
+
+    @Test("a subfeature with no settings is omitted")
+    func aSubfeatureWithNoSettingsIsOmitted() throws {
+        let result = EventHubExperimentSettings.current(try configuration("""
+        {
+            "readme": "test",
+            "version": 1,
+            "features": {
+                "contentScopeExperiments": {
+                    "state": "enabled",
+                    "exceptions": [],
+                    "features": {
+                        "withSettings":    { "state": "enabled", "settings": { "metrics": {} } },
+                        "withoutSettings": { "state": "enabled" }
+                    }
+                }
+            },
+            "unprotectedTemporary": []
+        }
+        """))
+
+        #expect(result.keys.sorted() == ["withSettings"])
+    }
+
+    @Test("on a subfeature ID present under both parents, the first parent listed wins")
+    func onACollisionTheFirstParentListedWins() throws {
+        // Documented behaviour of `current(_:)`, and arbitrary by design — nothing downstream depends
+        // on which parent a metric came from, since a conversion request names only the subfeature.
+        // Pinned so the arbitrary choice cannot change unnoticed.
+        let result = EventHubExperimentSettings.current(try configuration("""
+        {
+            "readme": "test",
+            "version": 1,
+            "features": {
+                "contentScopeExperiments": {
+                    "state": "enabled",
+                    "exceptions": [],
+                    "features": { "sharedID": { "state": "enabled", "settings": { "from": "css" } } }
+                },
+                "contentBlocking": {
+                    "state": "enabled",
+                    "exceptions": [],
+                    "features": { "sharedID": { "state": "enabled", "settings": { "from": "tds" } } }
+                }
+            },
+            "unprotectedTemporary": []
+        }
+        """))
+
+        #expect(result.count == 1)
+        #expect(result["sharedID"]?.contains("css") == true)
+    }
+
+    @Test("a config declaring no experiment features yields nothing")
+    func aConfigWithNoExperimentFeaturesYieldsNothing() throws {
+        let result = EventHubExperimentSettings.current(try configuration("""
+        { "readme": "test", "version": 1, "features": {}, "unprotectedTemporary": [] }
+        """))
+
+        #expect(result.isEmpty)
+    }
+}

--- a/SharedPackages/EventHub/Sources/EventHubTests/Unit/Wiring/WebEventsHandlerTests.swift
+++ b/SharedPackages/EventHub/Sources/EventHubTests/Unit/Wiring/WebEventsHandlerTests.swift
@@ -28,8 +28,7 @@ struct WebEventsHandlerTests {
         func handleWebEvent(_ webEventData: [String: Any], tabID: EventHubTabID) {
             handledWebEvents.append((webEventData, tabID))
         }
-        func handleImmediateEvent(_ type: String, data: Encodable?) {}
-        func handleAggregatedEvent(_ type: String, data: Encodable?) {}
+        func handleNativeEvent(_ type: String, data: Encodable?) {}
         func onNavigationStarted(tabID: EventHubTabID, url: String) {}
         func onTabClosed(tabID: EventHubTabID) {}
         func onConfigChanged() {}

--- a/iOS/DuckDuckGo/EventHub/EventHubService.swift
+++ b/iOS/DuckDuckGo/EventHub/EventHubService.swift
@@ -52,6 +52,11 @@ final class EventHubService {
             privacyConfigurationManager.privacyConfig.isEnabled(featureKey: .eventHub))
         let settingsSubject = CurrentValueSubject<[String: Any]?, Never>(
             privacyConfigurationManager.privacyConfig.settings(for: PrivacyFeature.eventHub))
+        // Experiment metrics live in the CSS/TDS experiment subfeatures rather than in the `eventHub`
+        // feature, so they arrive on their own publisher rather than through `EventHubSettings` — which
+        // exists to strip consent-gated telemetry, and a conversion request carries nothing gated.
+        let experimentSettingsSubject = CurrentValueSubject<[String: String], Never>(
+            EventHubExperimentSettings.current(privacyConfigurationManager.privacyConfig))
 
         let settings = EventHubSettings(
             featureEnabledPublisher: enabledSubject.eraseToAnyPublisher(),
@@ -67,7 +72,9 @@ final class EventHubService {
             parser: parser,
             settings: settings,
             scheduler: DispatchQueueEventHubScheduler(queue: DispatchQueue(label: "com.duckduckgo.eventhub.scheduler")),
-            pixelFiring: IOSEventHubPixelFiring()
+            pixelFiring: IOSEventHubPixelFiring(),
+            conversionReporting: IOSEventHubConversionReporting(),
+            experimentSettings: experimentSettingsSubject.eraseToAnyPublisher()
         )
 
         // Pushing the new values is all that is needed: `EventHub` subscribes to both publishers and
@@ -81,6 +88,7 @@ final class EventHubService {
                 Logger.eventHub.debug("Remote config updated — pushing to EventHub (enabled=\(enabled, privacy: .public))")
                 enabledSubject.send(enabled)
                 settingsSubject.send(privacyConfigurationManager.privacyConfig.settings(for: PrivacyFeature.eventHub))
+                experimentSettingsSubject.send(EventHubExperimentSettings.current(privacyConfigurationManager.privacyConfig))
             }
             .store(in: &cancellables)
     }

--- a/iOS/DuckDuckGo/EventHub/IOSEventHubPixelFiring.swift
+++ b/iOS/DuckDuckGo/EventHub/IOSEventHubPixelFiring.swift
@@ -21,6 +21,7 @@ import Common
 import EventHub
 import Foundation
 import os.log
+import PixelExperimentKit
 import PixelKit
 
 /// PixelKit event for EventHub-originated pixels, shared by the telemetry and failure paths below.
@@ -62,5 +63,25 @@ final class IOSEventHubDebugEventMapping: EventMapping<EventHubDebugEvent> {
 
     override init(mapping: @escaping EventMapping<EventHubDebugEvent>.Mapping) {
         fatalError("Use init()")
+    }
+}
+
+/// Hands EventHub's experiment-metric conversion requests to the Native Apps experiment framework.
+///
+/// Lives beside the pixel-firing conformance rather than in the EventHub package: the package must not
+/// depend on `PixelExperimentKit`, whose product is already linked by this app target and whose
+/// products cannot be linked twice without breaking this project's test-target link graph.
+///
+/// Everything the framework owns happens past this call — enrollment and cohort resolution, conversion
+/// window containment, threshold accumulation, repeat suppression and the pixel itself. A request for
+/// an experiment the user is not enrolled in is a no-op there, which is why the hub does not filter.
+struct IOSEventHubConversionReporting: EventHubConversionReporting {
+
+    func reportConversion(experiment: String, metric: String, windowDays: ClosedRange<Int>, threshold: Int) {
+        Logger.eventHub.info("experiment metric conversion: \(experiment, privacy: .public)/\(metric, privacy: .public) window \(windowDays.lowerBound, privacy: .public)-\(windowDays.upperBound, privacy: .public) threshold \(threshold, privacy: .public)")
+        PixelKit.fireExperimentPixelIfThresholdReached(for: experiment,
+                                                       metric: metric,
+                                                       conversionWindowDays: windowDays,
+                                                       threshold: threshold)
     }
 }

--- a/iOS/SharedTestUtils/Mocks/BrowserServiceKit/PrivacyConfig/MockPrivacyConfiguration.swift
+++ b/iOS/SharedTestUtils/Mocks/BrowserServiceKit/PrivacyConfig/MockPrivacyConfiguration.swift
@@ -61,6 +61,10 @@ class MockPrivacyConfiguration: PrivacyConfiguration {
         return subfeatureSettings
     }
 
+    func allSubfeatureSettings(for feature: PrivacyFeature) -> [SubfeatureID: PrivacyConfigurationData.PrivacyFeature.SubfeatureSettings] {
+        [:]
+    }
+
     func exceptionsList(forFeature featureKey: PrivacyFeature) -> [String] { exceptionsList(featureKey) }
     var isFeatureKeyEnabled: ((PrivacyFeature, AppVersionProvider) -> Bool)?
     func isEnabled(featureKey: PrivacyFeature, versionProvider: AppVersionProvider) -> Bool {

--- a/iOS/SharedTestUtils/Mocks/BrowserServiceKit/PrivacyConfig/PrivacyConfigurationManagerMock.swift
+++ b/iOS/SharedTestUtils/Mocks/BrowserServiceKit/PrivacyConfig/PrivacyConfigurationManagerMock.swift
@@ -107,6 +107,10 @@ class PrivacyConfigurationMock: PrivacyConfiguration {
         return subfeatureSettings[subfeature.rawValue] ?? ""
     }
 
+    func allSubfeatureSettings(for feature: PrivacyFeature) -> [SubfeatureID: PrivacyConfigurationData.PrivacyFeature.SubfeatureSettings] {
+        [:]
+    }
+
     var userUnprotected = Set<String>()
     func userEnabledProtection(forDomain domain: String) {
         userUnprotected.remove(domain)

--- a/iOS/SharedTestUtils/Mocks/DuckDuckGo/Tabs/MockTabDelegate.swift
+++ b/iOS/SharedTestUtils/Mocks/DuckDuckGo/Tabs/MockTabDelegate.swift
@@ -311,8 +311,7 @@ final class StubEventHub: EventHubManaging {
     private(set) var closedTabIDs: [EventHubTabID] = []
 
     func handleWebEvent(_ webEventData: [String: Any], tabID: EventHubTabID) {}
-    func handleImmediateEvent(_ type: String, data: Encodable?) {}
-    func handleAggregatedEvent(_ type: String, data: Encodable?) {}
+    func handleNativeEvent(_ type: String, data: Encodable?) {}
 
     func onNavigationStarted(tabID: EventHubTabID, url: String) {
         navigationStarts.append((tabID, url))

--- a/macOS/DBPE2ETests/DBPEndToEndTests.swift
+++ b/macOS/DBPE2ETests/DBPEndToEndTests.swift
@@ -615,6 +615,10 @@ private extension DBPEndToEndTests {
             nil
         }
 
+        func allSubfeatureSettings(for feature: PrivacyFeature) -> [SubfeatureID: PrivacyConfigurationData.PrivacyFeature.SubfeatureSettings] {
+            [:]
+        }
+
         func userEnabledProtection(forDomain: String) {
 
         }

--- a/macOS/DuckDuckGo/EventHub/MacOSEventHubIntegration.swift
+++ b/macOS/DuckDuckGo/EventHub/MacOSEventHubIntegration.swift
@@ -46,6 +46,11 @@ final class MacOSEventHubIntegration {
             privacyConfigurationManager.privacyConfig.isEnabled(featureKey: .eventHub))
         let settingsSubject = CurrentValueSubject<[String: Any]?, Never>(
             privacyConfigurationManager.privacyConfig.settings(for: PrivacyFeature.eventHub))
+        // Experiment metrics live in the CSS/TDS experiment subfeatures rather than in the `eventHub`
+        // feature, so they arrive on their own publisher rather than through `EventHubSettings` — which
+        // exists to strip consent-gated telemetry, and a conversion request carries nothing gated.
+        let experimentSettingsSubject = CurrentValueSubject<[String: String], Never>(
+            EventHubExperimentSettings.current(privacyConfigurationManager.privacyConfig))
 
         let settings = EventHubSettings(
             featureEnabledPublisher: enabledSubject.eraseToAnyPublisher(),
@@ -61,7 +66,9 @@ final class MacOSEventHubIntegration {
             parser: parser,
             settings: settings,
             scheduler: DispatchQueueEventHubScheduler(queue: DispatchQueue(label: "com.duckduckgo.eventhub.scheduler")),
-            pixelFiring: MacOSEventHubPixelFiring()
+            pixelFiring: MacOSEventHubPixelFiring(),
+            conversionReporting: MacOSEventHubConversionReporting(),
+            experimentSettings: experimentSettingsSubject.eraseToAnyPublisher()
         )
         self.eventHub = eventHub
 
@@ -76,6 +83,7 @@ final class MacOSEventHubIntegration {
                 Logger.eventHub.debug("Remote config updated — pushing to EventHub (enabled=\(enabled, privacy: .public))")
                 enabledSubject.send(enabled)
                 settingsSubject.send(privacyConfigurationManager.privacyConfig.settings(for: PrivacyFeature.eventHub))
+                experimentSettingsSubject.send(EventHubExperimentSettings.current(privacyConfigurationManager.privacyConfig))
             }
             .store(in: &cancellables)
     }

--- a/macOS/DuckDuckGo/EventHub/MacOSEventHubPixelFiring.swift
+++ b/macOS/DuckDuckGo/EventHub/MacOSEventHubPixelFiring.swift
@@ -20,6 +20,7 @@ import Common
 import EventHub
 import Foundation
 import os.log
+import PixelExperimentKit
 import PixelKit
 
 /// The macOS platform marker EventHub appends itself, rather than letting PixelKit derive one.
@@ -74,5 +75,25 @@ final class MacOSEventHubDebugEventMapping: EventMapping<EventHubDebugEvent> {
 
     override init(mapping: @escaping EventMapping<EventHubDebugEvent>.Mapping) {
         fatalError("Use init()")
+    }
+}
+
+/// Hands EventHub's experiment-metric conversion requests to the Native Apps experiment framework.
+///
+/// Lives beside the pixel-firing conformance rather than in the EventHub package: the package must not
+/// depend on `PixelExperimentKit`, whose product is already linked by this app target and whose
+/// products cannot be linked twice without breaking this project's test-target link graph.
+///
+/// Everything the framework owns happens past this call — enrollment and cohort resolution, conversion
+/// window containment, threshold accumulation, repeat suppression and the pixel itself. A request for
+/// an experiment the user is not enrolled in is a no-op there, which is why the hub does not filter.
+struct MacOSEventHubConversionReporting: EventHubConversionReporting {
+
+    func reportConversion(experiment: String, metric: String, windowDays: ClosedRange<Int>, threshold: Int) {
+        Logger.eventHub.info("experiment metric conversion: \(experiment, privacy: .public)/\(metric, privacy: .public) window \(windowDays.lowerBound, privacy: .public)-\(windowDays.upperBound, privacy: .public) threshold \(threshold, privacy: .public)")
+        PixelKit.fireExperimentPixelIfThresholdReached(for: experiment,
+                                                       metric: metric,
+                                                       conversionWindowDays: windowDays,
+                                                       threshold: threshold)
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1218179320032926
Tech Design URL: https://app.asana.com/1/137249556945/project/481882893211075/task/1216911265362552
CC:

### Description
Integration branch for the EventHub metrics stack. Both child PRs are reviewed and merged into this branch — this one just brings the stack to `main`.

- #6606 — the hub takes one de-duplication decision per web event, before any handler is told about it. The event's payload joins the de-duplication key, and the `immediate` trigger becomes `immediate_v2` to reflect that immediate pixels are now de-duplicated too.
- #6666 — experiment metrics declared in remote config settings report conversions to the Native Apps experiment framework, so a new metric can be hooked up entirely through config. Also folds the native-event entry points into one and fixes data parameter values arriving double percent-encoded.

### Testing Steps
Already verified on the child PRs — the testing steps and their results are in #6606 and #6666. Nothing was added on top of them here.

### Impact
High — inherited from #6606, which changes what already-released telemetry reports.

#### What could go wrong?
- The five shipped `webTelemetry_captcha_*` immediate pixels stay silent until privacy config ships `immediate_v2` entries → the config change must land before this reaches users.
- Pixels carrying a `data` parameter change value format (they were double-encoded and unusable) → worth flagging to Data Science.

Full risk breakdown is in the child PRs.

### Quality Considerations
Conformance with the cross-platform behavioural specification is complete on Apple: every case ID in the de-duplication, telemetry and metrics suites is covered by a named test.

`platform-support.md` in `ddg-workflow` needs updating after this lands — it records five Apple divergences that this stack resolves.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes live telemetry semantics (dedup, immediate_v2 config dependency, data-parameter wire format) and adds experiment conversion reporting on the critical EventHub path; privacy config must ship immediate_v2 before release.
> 
> **Overview**
> **EventHub** now treats web telemetry and experiment metrics as one pipeline: a single hub-level de-duplication step runs before any handler, then each delivered event fans out to immediate pixels, period counters, and metric conversion reporting.
> 
> Web events are de-duplicated once per tab page on **`type × canonical JSON payload`**, so repeat frames on the same page no longer inflate counters or immediate fires. Immediate triggers move from retired **`immediate`** to **`immediate_v2`** so older clients ignore config that assumes the new semantics. Native ingress is unified as **`handleNativeEvent`**, which applies the same fan-out as web events (without tab dedup).
> 
> Experiment **`metrics`** declared in CSS/TDS subfeature settings are parsed into flat **`MetricRequest`**s and forwarded through **`EventHubConversionReporting`** (wired to **PixelExperimentKit** on iOS/macOS). **`PrivacyConfiguration.allSubfeatureSettings`** enables reading remote-only experiment IDs. Data parameters emit compact JSON without pre-encoding (fixing double percent-encoding); missing keys clear the last value instead of leaving stale data.
> 
> Cross-platform spec coverage is added via dedicated deduplication, telemetry, and metrics test suites.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2d509e9da478cbbc94cf8fc18075a39c4de25d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->