### PR TITLE
iOS: Select existing search queries when unified input opens

### DIFF
--- a/iOS/AtbUITests/FloatingUIXCUITests.swift
+++ b/iOS/AtbUITests/FloatingUIXCUITests.swift
@@ -123,6 +123,37 @@ class FloatingUIXCUITestCase: XCTestCase {
         assertConfiguredBarPosition()
     }
 
+    func verifyExistingSearchReplacement(toggleEnabled: Bool) {
+        app.terminate()
+        launchApp(toggleEnabled: toggleEnabled)
+        searchField.tap()
+        XCTAssertTrue(element(withIdentifier: AccessibilityID.utiDismiss).waitForHittable(timeout: timeout))
+        XCTAssertEqual(element(withIdentifier: "AddressBar.Button.DuckAI").isHittable, toggleEnabled)
+        searchField.typeText("original query\r")
+        XCTAssertTrue(app.staticTexts[Page.oneHeading].waitForExistence(timeout: timeout))
+        XCTAssertTrue(element(withIdentifier: AccessibilityID.utiDismiss).waitForNotHittable(timeout: timeout))
+
+        for returnsFromBackground in [false, true] {
+            if returnsFromBackground {
+                XCUIDevice.shared.press(.home)
+                XCTAssertTrue(app.wait(for: .runningBackground, timeout: timeout))
+                app.activate()
+            }
+
+            XCTAssertTrue(searchField.waitForHittable(timeout: timeout))
+            searchField.tap()
+            XCTAssertTrue(element(withIdentifier: AccessibilityID.utiDismiss).waitForHittable(timeout: timeout))
+            XCTAssertTrue(app.keyboards.firstMatch.waitForExistence(timeout: timeout))
+            XCTAssertEqual(searchField.value as? String, "original query")
+
+            searchField.typeText("replacement query")
+            XCTAssertEqual(searchField.value as? String, "replacement query")
+
+            element(withIdentifier: AccessibilityID.utiDismiss).tap()
+            XCTAssertTrue(element(withIdentifier: AccessibilityID.utiDismiss).waitForNotHittable(timeout: timeout))
+        }
+    }
+
     func verifyTabSwitcherTransitions() {
         tabSwitcherButton.tap()
 
@@ -464,7 +495,7 @@ class FloatingUIXCUITestCase: XCTestCase {
         app.webViews.firstMatch
     }
 
-    private func launchApp() {
+    private func launchApp(toggleEnabled: Bool? = nil) {
         app.launchArguments = [
             "-clearAllDefaults",
             "isRunningUITests",
@@ -474,6 +505,12 @@ class FloatingUIXCUITestCase: XCTestCase {
             "-AppleLanguages", "(en)",
             "-AppleLocale", "en_GB",
         ]
+        if let toggleEnabled {
+            app.launchArguments += [
+                "-aichat.settings.isEnabled", "true",
+                "-aichat.settings.showAIChatExperimentalSearchInput", String(toggleEnabled),
+            ]
+        }
         app.launchEnvironment = [
             "UITEST_MODE": "1",
             "BASE_URL": serverBaseURL,
@@ -710,6 +747,9 @@ final class FloatingUITopBarTests: FloatingUIXCUITestCase {
 
     override var barPosition: FloatingUIBarPosition { .top }
 
+    func testExistingSearchReplacementWithToggleEnabled() { verifyExistingSearchReplacement(toggleEnabled: true) }
+    func testExistingSearchReplacementWithToggleDisabled() { verifyExistingSearchReplacement(toggleEnabled: false) }
+
     func testUnifiedToggleInputTransitions() { verifyUnifiedToggleInputTransitions() }
     func testTabSwitcherTransitions() { verifyTabSwitcherTransitions() }
     func testBrowserChromeLongPressMenus() { verifyBrowserChromeLongPressMenus() }
@@ -734,6 +774,9 @@ final class FloatingUITopBarTests: FloatingUIXCUITestCase {
 final class FloatingUIBottomBarTests: FloatingUIXCUITestCase {
 
     override var barPosition: FloatingUIBarPosition { .bottom }
+
+    func testExistingSearchReplacementWithToggleEnabled() { verifyExistingSearchReplacement(toggleEnabled: true) }
+    func testExistingSearchReplacementWithToggleDisabled() { verifyExistingSearchReplacement(toggleEnabled: false) }
 
     func testUnifiedToggleInputTransitions() { verifyUnifiedToggleInputTransitions() }
     func testTabSwitcherTransitions() { verifyTabSwitcherTransitions() }

--- a/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
+++ b/iOS/DuckDuckGo/AIChat/InputBox/SwitchBar/TextEntry/SwitchBarTextEntryView.swift
@@ -986,17 +986,6 @@ class SwitchBarTextEntryView: UIView {
         }
     }
 
-    func moveCaretToStart() {
-        if usesTextField {
-            let start = textField.beginningOfDocument
-            textField.selectedTextRange = textField.textRange(from: start, to: start)
-        } else {
-            let start = textView.beginningOfDocument
-            textView.selectedTextRange = textView.textRange(from: start, to: start)
-            textView.scrollRangeToVisible(NSRange(location: 0, length: 0))
-        }
-    }
-
     func setQueryText(_ text: String) {
         if usesTextField {
             textField.text = text

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -5798,7 +5798,7 @@ extension MainViewController: OmniBarDelegate {
     func onTextFieldDidBeginEditing(_ omniBar: OmniBarView) -> Bool {
 
         let selectQueryText = !(isSERPPresented && !skipSERPFlow)
-        skipSERPFlow = false
+        resetSERPFlowAfterOmnibarFocus()
         
         if !daxDialogsManager.shouldShowFireButtonPulse {
             ViewHighlighter.hideAll()
@@ -5807,10 +5807,8 @@ extension MainViewController: OmniBarDelegate {
         return selectQueryText
     }
 
-    func shouldAutoSelectTextForSERPQuery() -> Bool {
-        let shouldSelect = isSERPPresented && skipSERPFlow
+    func resetSERPFlowAfterOmnibarFocus() {
         skipSERPFlow = false
-        return shouldSelect
     }
 
     func onRefreshPressed() {

--- a/iOS/DuckDuckGo/OmniBarDelegate.swift
+++ b/iOS/DuckDuckGo/OmniBarDelegate.swift
@@ -118,9 +118,6 @@ protocol OmniBarDelegate: AnyObject {
     /// Called when text changes in the AI Chat text view (iPad tab mode), for filtering chat history suggestions.
     func onAIChatQueryUpdated(_ query: String)
 
-    /// Returns whether search query text on a SERP should be auto-selected in the experimental address bar.
-    func shouldAutoSelectTextForSERPQuery() -> Bool
-
     // MARK: - Experimental Address Bar
     func onExperimentalAddressBarTapped()
     func onExperimentalAddressBarClearPressed()
@@ -247,8 +244,6 @@ extension OmniBarDelegate {
     func onOmniBarExpandedContentSizeChanged() {}
 
     func onAIChatQueryUpdated(_ query: String) {}
-
-    func shouldAutoSelectTextForSERPQuery() -> Bool { false }
 
     // Default no-op implementations for experimental address bar pixel hooks
     func onExperimentalAddressBarTapped() {}

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
@@ -1275,19 +1275,18 @@ extension MainViewController: UnifiedToggleInputOmnibarActivating {
         coordinator.updateInputMode(inputMode, animated: false)
         let isToggleEnabled = isAIChatSearchInputToggleEnabledForCurrentOnboardingState()
         coordinator.updateToggleEnabled(isToggleEnabled)
+        resetSERPFlowForQuery(currentText)
         coordinator.activateFromOmnibar(prefilledText: currentText,
-                                        shouldSelectAllText: shouldAutoSelectOmnibarText(currentText),
                                         inputMode: inputMode,
                                         cardPosition: position)
         return .intercept
     }
 
-    private func shouldAutoSelectOmnibarText(_ text: String?) -> Bool {
-        guard let text = text?.trimmingWhitespace(), !text.isEmpty else { return false }
-        if URL(trimmedAddressBarString: text, useUnifiedLogic: isUnifiedURLPredictionEnabled) != nil {
-            return true
-        }
-        return shouldAutoSelectTextForSERPQuery()
+    private func resetSERPFlowForQuery(_ text: String?) {
+        guard let text = text?.trimmingWhitespace(),
+              !text.isEmpty,
+              URL(trimmedAddressBarString: text, useUnifiedLogic: isUnifiedURLPredictionEnabled) == nil else { return }
+        resetSERPFlowAfterOmnibarFocus()
     }
 }
 

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputCoordinator.swift
@@ -1017,7 +1017,7 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
 
     // MARK: - Omnibar State
 
-    func activateFromOmnibar(prefilledText: String? = nil, shouldSelectAllText: Bool = true, inputMode: TextEntryMode = .search, cardPosition: UnifiedToggleInputCardPosition = .top) {
+    func activateFromOmnibar(prefilledText: String? = nil, inputMode: TextEntryMode = .search, cardPosition: UnifiedToggleInputCardPosition = .top) {
         keyboardMonitor.arm(awaiting: cardPosition == .top)
         displayState = .omnibar(.active)
         if host == .omnibar {
@@ -1042,15 +1042,12 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
 
         // Set text before apply so clearDismissSnapshot sees the correct handler state when
         // it fires inside applyCardLayout — otherwise textRightInset starts at the no-button value.
-        let selectsAllText: Bool
         if let text = prefilledText, !text.isEmpty {
             textModel.setText(text)
             textModel.markPrefilledSelected()
             omnibarPrefilledText = text
-            selectsAllText = shouldSelectAllText
         } else {
             omnibarPrefilledText = nil
-            selectsAllText = false
         }
         updateFloatingReturnKeyState()
 
@@ -1075,11 +1072,7 @@ final class UnifiedToggleInputCoordinator: NSObject, AIChatInputBoxHandling {
             guard omnibarPrefilledText != nil else { return }
             DispatchQueue.main.async { [weak self] in
                 guard let self, isOmnibarEditing else { return }
-                if selectsAllText {
-                    viewController.selectAllText()
-                } else {
-                    viewController.moveCaretToStart()
-                }
+                viewController.selectAllText()
             }
         }
     }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
@@ -993,10 +993,6 @@ final class UnifiedToggleInputView: UIView {
         textEntryView.selectAllText()
     }
 
-    func moveCaretToStart() {
-        textEntryView.moveCaretToStart()
-    }
-
     var placeholderWindowX: CGFloat? { textEntryView.placeholderWindowX }
 
     var defaultPlaceholderColor: UIColor { textEntryView.defaultPlaceholderColor }

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputViewController.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputViewController.swift
@@ -385,10 +385,6 @@ final class UnifiedToggleInputViewController: UIViewController {
         inputBarView.selectAllText()
     }
 
-    func moveCaretToStart() {
-        inputBarView.moveCaretToStart()
-    }
-
     var placeholderWindowX: CGFloat? { inputBarView.placeholderWindowX }
 
     var defaultPlaceholderColor: UIColor { inputBarView.defaultPlaceholderColor }

--- a/iOS/DuckDuckGoTests/QuerySubmittedTests.swift
+++ b/iOS/DuckDuckGoTests/QuerySubmittedTests.swift
@@ -274,8 +274,6 @@ final class MockOmniBarDelegate: OmniBarDelegate {
 
     func onEditFavorite(_ favorite: Bookmarks.BookmarkEntity) {}
 
-    func shouldAutoSelectTextForSERPQuery() -> Bool { false }
-    
     func isCurrentTabFireTab() -> Bool { false }
 
 }

--- a/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputCoordinatorTests.swift
+++ b/iOS/DuckDuckGoTests/UnifiedToggleInput/UnifiedToggleInputCoordinatorTests.swift
@@ -806,6 +806,35 @@ final class UnifiedToggleInputCoordinatorTests: XCTestCase {
         XCTAssertEqual(sut.textState, .prefilledSelected)
     }
 
+    func test_activateFromOmnibar_withPrefilledTextAndToggleEnabled_selectsAllText() throws {
+        let text = "test query"
+        sut.updateToggleEnabled(true)
+        sut.activateFromOmnibar(prefilledText: text)
+        let textField = try XCTUnwrap(firstDescendant(of: UITextField.self, in: sut.viewController.view))
+
+        XCTAssertFalse(textField.isHidden)
+        assertAllTextIsSelected(in: textField, expectedLength: text.utf16.count)
+    }
+
+    func test_activateFromOmnibar_withPrefilledAIChatText_selectsAllText() throws {
+        let text = "test prompt"
+        sut.activateFromOmnibar(prefilledText: text, inputMode: .aiChat)
+        let textView = try XCTUnwrap(firstDescendant(of: UITextView.self, in: sut.viewController.view))
+
+        XCTAssertFalse(textView.isHidden)
+        assertAllTextIsSelected(in: textView, expectedLength: text.utf16.count)
+    }
+
+    func test_activateFromOmnibar_withPrefilledTextAndToggleDisabled_selectsAllText() throws {
+        let text = "test query"
+        sut.updateToggleEnabled(false)
+        sut.activateFromOmnibar(prefilledText: text)
+        let textField = try XCTUnwrap(firstDescendant(of: UITextField.self, in: sut.viewController.view))
+
+        XCTAssertFalse(textField.isHidden)
+        assertAllTextIsSelected(in: textField, expectedLength: text.utf16.count)
+    }
+
     func test_activateFromOmnibar_toggleDisabled_forcesSearchMode() {
         sut.updateToggleEnabled(false)
         sut.activateFromOmnibar(inputMode: .aiChat)
@@ -3203,6 +3232,35 @@ final class UnifiedToggleInputCoordinatorTests: XCTestCase {
         coord.unifiedToggleInputVC(coord.viewController, isDraggingToggle: false)
 
         XCTAssertFalse(coord.contentViewController.isSwipeEnabled, "Restoring after a drag must not enable swipe when the toggle is hidden")
+    }
+
+    private func assertAllTextIsSelected(in textInput: UIView & UITextInput, expectedLength: Int, file: StaticString = #filePath, line: UInt = #line) {
+        let expectation = expectation(description: "All prefilled text selected")
+        DispatchQueue.main.async {
+            DispatchQueue.main.async {
+                guard let selectedRange = textInput.selectedTextRange else {
+                    XCTFail("Expected a selected text range", file: file, line: line)
+                    expectation.fulfill()
+                    return
+                }
+                XCTAssertEqual(textInput.offset(from: textInput.beginningOfDocument, to: selectedRange.start), 0, file: file, line: line)
+                XCTAssertEqual(textInput.offset(from: selectedRange.start, to: selectedRange.end), expectedLength, file: file, line: line)
+                expectation.fulfill()
+            }
+        }
+        waitForExpectations(timeout: 1)
+    }
+
+    private func firstDescendant<View: UIView>(of type: View.Type, in view: UIView) -> View? {
+        for subview in view.subviews {
+            if let match = subview as? View {
+                return match
+            }
+            if let match = firstDescendant(of: type, in: subview) {
+                return match
+            }
+        }
+        return nil
     }
 
     /// Mirrors `test_syncInputModeFromExternalSource_toggleDisabled_forcesAIChatInAITabSession`


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206488453854252/task/1217128605643788

### Description

Always select the full existing search query when Unified Toggle Input opens, so typing replaces it instead of inserting at the beginning. Applies with the Search/Duck.ai toggle enabled or disabled.

### Testing Steps

On iPhone, run the query checks with the toggle enabled, then disabled; cover both top and bottom address-bar positions before changing the toggle setting.

**Query editing (new behavior)**

1. Submit a search, using a long query for one pass.
2. Tap the address bar → the entire query is selected.
3. Type a replacement query → it replaces the entire selection.
4. Submit the replacement query.
5. Background the app.
6. Reopen the app.
7. Tap the address bar → the entire query is selected again.
8. Press Backspace → the field clears.

**Regression checks (once)**

1. Submit another search.
2. Tap the address bar → all text is selected.
3. Tap within the selected query → a caret appears for precise editing.
4. Type a character → it edits at the caret rather than replacing the query.
5. Navigate to a website.
6. Tap the address bar → the full URL is still selected.
7. Open a new tab.
8. Tap the empty input → typing works normally.

Added unit selection checks and UI regression tests for query replacement after search and background/foreground, with toggle on/off and both bar positions. Local build/test execution is blocked by Beekeeper's approval policy; manual checks above are pending.

### Impact

Low: affects initial text selection when editing an existing search.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized omnibar/UTI focus and selection behavior; legacy omnibar SERP select logic is largely unchanged aside from SERP-flow reset naming.
> 
> **Overview**
> **Unified Toggle Input** now **always selects the full prefilled address-bar text** when editing opens (search or Duck.ai, toggle on or off), so the next keystroke **replaces** the query instead of inserting at the start. The `shouldSelectAllText` flag, **caret-at-start** path, and **`shouldAutoSelectTextForSERPQuery`** delegate hook are removed; **`activateFromOmnibar`** always calls **`selectAllText()`** after focus.
> 
> SERP **skip-flow** is reset via **`resetSERPFlowAfterOmnibarFocus`** / **`resetSERPFlowForQuery`** when reopening with a non-URL query, without driving a separate auto-select decision on the UTI path.
> 
> **Tests:** new **Floating UI** UI scenarios (toggle on/off, top/bottom bar, background/foreground) and **coordinator** unit checks that prefilled text ends fully selected in both `UITextField` and `UITextView`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10310859a3cb66b08b31c3b74cd18c174bb94260. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->