### PR TITLE
Danger check test PR

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -22,4 +22,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           npx --yes -p danger@13.0.4 -p typescript@6 -- \
-            danger ci --dangerfile duckduckgo/danger-settings/org/allPRs.ts@main
+            danger ci --dangerfile duckduckgo/danger-settings/org/allPRs.ts@mariusz/harden-feature-flag-file-matching

--- a/iOS/LocalPackages/FeatureFlags-iOS/Sources/FeatureFlags/FeatureFlag.swift
+++ b/iOS/LocalPackages/FeatureFlags-iOS/Sources/FeatureFlags/FeatureFlag.swift
@@ -21,6 +21,8 @@ import Foundation
 import PrivacyConfig
 
 public enum FeatureFlag: String {
+    case dangerCheckProbe
+
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1211866605041091
     case sync
 


### PR DESCRIPTION
Only for testing https://github.com/duckduckgo/danger-settings/pull/29.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI configuration and a probe enum case; the main risk is accidentally merging the temporary Danger branch pin, which would affect Danger behavior on all PRs.
> 
> **Overview**
> This is a **Danger validation PR**: it exercises updated org Danger rules for **feature-flag file matching** without shipping product behavior.
> 
> The **Shared - Danger JS** workflow now loads `allPRs.ts` from the branch `mariusz/harden-feature-flag-file-matching` instead of `main`, so CI on this PR runs the in-progress Danger settings.
> 
> On iOS, a new `FeatureFlag` enum case **`dangerCheckProbe`** is added so the Danger check can detect a feature-flag change in `FeatureFlag.swift`. That case is only for the probe; it is not described as user-facing functionality in this diff.
> 
> **Before merge:** revert the workflow dangerfile ref to `@main` unless the branch is intentionally promoted org-wide.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4b6fee5934eca824ee9f7996a4d4eca0c2f60d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->