### PR TITLE
[iOS] Move bookmark importing logic out of Core

### DIFF
--- a/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
+++ b/iOS/DuckDuckGo-iOS.xcodeproj/project.pbxproj
@@ -5110,6 +5110,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				708BA1CBA61D18E2FCEC6043 /* WideEvent in Frameworks */,
+				C14882ED27F211A000D59F0C /* SwiftSoup in Frameworks */,
 				D61CDA182B7CF78300A0FBB9 /* ZIPFoundation in Frameworks */,
 				FCFC00031F00000000010001 /* DDGError in Frameworks */,
 				A64F1A060000000000000006 /* FeatureFlags-iOS in Frameworks */,
@@ -5351,7 +5352,6 @@
 				4BABF9183022746600B46B44 /* AppRouting in Frameworks */,
 				4BACF9183022746600B46B44 /* InstallStatistics in Frameworks */,
 				4BC95E8D2D741700002FAB32 /* DuckPlayer in Frameworks */,
-				C14882ED27F211A000D59F0C /* SwiftSoup in Frameworks */,
 				4BC95E892D7416F2002FAB32 /* ContentBlocking in Frameworks */,
 				4BC95E972D741749002FAB32 /* SyncDataProviders in Frameworks */,
 				4BC95E9D2D74175A002FAB32 /* SpecialErrorPages in Frameworks */,
