### PR TITLE
Fix the Duck.ai usage card's collapsing title and block a spent allowance

### DIFF
--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/SwitchBarHandling.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/SwitchBarHandling.swift
@@ -56,6 +56,9 @@ protocol SwitchBarHandling: AnyObject {
     /// Suppresses the in-pill voice button — used when an external flank already provides one.
     var hidesVoiceButton: Bool { get set }
 
+    /// A spent Duck.ai allowance: the field takes no more text and no prompt can be sent.
+    var isInputBlockedByUsageLimit: Bool { get }
+
     var hasSubmittedPrompt: Bool { get set }
     var hasSubmittedPromptPublisher: AnyPublisher<Bool, Never> { get }
     var submitsAIChatOnKeyboardReturn: Bool { get }
@@ -93,5 +96,6 @@ extension SwitchBarHandling {
     var usesExpandedAIChatTextEntryLayout: Bool { false }
     var usesLegacyLayoutMetrics: Bool { false }
     var submitsAIChatOnKeyboardReturn: Bool { true }
+    var isInputBlockedByUsageLimit: Bool { false }
     var submitsAIChatOnKeyboardReturnPublisher: AnyPublisher<Bool, Never> { Just(true).eraseToAnyPublisher() }
 }

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
@@ -1169,6 +1169,9 @@ extension SwitchBarTextEntryView: UITextViewDelegate {
     }
 
     func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
+        // Refusing the edit rather than clearing `isEditable`: that would end editing and take the
+        // keyboard, and the card explaining the block down with it.
+        guard !handler.isInputBlockedByUsageLimit else { return false }
         if text == "\n" {
             if currentMode == .aiChat && !handler.submitsAIChatOnKeyboardReturn {
                 return true

--- a/iOS/DuckDuckGo/UnifiedToggleInput/Footer/UTIFooterCardView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/Footer/UTIFooterCardView.swift
@@ -185,7 +185,9 @@ private extension UTIFooterCardView {
 
         let textStack = UIStackView(arrangedSubviews: [titleLabel, subtitleLabel])
         textStack.axis = .vertical
-        textStack.alignment = .leading
+        // `.fill`, not `.leading`: a leading-aligned label keeps the width its own content was last
+        // measured at, and this card is measured at the flanked width too, where there is no room.
+        textStack.alignment = .fill
         textStack.spacing = Constants.textSpacing
         textStack.translatesAutoresizingMaskIntoConstraints = false
         contentView.addSubview(textStack)
@@ -333,6 +335,9 @@ final class UTIFooterActionButton: UIView {
         primaryButton.configuration = Self.makePrimaryConfiguration()
         // The label gives before the pill does, so a zero-width collapse can't break the layout.
         primaryButton.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
+        // Hugging the title makes the text stack's width the remainder rather than the losing side
+        // of a tie between two default priorities.
+        primaryButton.setContentHuggingPriority(.defaultHigh, for: .horizontal)
         primaryButton.addTarget(self, action: #selector(primaryTapped), for: .primaryActionTriggered)
         addSubview(primaryButton)
 

--- a/iOS/DuckDuckGo/UnifiedToggleInput/Footer/UTIFooterCardView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/Footer/UTIFooterCardView.swift
@@ -355,6 +355,7 @@ final class UTIFooterActionButton: UIView {
 
     private static func makePrimaryConfiguration() -> UIButton.Configuration {
         var configuration = UIButton.Configuration.plain()
+        configuration.titleLineBreakMode = .byTruncatingTail
         configuration.contentInsets = NSDirectionalEdgeInsets(top: 0,
                                                               leading: Constants.titleHorizontalPadding,
                                                               bottom: 0,

--- a/iOS/DuckDuckGo/UnifiedToggleInput/Footer/UTIFooterController.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/Footer/UTIFooterController.swift
@@ -43,6 +43,9 @@ final class UTIFooterController {
 
     weak var presenter: UTIFooterPresenting?
 
+    /// Reported when the spent-allowance state changes, so the input goes inert alongside the card.
+    var onInputBlockChanged: ((Bool) -> Void)?
+
     private let viewModel: DuckAiUsageWarningViewModel
     private let highUsageNotice: UTIFooterHighUsageNoticeSource?
     private let mapper: UTIFooterMessageMapper
@@ -57,6 +60,8 @@ final class UTIFooterController {
     private var currentExposure: DuckAiUsageWarningExposure?
 
     private var modelSwitchNotice: CreateImageModelSwitchNotice?
+
+    private var isInputBlocked = false
 
     private(set) var currentMessage: UTIFooterMessage?
 
@@ -90,6 +95,7 @@ final class UTIFooterController {
         highUsageNotice?.clear()
         currentMessage = nil
         currentExposure = nil
+        updateInputBlock()
         // Keeps the view's copy in lockstep — otherwise a later refresh that resolves to no
         // warning no-ops (nil == nil) and the view resurrects the stale card on the next expand.
         presenter?.clearPendingFooterMessage()
@@ -192,6 +198,7 @@ final class UTIFooterController {
     }
 
     private func applyCurrentState() {
+        updateInputBlock()
         let card = resolveCard()
         let message = card?.message
         guard message != currentMessage else {
@@ -206,6 +213,17 @@ final class UTIFooterController {
         animator { [weak self] in
             self?.presenter?.applyFooterMessage(message)
         }
+    }
+
+    /// Suppression counts: a block the card is not on screen to explain would read as the input
+    /// having broken. Reported off the warning rather than the visible message, so the model-switch
+    /// notice taking the slot does not lift it.
+    private func updateInputBlock() {
+        let blocked = !isSuppressed && viewModel.warning?.blocksInput == true
+        guard blocked != isInputBlocked else { return }
+        isInputBlocked = blocked
+        Logger.duckAIUsageWarnings.debug("[UsageWarnings] input blocked=\(blocked, privacy: .public)")
+        onInputBlockChanged?(blocked)
     }
 
     private struct ResolvedCard {

--- a/iOS/DuckDuckGo/UnifiedToggleInput/Footer/UTIFooterController.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/Footer/UTIFooterController.swift
@@ -215,9 +215,6 @@ final class UTIFooterController {
         }
     }
 
-    /// Suppression counts: a block the card is not on screen to explain would read as the input
-    /// having broken. Reported off the warning rather than the visible message, so the model-switch
-    /// notice taking the slot does not lift it.
     private func updateInputBlock() {
         let blocked = !isSuppressed && viewModel.warning?.blocksInput == true
         guard blocked != isInputBlocked else { return }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
@@ -925,6 +925,9 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
                                               measurement: makeUsageWarningMeasurement(),
                                               createImagePixelFiring: createImagePixelFiring)
         footerController?.presenter = viewController
+        footerController?.onInputBlockChanged = { [weak self] blocked in
+            self?.viewController.isInputBlockedByUsageLimit = blocked
+        }
 
         // Also what brings a message back after the user has acted on the previous one.
         usageLimitsStore?.snapshotUpdates?

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputHandler.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputHandler.swift
@@ -120,6 +120,10 @@ final class UnifiedToggleInputHandler: SwitchBarHandling {
 
     var isImageGenerationSelected: Bool = false
 
+    /// Mirrors the usage card's blocking state, so every path into a prompt is closed and not just
+    /// the buttons that look closed.
+    var isInputBlockedByUsageLimit: Bool = false
+
     // MARK: - SwitchBarHandling — Publishers
 
     var currentTextPublisher: AnyPublisher<String, Never> {
@@ -195,12 +199,14 @@ final class UnifiedToggleInputHandler: SwitchBarHandling {
     }
 
     func submitText(_ text: String) {
+        guard !isInputBlockedByUsageLimit else { return }
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
         textSubmissionSubject.send((text: trimmed, mode: currentToggleState))
     }
 
     func submitAIChatAttachmentOnlyPrompt() {
+        guard !isInputBlockedByUsageLimit else { return }
         textSubmissionSubject.send((text: "", mode: .aiChat))
     }
 

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputToolbarView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputToolbarView.swift
@@ -66,6 +66,15 @@ final class UnifiedToggleInputToolbarView: UIView {
         didSet { updateSubmitButtonAppearance() }
     }
 
+    /// A spent allowance blocks the voice button too: it opens a chat the allowance can't pay for.
+    var isInputBlockedByUsageLimit: Bool = false {
+        didSet {
+            guard oldValue != isInputBlockedByUsageLimit else { return }
+            updateSubmitButtonAppearance()
+            updateToolbarControlsEnabledState()
+        }
+    }
+
     var usesNewPromptSubmitStyle: Bool = false {
         didSet { updateSubmitButtonAppearance() }
     }
@@ -556,9 +565,13 @@ private extension UnifiedToggleInputToolbarView {
         }()
         submitButton.setImage(icon, for: .normal)
         let submitAllowed = isSubmitEnabled && !isSubmitBlockedByRecoveryCard
-        let isActive = submitAllowed || showVoice
+        let isActive = (submitAllowed || showVoice) && !isInputBlockedByUsageLimit
         submitButton.isEnabled = isActive
-        if showVoice {
+        // The blocked button keeps its icon and takes the inactive submit fill: the voice and
+        // return-key styles have no disabled state of their own.
+        if isInputBlockedByUsageLimit {
+            submitButton.applySubmitStyle(isActive: false, isFireTab: isFireTab, activeForeground: .white)
+        } else if showVoice {
             submitButton.applyAIVoiceChatStyle()
         } else if usesReturnKeyStyle {
             submitButton.applyReturnKeyStyle()
@@ -578,7 +591,7 @@ private extension UnifiedToggleInputToolbarView {
     }
 
     func updateToolbarControlsEnabledState() {
-        let controlsAreEnabled = !isGenerating
+        let controlsAreEnabled = !isGenerating && !isInputBlockedByUsageLimit
         imageButton.isEnabled = controlsAreEnabled && isImageButtonAvailable
         toolsButton.isEnabled = controlsAreEnabled
         reasoningButton.isEnabled = controlsAreEnabled

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
@@ -239,6 +239,10 @@ final class UnifiedToggleInputView: UIView {
         didSet { toolsToolbar.isSubmitBlockedByRecoveryCard = isToolbarSubmitBlockedByRecoveryCard }
     }
 
+    var isInputBlockedByUsageLimit: Bool = false {
+        didSet { toolsToolbar.isInputBlockedByUsageLimit = isInputBlockedByUsageLimit }
+    }
+
     var isGenerating: Bool = false {
         didSet { toolsToolbar.isGenerating = isGenerating }
     }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
@@ -1149,7 +1149,7 @@ final class UnifiedToggleInputView: UIView {
             aiTabCollapsedMenuButton.isHidden = true
         }
         guard layout != currentLayout else {
-            updateExpandedBorderVisibility(expanded && layout.showsToggle)
+            updateExpandedBorderVisibility(expanded && (layout.showsToggle || layout.showsToolbar))
             return
         }
         currentLayout = layout
@@ -1217,7 +1217,7 @@ final class UnifiedToggleInputView: UIView {
         cardView.layer.maskedCorners = Constants.allCorners
         cardView.clipsToBounds = expanded && (usesOmnibarMargins || !isToggleEnabled)
 
-        updateExpandedBorderVisibility(expanded && showsToggle)
+        updateExpandedBorderVisibility(expanded && (showsToggle || showToolbar))
         let changes = {
             self.setCardFlanked(layout == .flanked)
             // Bottom collapsed pose is a capsule to match the floating omnibar pill; everything

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputViewController.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputViewController.swift
@@ -177,6 +177,16 @@ final class UnifiedToggleInputViewController: UIViewController {
         set { inputBarView.isToolbarSubmitBlockedByRecoveryCard = newValue }
     }
 
+    /// The handler's copy closes the keyboard's own routes into a prompt; the view's greys out the
+    /// controls that would offer one.
+    var isInputBlockedByUsageLimit: Bool = false {
+        didSet {
+            guard isInputBlockedByUsageLimit != oldValue else { return }
+            handler.isInputBlockedByUsageLimit = isInputBlockedByUsageLimit
+            inputBarView.isInputBlockedByUsageLimit = isInputBlockedByUsageLimit
+        }
+    }
+
     var isGenerating: Bool = false {
         didSet {
             guard isGenerating != oldValue else { return }

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/Footer/UTIFooterCardViewTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/Footer/UTIFooterCardViewTests.swift
@@ -26,6 +26,10 @@ import XCTest
 final class UTIFooterCardViewTests: XCTestCase {
 
     private let phoneWidth: CGFloat = 390
+    /// The input card's two widths on a phone: expanded to the omnibar margins, and flanked by the
+    /// AI tab's fire and menu buttons — the footer card follows both.
+    private let expandedCardWidth: CGFloat = 361
+    private let flankedCardWidth: CGFloat = 249
     /// Longer than the room a titled card leaves beside its CTA and close button at phone width.
     private let wrappingTitle = "Advanced AI models limit reached for this billing period"
 
@@ -236,6 +240,24 @@ final class UTIFooterCardViewTests: XCTestCase {
                                  sut.convert(dismiss.bounds, from: dismiss).minX)
     }
 
+    /// The footer's width follows the input card, so a message can be measured at the flanked
+    /// AI-tab width. A title left at its own intrinsic width keeps that measurement, which is what
+    /// draws it as a column of one or two characters a line.
+    func test_title_ownsItsRoomAtEveryCardWidth() {
+        let sut = UTIFooterCardView()
+        sut.configure(with: makeLimitReachedMessage(), animateIcon: false)
+
+        for width in [flankedCardWidth, expandedCardWidth] {
+            layOut(sut, atWidth: width)
+
+            guard let label = titleLabel(in: sut), let stack = textStack(in: sut) else {
+                return XCTFail("Expected the title to be part of the card")
+            }
+            XCTAssertEqual(label.bounds.width, stack.bounds.width, accuracy: 0.5,
+                           "The title has to own the room the CTA leaves it, at card width \(width)")
+        }
+    }
+
     // MARK: - Helpers
 
     /// Lays the card out at phone width for `isDismissible` and reports the trailing edge of the
@@ -253,6 +275,12 @@ final class UTIFooterCardViewTests: XCTestCase {
             return 0
         }
         return card.convert(subview.bounds, from: subview).maxX
+    }
+
+    private func layOut(_ card: UTIFooterCardView, atWidth width: CGFloat) {
+        card.frame = CGRect(x: 0, y: 0, width: width, height: 200)
+        card.setNeedsLayout()
+        card.layoutIfNeeded()
     }
 
     private func infoIcon(in card: UTIFooterCardView) -> UIImageView? {
@@ -344,6 +372,16 @@ final class UTIFooterCardViewTests: XCTestCase {
                          subtitle: nil,
                          primaryAction: nil,
                          isDismissible: true)
+    }
+
+    /// The blocked card as shipped: a short title beside a CTA wide enough to compress it, and no
+    /// close button, so the pill reaches the trailing edge.
+    private func makeLimitReachedMessage() -> UTIFooterMessage {
+        UTIFooterMessage(icon: .alert,
+                         title: "Daily limit reached",
+                         subtitle: "Resets in 5 hours",
+                         primaryAction: .init(title: "Start Using Weekly Limit"),
+                         isDismissible: false)
     }
 
     private func makeIconlessMessage() -> UTIFooterMessage {

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/Footer/UTIFooterControllerTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/Footer/UTIFooterControllerTests.swift
@@ -32,6 +32,7 @@ final class UTIFooterControllerTests: XCTestCase {
     private var createImagePixelFiring: MockCreateImagePixelFiring!
     private var selectedModel: (id: String?, shortName: String?) = (nil, nil)
     private var animationCount = 0
+    private var reportedBlocks: [Bool] = []
     private var sut: UTIFooterController!
 
     private let now = Date(timeIntervalSince1970: 1_800_000_000)
@@ -45,6 +46,7 @@ final class UTIFooterControllerTests: XCTestCase {
         createImagePixelFiring = MockCreateImagePixelFiring()
         selectedModel = (nil, nil)
         animationCount = 0
+        reportedBlocks = []
         viewModel = makeViewModel()
         sut = UTIFooterController(viewModel: viewModel,
                                   highUsageNotice: makeNoticeSource(),
@@ -55,6 +57,7 @@ final class UTIFooterControllerTests: XCTestCase {
                                       changes()
                                   })
         sut.presenter = presenter
+        sut.onInputBlockChanged = { [unowned self] blocked in reportedBlocks.append(blocked) }
     }
 
     override func tearDown() {
@@ -105,6 +108,56 @@ final class UTIFooterControllerTests: XCTestCase {
         sut.refresh()
 
         XCTAssertEqual(animationCount, 2)
+    }
+
+    // MARK: - Input block
+
+    /// The allowance is spent, so the card is the only thing left to act on.
+    func test_refresh_reportsTheInputBlockedWhenTheLimitIsReached() {
+        limitsProvider.limits = weeklyReachedWithUpsell()
+
+        sut.refresh()
+
+        XCTAssertEqual(reportedBlocks, [true])
+    }
+
+    func test_refresh_leavesTheInputLiveWhileTheWarningIsOnlyApproaching() {
+        limitsProvider.limits = weeklyUsage(90)
+
+        sut.refresh()
+
+        XCTAssertTrue(reportedBlocks.isEmpty)
+    }
+
+    /// A block with no card on screen to explain it would read as the input having broken.
+    func test_setSuppressed_liftsTheBlockWithTheCard() {
+        limitsProvider.limits = weeklyReachedWithUpsell()
+        sut.refresh()
+
+        sut.setSuppressed(true)
+
+        XCTAssertEqual(reportedBlocks, [true, false])
+    }
+
+    func test_resetForPoseChange_liftsTheBlock() {
+        limitsProvider.limits = weeklyReachedWithUpsell()
+        sut.refresh()
+
+        sut.resetForPoseChange()
+
+        XCTAssertEqual(reportedBlocks, [true, false])
+    }
+
+    /// The CTA exists to unblock the user, and since #6644 it pushes the hand-off to the live chat
+    /// instead of writing an entry — so no snapshot update comes back to lift the block for it.
+    func test_performPrimaryAction_liftsTheBlockWhenTheHandOffIsTaken() {
+        limitsProvider.limits = dailyReachedWithWeeklyHandOff()
+        sut.refresh()
+        XCTAssertEqual(reportedBlocks, [true])
+
+        sut.performPrimaryAction()
+
+        XCTAssertEqual(reportedBlocks, [true, false])
     }
 
     // MARK: - Dismissal
@@ -817,6 +870,22 @@ final class UTIFooterControllerTests: XCTestCase {
                                       dismissible: false),
             cta: DuckAiUsageCta(id: .subscribe),
             signature: "snapshot-reached-upsell"
+        )
+    }
+
+    /// The blocked state the screenshot shows: a spent daily allowance whose only offer is the
+    /// weekly hand-off.
+    private func dailyReachedWithWeeklyHandOff() -> DuckAiUsageSnapshot {
+        DuckAiUsageSnapshot(
+            notice: DuckAiUsageNotice(id: .dailyReached,
+                                      window: .daily,
+                                      percentUsed: 100,
+                                      resetsAt: now.addingTimeInterval(18_000),
+                                      reached: true,
+                                      dismissible: false),
+            cta: DuckAiUsageCta(id: .bypassWeekly,
+                                putEntries: [DuckAiNativeStorageEntry(key: "usageLimits", value: "{}")]),
+            signature: "snapshot-daily-reached"
         )
     }
 

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputHandlerTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputHandlerTests.swift
@@ -234,6 +234,21 @@ final class UnifiedToggleInputHandlerTests: XCTestCase {
         waitForExpectations(timeout: 1)
     }
 
+    /// The greyed-out button is not the only route into a prompt: the keyboard return key and
+    /// Paste & Go both come through here.
+    func test_submitText_whenInputIsBlockedByUsageLimit_doesNotFirePublisher() {
+        var fired = false
+        sut.textSubmissionPublisher
+            .sink { _ in fired = true }
+            .store(in: &cancellables)
+        sut.isInputBlockedByUsageLimit = true
+
+        sut.submitText("hello")
+        sut.submitAIChatAttachmentOnlyPrompt()
+
+        XCTAssertFalse(fired)
+    }
+
     func test_submitText_emptyString_doesNotFirePublisher() {
         var fired = false
         sut.textSubmissionPublisher

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputToolbarViewTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputToolbarViewTests.swift
@@ -114,6 +114,57 @@ final class UnifiedToggleInputToolbarViewTests: XCTestCase {
         XCTAssertTrue(selectedToolClearButton?.isEnabled ?? false)
     }
 
+    /// A spent allowance leaves the card's own CTA as the only live control.
+    func test_isInputBlockedByUsageLimit_disablesToolbarConfigurationButtons() {
+        let sut = UnifiedToggleInputToolbarView()
+        sut.isImageButtonEnabled = true
+        sut.selectedTool = .webSearch
+
+        let attachmentButton = findButton(accessibilityLabel: UserText.aiChatToolbarAttachButtonAccessibilityLabel, in: sut)
+        let toolsButton = findButton(accessibilityLabel: UserText.aiChatToolbarToolsButtonAccessibilityLabel, in: sut)
+        let reasoningButton = findButton(accessibilityIdentifier: "AIChat.Toolbar.Button.Reasoning", in: sut)
+        let modelChipButton = findButton(accessibilityIdentifier: "AIChat.Toolbar.Button.ModelChip", in: sut)
+
+        sut.isInputBlockedByUsageLimit = true
+
+        XCTAssertFalse(attachmentButton?.isEnabled ?? true)
+        XCTAssertFalse(toolsButton?.isEnabled ?? true)
+        XCTAssertFalse(reasoningButton?.isEnabled ?? true)
+        XCTAssertFalse(modelChipButton?.isEnabled ?? true)
+
+        sut.isInputBlockedByUsageLimit = false
+
+        XCTAssertTrue(attachmentButton?.isEnabled ?? false)
+        XCTAssertTrue(toolsButton?.isEnabled ?? false)
+        XCTAssertTrue(reasoningButton?.isEnabled ?? false)
+        XCTAssertTrue(modelChipButton?.isEnabled ?? false)
+    }
+
+    func test_isInputBlockedByUsageLimit_disablesTheSubmitButton() {
+        let sut = UnifiedToggleInputToolbarView()
+        sut.isSubmitEnabled = true
+
+        let submitButton = findButton(accessibilityLabel: UserText.aiChatToolbarSubmitButtonAccessibilityLabel, in: sut)
+        XCTAssertTrue(submitButton?.isEnabled ?? false)
+
+        sut.isInputBlockedByUsageLimit = true
+
+        XCTAssertFalse(submitButton?.isEnabled ?? true)
+    }
+
+    /// Voice is a way into a chat the allowance can't pay for either, so it greys out with submit.
+    func test_isInputBlockedByUsageLimit_disablesTheVoiceButton() {
+        let sut = UnifiedToggleInputToolbarView()
+        sut.isAIVoiceChatActive = true
+
+        let submitButton = findButton(accessibilityLabel: UserText.aiChatToolbarSubmitButtonAccessibilityLabel, in: sut)
+        XCTAssertTrue(submitButton?.isEnabled ?? false, "Voice is live on an empty input")
+
+        sut.isInputBlockedByUsageLimit = true
+
+        XCTAssertFalse(submitButton?.isEnabled ?? true)
+    }
+
     func test_isGenerating_doesNotReenableUnavailableAttachmentButton() {
         let sut = UnifiedToggleInputToolbarView()
         sut.isImageButtonEnabled = false


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201011656765697/task/1218185901618524?focus=true
Tech Design URL:
CC:

### Description
The usage-limit card's title sometimes rendered as a column of one or two characters a line, because the card's width follows the input card and its text stack left the title at whatever width it was last measured at — including the much narrower flanked AI-tab pose. It now fills the room it is given, so the wrap always matches the space actually available. Separately, a spent allowance now makes the whole input inert on iOS as it already does on macOS: submit and voice grey out, the tools/attach/reasoning/model controls disable, and the keyboard's own routes into a prompt close, leaving the card's own CTA as the only thing to act on.

### Testing Steps
1. Enable `utiDuckAIWarnings`, then seed a blocked state via Debug ▸ AI Chat ▸ Duck.ai Usage Warnings ▸ daily limit reached.
2. Open a Duck.ai tab and focus the input → the card reads "Daily limit reached" on one or two lines, never a vertical column of characters. Rotate and collapse/expand the input a few times → it stays readable.
3. With the card up: the send button is grey and does nothing, the voice button is grey and does nothing, the attach/tools/reasoning/model controls are disabled, and typing in the field does nothing. Tap "Start Using Weekly Limit" → the card retires and all of the above become live again.

### Impact
Low — behind `utiDuckAIWarnings`, internal only, and iOS-only.

#### What could go wrong?
A block could outlive the card that explains it and leave the user with a permanently dead input → it is reported off the same suppression the card is, lifted by `showCollapsed`/`hide`, and covered by tests for the suppression, pose-reset and CTA paths.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> iOS-only Duck.ai usage UI behind `utiDuckAIWarnings`; input blocking is tied to the same footer suppression and CTA paths covered by new tests.
> 
> **Overview**
> Fixes the Duck.ai usage footer so long titles use the full card width (including the narrow flanked AI-tab pose) instead of wrapping one character per line, via stack **fill** alignment and tighter button compression/hugging on the CTA pill.
> 
> When a usage warning **`blocksInput`** (spent allowance), **`UTIFooterController`** now reports **`onInputBlockChanged`** and the unified input goes inert like macOS: typing is rejected without dismissing the keyboard, submit/voice grey out, toolbar controls disable, and **`submitText`** / attachment-only paths are no-ops. The block clears with suppression, pose reset, or taking the weekly hand-off CTA. Expanded input chrome also shows the border when only the toolbar is visible.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee2049bf6f1f399b9dfc140385e6e6f20e6118ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->