@@ -8659,7 +8659,6 @@
 		C14882D627F2010700D59F0C /* ImportExport */ = {
 			isa = PBXGroup;
 			children = (
-				C14882D927F2011C00D59F0C /* BookmarksImporter.swift */,
 			);
 			name = ImportExport;
 			sourceTree = "<group>";
@@ -10245,6 +10244,7 @@
 		F1668BCC1E798025008CBA04 /* Bookmarks */ = {
 			isa = PBXGroup;
 			children = (
+				C14882D927F2011C00D59F0C /* BookmarksImporter.swift */,
 				C14882D727F2011C00D59F0C /* BookmarksExporter.swift */,
 				C1963862283794A000298D4D /* BookmarksCachingSearch.swift */,
 				98629D302C21765A001E6031 /* BookmarksStateValidation.swift */,
@@ -10907,6 +10907,7 @@
 			name = DuckDuckGo;
 			packageProductDependencies = (
 				524F28DF1A4A0B9EAD27884C /* WideEvent */,
+				C14882EC27F211A000D59F0C /* SwiftSoup */,
 				D61CDA172B7CF78300A0FBB9 /* ZIPFoundation */,
 				FCFC00021F00000000010001 /* DDGError */,
 				A64F1A030000000000000003 /* FeatureFlags-iOS */,
@@ -11248,7 +11249,6 @@
 				FCFC00021F00000000030001 /* URLPredictor */,
 				A64F1A020000000000000002 /* FeatureFlags-iOS */,
 				F486D33325069BBB002D07D7 /* Kingfisher */,
-				C14882EC27F211A000D59F0C /* SwiftSoup */,
 				CB6CC7E32CD2529000320907 /* BrokenSitePrompt */,
 				CBECDB6E2CD3DFBE005B8B87 /* PageRefreshMonitor */,
 				4BC95E802D7416D7002FAB32 /* Bookmarks */,
@@ -11882,6 +11882,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C14882DC27F2011C00D59F0C /* BookmarksImporter.swift in Sources */,
 				C14882DA27F2011C00D59F0C /* BookmarksExporter.swift in Sources */,
 				C1963863283794A000298D4D /* BookmarksCachingSearch.swift in Sources */,
 				98629D312C21765A001E6031 /* BookmarksStateValidation.swift in Sources */,
@@ -13997,7 +13998,6 @@
 				FC0A7B0B2F00000100AAB001 /* PixelKitParameterProvider.swift in Sources */,
 				F41C2DA526C1975E00F9A760 /* LegacyBookmarksCoreDataStorage.swift in Sources */,
 				6F9857342CD27FA2001BE9A0 /* BoolFileMarker.swift in Sources */,
-				C14882DC27F2011C00D59F0C /* BookmarksImporter.swift in Sources */,
 				CBAA195A27BFE15600A4BD49 /* NSManagedObjectContextExtension.swift in Sources */,
 				F124B95A2F2CC20C00B29447 /* BuildFlags.swift in Sources */,
 				85BDC3192436161C0053DB07 /* LoginFormDetectionUserScript.swift in Sources */,

--- a/iOS/DuckDuckGo/BookmarksImporter.swift
+++ b/iOS/DuckDuckGo/BookmarksImporter.swift
@@ -18,6 +18,7 @@
 //
 
 import Bookmarks
+import Core
 import Common
 import FoundationExtensions
 import Foundation

--- a/iOS/DuckDuckGo/DataImport/DataImportManager.swift
+++ b/iOS/DuckDuckGo/DataImport/DataImportManager.swift
@@ -17,7 +17,6 @@
 //  limitations under the License.
 //
 
-import Core
 import Foundation
 import BrowserServicesKit
 import SecureStorage

--- a/iOS/DuckDuckGoTests/BookmarksExporterTests.swift
+++ b/iOS/DuckDuckGoTests/BookmarksExporterTests.swift
@@ -18,7 +18,6 @@
 //
 
 import XCTest
-@testable import Core
 @testable import DuckDuckGo
 
 @MainActor

--- a/iOS/DuckDuckGoTests/BookmarksImporterTests.swift
+++ b/iOS/DuckDuckGoTests/BookmarksImporterTests.swift
@@ -18,10 +18,9 @@
 //
 
 import Bookmarks
-import SwiftSoup
 import XCTest
 
-@testable import Core
+@testable import DuckDuckGo
 
 @MainActor
 class BookmarksImporterTests: XCTestCase {

--- a/iOS/PerformanceTests/BookmarksExportPerformanceTests.swift
+++ b/iOS/PerformanceTests/BookmarksExportPerformanceTests.swift
@@ -21,7 +21,6 @@ import XCTest
 import Bookmarks
 import Persistence
 import CoreData
-@testable import Core
 @testable import DuckDuckGo
 
 class BookmarksExportPerformanceTests: XCTestCase {

--- a/iOS/PerformanceTests/BookmarksImportPerformanceTests.swift
+++ b/iOS/PerformanceTests/BookmarksImportPerformanceTests.swift
@@ -21,7 +21,7 @@ import XCTest
 import Bookmarks
 import Persistence
 import CoreData
-@testable import Core
+@testable import DuckDuckGo
 
 class BookmarksImportPerformanceTests: XCTestCase {
     


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ External contributors: file an issue before opening a PR.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1193060753475688/task/1218212271878858?focus=true
Tech Design URL:
CC:

### Description
<!-- What changed and why, in plain English. No class names, method names, or implementation details — the diff shows those. Keep it brief. -->

This PR moves bookmarks importing code out of Core, as part of the initiative to remove Core entirely.

### Testing Steps
<!-- One action per step. Note expected outcome inline where relevant, e.g. "3. Tap Save → settings screen dismisses". Assume the reviewer is unfamiliar with this part of the app. -->
1. Check that importing works as expected

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

High: Could break bookmarks importing

#### What could go wrong?
<!-- Before submitting: identify realistic failure scenarios and check a mitigation exists in this diff (test, flag, guard). Only keep this section if the risk is non-obvious to a reviewer. Otherwise delete it. One line per scenario: "X could happen → mitigated by Y." -->

### Quality Considerations
<!-- Edge cases, performance, privacy/security impact — omit if not applicable -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Relocates user-facing bookmark import and its SwiftSoup dependency across targets; mistakes in linkage could break HTML import despite unchanged logic and existing tests.
> 
> **Overview**
> Moves **bookmark HTML import** (`BookmarksImporter`) out of the **Core** framework and into the main **DuckDuckGo** app module, as part of shrinking Core.
> 
> The Xcode project now compiles `BookmarksImporter.swift` with the app target (under Bookmarks) instead of Core, and **SwiftSoup** is linked on **DuckDuckGo** rather than Core. `BookmarksImporter` adds `import Core` where it still needs Core types; `DataImportManager` drops its Core import because the importer lives in-app.
> 
> Tests and performance suites switch from `@testable import Core` to `@testable import DuckDuckGo` for importer-related coverage; import behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3fa0621d2f2b30fec14396388f392d63ee305a75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->