### PR TITLE
Add a base controller for the redesigned New Tab Page

### DIFF
--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -6469,15 +6469,15 @@ extension MainViewController: EscapeHatchActionRouter {
 
 extension MainViewController: NewTabPageControllerDelegate {
 
-    func newTabPageDidSelectFavorite(_ controller: NewTabPageViewController, favorite: BookmarkEntity) {
+    func newTabPageDidSelectFavorite(_ controller: any NewTabPage, favorite: BookmarkEntity) {
         self.onSelectFavorite(favorite)
     }
 
-    func newTabPageDidScroll(_ controller: NewTabPageViewController) {
+    func newTabPageDidScroll(_ controller: any NewTabPage) {
         recordNewTabPageSessionAction { $0.scrollView() }
     }
 
-    func newTabPage(_ controller: NewTabPageViewController, didInteractWithMessage interaction: NewTabPageMessageInteraction) {
+    func newTabPage(_ controller: any NewTabPage, didInteractWithMessage interaction: NewTabPageMessageInteraction) {
         recordNewTabPageSessionAction { instrumentation in
             switch interaction {
             case .callToAction: instrumentation.clickMessageCta()
@@ -6486,15 +6486,15 @@ extension MainViewController: NewTabPageControllerDelegate {
         }
     }
 
-    func newTabPageDidEditFavorite(_ controller: NewTabPageViewController, favorite: BookmarkEntity) {
+    func newTabPageDidEditFavorite(_ controller: any NewTabPage, favorite: BookmarkEntity) {
         segueToEditBookmark(favorite)
     }
 
-    func newTabPageDidRequestFaviconsFetcherOnboarding(_ controller: NewTabPageViewController) {
+    func newTabPageDidRequestFaviconsFetcherOnboarding(_ controller: any NewTabPage) {
         faviconsFetcherOnboarding.presentOnboardingIfNeeded(from: self)
     }
 
-    func newTabPageDidRequestSwitchToTab(_ controller: NewTabPageViewController, tab: Tab) {
+    func newTabPageDidRequestSwitchToTab(_ controller: any NewTabPage, tab: Tab) {
         let targetTabsModel = tabManager.tabsModel(for: tab.mode)
         guard targetTabsModel.tabExists(tab: tab) else {
             clearEscapeHatch()
@@ -6512,12 +6512,12 @@ extension MainViewController: NewTabPageControllerDelegate {
         clearEscapeHatch()
     }
 
-    func newTabPageDidRequestTabSwitcher(_ controller: NewTabPageViewController) {
+    func newTabPageDidRequestTabSwitcher(_ controller: any NewTabPage) {
         ntpAfterIdleInstrumentation.escapeHatchTabSwitcherTapped()
         requestTabSwitcher()
     }
 
-    func newTabPageDidDismissDuckAIFireOnboardingCompletion(_ controller: NewTabPageViewController) {
+    func newTabPageDidDismissDuckAIFireOnboardingCompletion(_ controller: any NewTabPage) {
         markSearchContextualOnboardingAsSeen()
     }
 

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -176,7 +176,8 @@ class MainViewController: UIViewController {
                                                            aiChatSettings: aiChatSettings,
                                                            subscriptionManager: subscriptionManager,
                                                            internalUserCommands: internalUserCommands,
-                                                           floatingUIManager: floatingUIManager)
+                                                           floatingUIManager: floatingUIManager,
+                                                           redesignFeature: NewTabPageRedesignFeature(featureFlagger: featureFlagger))
 
     var tabsBarController: TabsBarViewController?
     var suggestionTrayController: SuggestionTrayViewController?

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -160,7 +160,7 @@ class MainViewController: UIViewController {
         return emailManager
     }()
 
-    var newTabPageViewController: NewTabPageViewController?
+    var newTabPageViewController: (any NewTabPage)?
 
     var tabsBarController: TabsBarViewController?
     var suggestionTrayController: SuggestionTrayViewController?
@@ -6773,7 +6773,7 @@ extension MainViewController: TabDelegate {
         // on every dismissal path.
         newTabPageViewController?.view.alpha = 0
         DispatchQueue.main.async { [weak self] in
-            self?.newTabPageViewController?.showDuckAIOnboardingCompletionWithActiveAddressBar(message: message)
+            self?.newTabPageViewController?.showDuckAIOnboardingCompletionWithActiveAddressBar(message: message, textEntryMode: nil)
         }
     }
     

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -162,6 +162,22 @@ class MainViewController: UIViewController {
 
     var newTabPageViewController: (any NewTabPage)?
 
+    private lazy var newTabPageBuilder = NewTabPageBuilder(favoritesInteractionModel: favoritesViewModel,
+                                                           homePageMessagesConfiguration: homePageConfiguration,
+                                                           subscriptionDataReporting: subscriptionDataReporter,
+                                                           daxDialogsManager: daxDialogsManager,
+                                                           onboardingFlowProvider: onboardingManager,
+                                                           faviconLoader: faviconLoader,
+                                                           faviconsCache: favicons,
+                                                           remoteMessagingActionHandler: remoteMessagingActionHandler,
+                                                           remoteMessagingImageLoader: remoteMessagingImageLoader,
+                                                           remoteMessagingPixelReporter: remoteMessagingPixelReporter,
+                                                           appSettings: appSettings,
+                                                           aiChatSettings: aiChatSettings,
+                                                           subscriptionManager: subscriptionManager,
+                                                           internalUserCommands: internalUserCommands,
+                                                           floatingUIManager: floatingUIManager)
+
     var tabsBarController: TabsBarViewController?
     var suggestionTrayController: SuggestionTrayViewController?
 
@@ -2209,29 +2225,10 @@ class MainViewController: UIViewController {
         }
 
         let newTabDaxDialogFactory = NewTabDaxDialogFactory(delegate: self, daxDialogsFlowCoordinator: daxDialogsManager, onboardingPixelReporter: contextualOnboardingPixelReporter)
-        let narrowLayoutInLandscape = aiChatSettings.isAIChatSearchInputUserSettingsEnabled
 
-        let controller = NewTabPageViewController(isFocussedState: false,
-                                                  openedAfterIdle: hatch != nil,
-                                                  dismissKeyboardOnScroll: true,
-                                                  tab: tabModel,
-                                                  interactionModel: favoritesViewModel,
-                                                  homePageMessagesConfiguration: homePageConfiguration,
-                                                  subscriptionDataReporting: subscriptionDataReporter,
-                                                  newTabDialogFactory: newTabDaxDialogFactory,
-                                                  daxDialogsManager: daxDialogsManager,
-                                                  onboardingFlowProvider: onboardingManager,
-                                                  faviconLoader: faviconLoader,
-                                                  remoteMessagingActionHandler: remoteMessagingActionHandler,
-                                                  remoteMessagingImageLoader: remoteMessagingImageLoader,
-                                                  remoteMessagingPixelReporter: remoteMessagingPixelReporter,
-                                                  appSettings: appSettings,
-                                                  faviconsCache: favicons,
-                                                  subscriptionManager: subscriptionManager,
-                                                  internalUserCommands: internalUserCommands,
-                                                  narrowLayoutInLandscape: narrowLayoutInLandscape,
-                                                  floatingUIManager: floatingUIManager
-        )
+        let controller = newTabPageBuilder.makeNewTabPage(tab: tabModel,
+                                                          openedAfterIdle: hatch != nil,
+                                                          daxDialogFactory: newTabDaxDialogFactory)
 
         controller.delegate = self
         controller.chromeDelegate = self

--- a/iOS/DuckDuckGo/NewTabPage/NewTabPage.swift
+++ b/iOS/DuckDuckGo/NewTabPage/NewTabPage.swift
@@ -83,7 +83,5 @@ protocol NewTabPage: UIViewController,
     /// `UIViewController.dismiss(animated:completion:)`.
     func dismiss()
 
-    /// Width decides part of the page's framing, so a resize has to be pushed in rather than
-    /// observed.
     func widthChanged()
 }

--- a/iOS/DuckDuckGo/NewTabPage/NewTabPage.swift
+++ b/iOS/DuckDuckGo/NewTabPage/NewTabPage.swift
@@ -19,12 +19,71 @@
 
 import UIKit
 
-protocol NewTabPage: UIViewController {
+/// Content state used to hand off to and from the focused input.
+protocol NewTabPageContentHandoff {
+
+    /// Live visibility, including any override applied below.
+    var isShowingLogo: Bool { get }
+    var isShowingFavorites: Bool { get }
+
+    /// Visibility ignoring the overrides, so a dismissal can pick its handoff while an
+    /// override is still mid-transition.
+    var restingContentIsLogo: Bool { get }
+    var restingContentIsFavorites: Bool { get }
+
+    /// Overrides visibility for the duration of a handoff.
+    func setLogoHidden(_ hidden: Bool)
+    func setFavoritesHidden(_ hidden: Bool)
+}
+
+protocol NewTabPageChromeAdapting {
+
+    /// Suppression covers chrome that overlays the page surface, where the page's own framing
+    /// border would show as an artifact against it.
+    func setChromeLayoutContext(isBorderSuppressed: Bool)
+}
+
+/// The return-to-tab card shown after an idle period. A nil model means no card.
+protocol NewTabPageEscapeHatchPresenting {
+
+    func setEscapeHatch(_ model: EscapeHatchModel?)
+}
+
+/// Contextual onboarding and Duck.ai completion dialogs hosted over the New Tab Page.
+protocol NewTabPageOnboardingPresenting {
+
+    func showNextDaxDialog()
+
+    /// Advances the dialog sequence at the end of linear onboarding.
+    func onboardingCompleted()
+
+    /// Presents over an active address bar editing session, which `textEntryMode` configures.
+    func showDuckAIOnboardingCompletionWithActiveAddressBar(message: String, textEntryMode: TextEntryMode?)
+
+    /// Re-runs the hosted dialog's top inset after the caller changes what sits above it.
+    func refreshContextualOnboardingDialogLayout()
+
+    /// Ending an address bar editing session is what dismisses the Duck.ai completion dialog.
+    func dismissDuckAICompletionDialogIfNeededOnEditingEnd()
+}
+
+protocol NewTabPage: UIViewController,
+                     HomeScreenTransitionSource,
+                     NewTabPageContentHandoff,
+                     NewTabPageChromeAdapting,
+                     NewTabPageEscapeHatchPresenting,
+                     NewTabPageOnboardingPresenting {
 
     var isDragging: Bool { get }
 
+    var delegate: NewTabPageControllerDelegate? { get set }
+    var chromeDelegate: BrowserChromeDelegate? { get set }
+
+    /// Tears the page down and detaches it from its parent. Unrelated to
+    /// `UIViewController.dismiss(animated:completion:)`.
     func dismiss()
 
-    func showNextDaxDialog()
-    func onboardingCompleted()
+    /// Width decides part of the page's framing, so a resize has to be pushed in rather than
+    /// observed.
+    func widthChanged()
 }

--- a/iOS/DuckDuckGo/NewTabPage/NewTabPageBuilder.swift
+++ b/iOS/DuckDuckGo/NewTabPage/NewTabPageBuilder.swift
@@ -25,8 +25,7 @@ import Onboarding
 import RemoteMessaging
 import Subscription
 
-/// Builds the New Tab Page shown in a browser tab, holding the dependencies that outlive any single
-/// page so that the choice of implementation is made in one place.
+/// Builds the New Tab Page shown in a browser tab.
 struct NewTabPageBuilder {
 
     let favoritesInteractionModel: FavoritesListInteracting
@@ -45,8 +44,7 @@ struct NewTabPageBuilder {
     let internalUserCommands: URLBasedDebugCommands
     let floatingUIManager: FloatingUIManaging
 
-    /// `daxDialogFactory` is supplied per page because it holds a reference back to the presenting
-    /// view controller.
+    /// `daxDialogFactory` is supplied per page rather than stored.
     func makeNewTabPage(tab: Tab,
                         openedAfterIdle: Bool,
                         daxDialogFactory: any NewTabDaxDialogProviding) -> any NewTabPage {
@@ -68,7 +66,7 @@ struct NewTabPageBuilder {
                                  faviconsCache: faviconsCache,
                                  subscriptionManager: subscriptionManager,
                                  internalUserCommands: internalUserCommands,
-                                 // Read per page: the user can change this setting while the app runs.
+                                 // Read per page: the setting can change while the app runs.
                                  narrowLayoutInLandscape: aiChatSettings.isAIChatSearchInputUserSettingsEnabled,
                                  floatingUIManager: floatingUIManager)
     }

--- a/iOS/DuckDuckGo/NewTabPage/NewTabPageBuilder.swift
+++ b/iOS/DuckDuckGo/NewTabPage/NewTabPageBuilder.swift
@@ -43,11 +43,32 @@ struct NewTabPageBuilder {
     let subscriptionManager: any SubscriptionManager
     let internalUserCommands: URLBasedDebugCommands
     let floatingUIManager: FloatingUIManaging
+    let redesignFeature: NewTabPageRedesignFeatureProviding
 
     /// `daxDialogFactory` is supplied per page rather than stored.
     func makeNewTabPage(tab: Tab,
                         openedAfterIdle: Bool,
                         daxDialogFactory: any NewTabDaxDialogProviding) -> any NewTabPage {
+        // Fire tabs are excluded because their empty state is drawn elsewhere and would cover the
+        // page.
+        if !tab.fireTab, redesignFeature.isAvailable {
+            return makeRedesignedNewTabPage()
+        }
+
+        return makeCurrentNewTabPage(tab: tab,
+                                     openedAfterIdle: openedAfterIdle,
+                                     daxDialogFactory: daxDialogFactory)
+    }
+
+    private func makeRedesignedNewTabPage() -> any NewTabPage {
+        RedesignedNewTabPageViewController(blocks: [
+            SwiftUIBlock(id: "daxLogo", rootView: NewTabPageDaxLogoView())
+        ])
+    }
+
+    private func makeCurrentNewTabPage(tab: Tab,
+                                       openedAfterIdle: Bool,
+                                       daxDialogFactory: any NewTabDaxDialogProviding) -> any NewTabPage {
         NewTabPageViewController(isFocussedState: false,
                                  openedAfterIdle: openedAfterIdle,
                                  dismissKeyboardOnScroll: true,

--- a/iOS/DuckDuckGo/NewTabPage/NewTabPageBuilder.swift
+++ b/iOS/DuckDuckGo/NewTabPage/NewTabPageBuilder.swift
@@ -1,0 +1,75 @@
+//
+//  NewTabPageBuilder.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import AIChat
+import Bookmarks
+import BrowserServicesKit
+import Core
+import Onboarding
+import RemoteMessaging
+import Subscription
+
+/// Builds the New Tab Page shown in a browser tab, holding the dependencies that outlive any single
+/// page so that the choice of implementation is made in one place.
+struct NewTabPageBuilder {
+
+    let favoritesInteractionModel: FavoritesListInteracting
+    let homePageMessagesConfiguration: HomePageMessagesConfiguration
+    let subscriptionDataReporting: SubscriptionDataReporting
+    let daxDialogsManager: DaxDialogsManaging
+    let onboardingFlowProvider: OnboardingFlowProviding
+    let faviconLoader: FavoritesFaviconLoading
+    let faviconsCache: FavoritesFaviconCaching
+    let remoteMessagingActionHandler: RemoteMessagingActionHandling
+    let remoteMessagingImageLoader: RemoteMessagingImageLoading
+    let remoteMessagingPixelReporter: RemoteMessagingPixelReporting?
+    let appSettings: AppSettings
+    let aiChatSettings: AIChatSettingsProvider
+    let subscriptionManager: any SubscriptionManager
+    let internalUserCommands: URLBasedDebugCommands
+    let floatingUIManager: FloatingUIManaging
+
+    /// `daxDialogFactory` is supplied per page because it holds a reference back to the presenting
+    /// view controller.
+    func makeNewTabPage(tab: Tab,
+                        openedAfterIdle: Bool,
+                        daxDialogFactory: any NewTabDaxDialogProviding) -> any NewTabPage {
+        NewTabPageViewController(isFocussedState: false,
+                                 openedAfterIdle: openedAfterIdle,
+                                 dismissKeyboardOnScroll: true,
+                                 tab: tab,
+                                 interactionModel: favoritesInteractionModel,
+                                 homePageMessagesConfiguration: homePageMessagesConfiguration,
+                                 subscriptionDataReporting: subscriptionDataReporting,
+                                 newTabDialogFactory: daxDialogFactory,
+                                 daxDialogsManager: daxDialogsManager,
+                                 onboardingFlowProvider: onboardingFlowProvider,
+                                 faviconLoader: faviconLoader,
+                                 remoteMessagingActionHandler: remoteMessagingActionHandler,
+                                 remoteMessagingImageLoader: remoteMessagingImageLoader,
+                                 remoteMessagingPixelReporter: remoteMessagingPixelReporter,
+                                 appSettings: appSettings,
+                                 faviconsCache: faviconsCache,
+                                 subscriptionManager: subscriptionManager,
+                                 internalUserCommands: internalUserCommands,
+                                 // Read per page: the user can change this setting while the app runs.
+                                 narrowLayoutInLandscape: aiChatSettings.isAIChatSearchInputUserSettingsEnabled,
+                                 floatingUIManager: floatingUIManager)
+    }
+}

--- a/iOS/DuckDuckGo/NewTabPage/NewTabPageControllerDelegate.swift
+++ b/iOS/DuckDuckGo/NewTabPage/NewTabPageControllerDelegate.swift
@@ -27,18 +27,18 @@ enum NewTabPageMessageInteraction {
 }
 
 protocol NewTabPageControllerDelegate: AnyObject {
-    func newTabPageDidSelectFavorite(_ controller: NewTabPageViewController, favorite: BookmarkEntity)
-    func newTabPageDidEditFavorite(_ controller: NewTabPageViewController, favorite: BookmarkEntity)
-    func newTabPageDidRequestFaviconsFetcherOnboarding(_ controller: NewTabPageViewController)
-    func newTabPageDidRequestSwitchToTab(_ controller: NewTabPageViewController, tab: Tab)
-    func newTabPageDidRequestTabSwitcher(_ controller: NewTabPageViewController)
-    func newTabPageDidDismissDuckAIFireOnboardingCompletion(_ controller: NewTabPageViewController)
-    func newTabPageDidScroll(_ controller: NewTabPageViewController)
-    func newTabPage(_ controller: NewTabPageViewController, didInteractWithMessage interaction: NewTabPageMessageInteraction)
+    func newTabPageDidSelectFavorite(_ controller: any NewTabPage, favorite: BookmarkEntity)
+    func newTabPageDidEditFavorite(_ controller: any NewTabPage, favorite: BookmarkEntity)
+    func newTabPageDidRequestFaviconsFetcherOnboarding(_ controller: any NewTabPage)
+    func newTabPageDidRequestSwitchToTab(_ controller: any NewTabPage, tab: Tab)
+    func newTabPageDidRequestTabSwitcher(_ controller: any NewTabPage)
+    func newTabPageDidDismissDuckAIFireOnboardingCompletion(_ controller: any NewTabPage)
+    func newTabPageDidScroll(_ controller: any NewTabPage)
+    func newTabPage(_ controller: any NewTabPage, didInteractWithMessage interaction: NewTabPageMessageInteraction)
 }
 
 extension NewTabPageControllerDelegate {
-    func newTabPageDidDismissDuckAIFireOnboardingCompletion(_ controller: NewTabPageViewController) { }
-    func newTabPageDidScroll(_ controller: NewTabPageViewController) { }
-    func newTabPage(_ controller: NewTabPageViewController, didInteractWithMessage interaction: NewTabPageMessageInteraction) { }
+    func newTabPageDidDismissDuckAIFireOnboardingCompletion(_ controller: any NewTabPage) { }
+    func newTabPageDidScroll(_ controller: any NewTabPage) { }
+    func newTabPage(_ controller: any NewTabPage, didInteractWithMessage interaction: NewTabPageMessageInteraction) { }
 }

--- a/iOS/DuckDuckGo/NewTabPage/Redesign/NewTabPageBlock.swift
+++ b/iOS/DuckDuckGo/NewTabPage/Redesign/NewTabPageBlock.swift
@@ -1,0 +1,29 @@
+//
+//  NewTabPageBlock.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import UIKit
+
+/// One unit of New Tab Page content. Blocks are stacked vertically in the order given.
+///
+/// `id` is a stable string key for the block's persisted order and visibility.
+protocol NewTabPageBlock: AnyObject, Identifiable where ID == String {
+
+    /// The block's content, installed as a child view controller of the page.
+    var viewController: UIViewController { get }
+}

--- a/iOS/DuckDuckGo/NewTabPage/Redesign/NewTabPageRedesignFeature.swift
+++ b/iOS/DuckDuckGo/NewTabPage/Redesign/NewTabPageRedesignFeature.swift
@@ -1,0 +1,48 @@
+//
+//  NewTabPageRedesignFeature.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Common
+import FeatureFlags_iOS
+import PrivacyConfig
+
+protocol NewTabPageRedesignFeatureProviding {
+
+    /// Whether the redesigned New Tab Page can be shown on this device.
+    var isAvailable: Bool { get }
+}
+
+struct NewTabPageRedesignFeature: NewTabPageRedesignFeatureProviding {
+
+    private let featureFlagger: FeatureFlagger
+    private let devicePlatform: DevicePlatformProviding.Type
+
+    init(featureFlagger: FeatureFlagger,
+         devicePlatform: DevicePlatformProviding.Type = DevicePlatform.self) {
+        self.featureFlagger = featureFlagger
+        self.devicePlatform = devicePlatform
+    }
+
+    var isAvailable: Bool {
+        // The device check comes first, and must stay first: reading the flag on a device that can
+        // never show the redesign would enrol it in the experiment cohort and dilute the results.
+        guard devicePlatform.isIphone else { return false }
+
+        return featureFlagger.isFeatureOn(.newTabPageRedesign)
+    }
+}

--- a/iOS/DuckDuckGo/NewTabPage/Redesign/RedesignedNewTabPageViewController.swift
+++ b/iOS/DuckDuckGo/NewTabPage/Redesign/RedesignedNewTabPageViewController.swift
@@ -55,7 +55,7 @@ final class RedesignedNewTabPageViewController: UIViewController, NewTabPage {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        view.backgroundColor = UIColor(designSystemColor: .background)
+        view.backgroundColor = UIColor(designSystemColor: .alertYellow)
         addSubviews()
         installBlocks()
     }

--- a/iOS/DuckDuckGo/NewTabPage/Redesign/RedesignedNewTabPageViewController.swift
+++ b/iOS/DuckDuckGo/NewTabPage/Redesign/RedesignedNewTabPageViewController.swift
@@ -1,0 +1,171 @@
+//
+//  RedesignedNewTabPageViewController.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import DesignResourcesKit
+import UIKit
+
+/// A New Tab Page built as a vertical stack of independent blocks.
+final class RedesignedNewTabPageViewController: UIViewController, NewTabPage {
+
+    weak var delegate: NewTabPageControllerDelegate?
+    weak var chromeDelegate: BrowserChromeDelegate?
+
+    var isDragging: Bool { scrollView.isDragging }
+
+    private let blocks: [any NewTabPageBlock]
+
+    private let scrollView: UIScrollView = {
+        let scrollView = UIScrollView()
+        scrollView.alwaysBounceVertical = true
+        return scrollView
+    }()
+
+    private let blocksStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .vertical
+        return stackView
+    }()
+
+    init(blocks: [any NewTabPageBlock]) {
+        self.blocks = blocks
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    @available(*, unavailable)
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        view.backgroundColor = UIColor(designSystemColor: .background)
+        addSubviews()
+        installBlocks()
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        // The page is attached with alpha 0 ahead of a contextual dialog so content cannot flash
+        // for a frame first, and is expected to restore it itself.
+        view.alpha = 1
+    }
+
+    private func addSubviews() {
+        view.addSubview(scrollView)
+        scrollView.addSubview(blocksStackView)
+
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        blocksStackView.translatesAutoresizingMaskIntoConstraints = false
+
+        NSLayoutConstraint.activate([
+            scrollView.topAnchor.constraint(equalTo: view.topAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+
+            blocksStackView.topAnchor.constraint(equalTo: scrollView.contentLayoutGuide.topAnchor),
+            blocksStackView.bottomAnchor.constraint(equalTo: scrollView.contentLayoutGuide.bottomAnchor),
+            blocksStackView.leadingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.leadingAnchor),
+            blocksStackView.trailingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.trailingAnchor),
+
+            // Pinning the content width to the visible width leaves block heights as the only
+            // thing that can make the page scroll.
+            blocksStackView.widthAnchor.constraint(equalTo: scrollView.frameLayoutGuide.widthAnchor)
+        ])
+    }
+
+    private func installBlocks() {
+        for block in blocks {
+            let blockController = block.viewController
+
+            addChild(blockController)
+            blocksStackView.addArrangedSubview(blockController.view)
+            blockController.didMove(toParent: self)
+        }
+    }
+
+    func dismiss() {
+        delegate = nil
+        chromeDelegate = nil
+
+        removeFromParent()
+        view.removeFromSuperview()
+    }
+
+    /// No content on this page is sized from the page width.
+    func widthChanged() {}
+}
+
+extension RedesignedNewTabPageViewController: HomeScreenTransitionSource {
+
+    var snapshotView: UIView { view }
+
+    var rootContainerView: UIView { view }
+}
+
+/// The logo and favorites blocks are not hosted on this page yet.
+extension RedesignedNewTabPageViewController: NewTabPageContentHandoff {
+
+    var isShowingLogo: Bool { false }
+
+    var isShowingFavorites: Bool { false }
+
+    var restingContentIsLogo: Bool { false }
+
+    var restingContentIsFavorites: Bool { false }
+
+    func setLogoHidden(_ hidden: Bool) {}
+
+    func setFavoritesHidden(_ hidden: Bool) {}
+}
+
+extension RedesignedNewTabPageViewController: NewTabPageChromeAdapting {
+
+    /// This page draws no framing border.
+    func setChromeLayoutContext(isBorderSuppressed: Bool) {}
+}
+
+extension RedesignedNewTabPageViewController: NewTabPageEscapeHatchPresenting {
+
+    /// The escape hatch will arrive as a block.
+    func setEscapeHatch(_ model: EscapeHatchModel?) {}
+}
+
+/// Contextual dialogs are not hosted on this page yet. The presentation entry points trap in debug;
+/// the two that maintain an already-visible dialog are no-ops.
+extension RedesignedNewTabPageViewController: NewTabPageOnboardingPresenting {
+
+    func showNextDaxDialog() {
+        assertionFailure("Contextual onboarding is not implemented on the redesigned New Tab Page")
+    }
+
+    func onboardingCompleted() {
+        assertionFailure("Contextual onboarding is not implemented on the redesigned New Tab Page")
+    }
+
+    func showDuckAIOnboardingCompletionWithActiveAddressBar(message: String, textEntryMode: TextEntryMode?) {
+        assertionFailure("Contextual onboarding is not implemented on the redesigned New Tab Page")
+    }
+
+    func refreshContextualOnboardingDialogLayout() {}
+
+    func dismissDuckAICompletionDialogIfNeededOnEditingEnd() {}
+}

--- a/iOS/DuckDuckGo/NewTabPage/Redesign/RedesignedNewTabPageViewController.swift
+++ b/iOS/DuckDuckGo/NewTabPage/Redesign/RedesignedNewTabPageViewController.swift
@@ -149,8 +149,7 @@ extension RedesignedNewTabPageViewController: NewTabPageEscapeHatchPresenting {
     func setEscapeHatch(_ model: EscapeHatchModel?) {}
 }
 
-/// Contextual dialogs are not hosted on this page yet. The presentation entry points trap in debug;
-/// the two that maintain an already-visible dialog are no-ops.
+/// Contextual dialogs are not hosted on this page yet.
 extension RedesignedNewTabPageViewController: NewTabPageOnboardingPresenting {
 
     func showNextDaxDialog() {

--- a/iOS/DuckDuckGo/NewTabPage/Redesign/SwiftUIBlock.swift
+++ b/iOS/DuckDuckGo/NewTabPage/Redesign/SwiftUIBlock.swift
@@ -1,0 +1,40 @@
+//
+//  SwiftUIBlock.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import SwiftUI
+import UIKit
+
+/// A New Tab Page block whose content is a SwiftUI view.
+final class SwiftUIBlock<Content: View>: NewTabPageBlock {
+
+    let id: String
+
+    private let hostingController: UIHostingController<Content>
+
+    var viewController: UIViewController { hostingController }
+
+    init(id: String, rootView: Content) {
+        self.id = id
+
+        // The page already positions blocks inside its own safe area, so a hosting controller
+        // applying the safe area again would inset the block a second time.
+        hostingController = UIHostingController(rootView: rootView, ignoreSafeArea: true)
+        hostingController.view.backgroundColor = .clear
+    }
+}

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedInputContentContainerViewController.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedInputContentContainerViewController.swift
@@ -1105,23 +1105,23 @@ extension UnifiedInputContentContainerViewController {
 /// switch-tab exactly like the standalone NTP.
 extension UnifiedInputContentContainerViewController: NewTabPageControllerDelegate {
 
-    func newTabPageDidSelectFavorite(_ controller: NewTabPageViewController, favorite: BookmarkEntity) {
+    func newTabPageDidSelectFavorite(_ controller: any NewTabPage, favorite: BookmarkEntity) {
         delegate?.unifiedInputEditingStateDidSelectFavorite(favorite)
     }
 
-    func newTabPageDidEditFavorite(_ controller: NewTabPageViewController, favorite: BookmarkEntity) {
+    func newTabPageDidEditFavorite(_ controller: any NewTabPage, favorite: BookmarkEntity) {
         delegate?.unifiedInputEditingStateDidEditFavorite(favorite)
     }
 
-    func newTabPageDidRequestSwitchToTab(_ controller: NewTabPageViewController, tab: Tab) {
+    func newTabPageDidRequestSwitchToTab(_ controller: any NewTabPage, tab: Tab) {
         delegate?.unifiedInputEditingStateDidRequestSwitchTab(tab)
     }
 
-    func newTabPageDidRequestTabSwitcher(_ controller: NewTabPageViewController) {
+    func newTabPageDidRequestTabSwitcher(_ controller: any NewTabPage) {
         delegate?.unifiedInputEditingStateDidRequestTabSwitcher()
     }
 
-    func newTabPageDidRequestFaviconsFetcherOnboarding(_ controller: NewTabPageViewController) {}
+    func newTabPageDidRequestFaviconsFetcherOnboarding(_ controller: any NewTabPage) {}
 
     func newTabPageDidDismissDuckAIExperimentCompletion(_ controller: NewTabPageViewController) {}
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1218238887019765
Tech Design URL:
CC:

### Description
Groundwork for the New Tab Page redesign.

-> Update to the `NewTabPage` protocol, which existed but was never used as a type, and widens it into usable contract.
-> `MainViewController` now stores the existential. 
-> NTP construction moves into a builder.

### Testing Steps
1. With the feature flag off, open a new tab, verify the New Tab Page looks and behaves exactly as before.
2. Verify favorites open when tapped, and can be edited via long press.
3. Open the tab switcher from the New Tab Page, verify the transition animates from the page as before.
4. Tap the fire button on the New Tab Page, verify the animation plays as before.
5. Leave the app idle until the escape hatch triggers, verify it still appears.
6. Focus the address bar from the New Tab Page and dismiss it, verify the logo and favorites hand off without flicker.
7. Enable the `newTabPageRedesign` flag in the internal debug menu, open a new tab, verify a distinctly coloured page appears showing only the Dax logo.
8. Open a fire tab, verify it still shows the current New Tab Page.
9. With the flag on, run on an iPad, verify it still shows the current New Tab Page.

### Impact and Risks
Medium. The protocol and storage changes touch a good amount of places, however this should be safe for existing functionality. Should be safe if the flag is not enabled for this version.

#### What could go wrong?
-- 

### Quality Considerations
--

### Notes to Reviewer
The commits are ordered to be reviewed in sequence, each one builds on its own. The protocol widening is declaration only, the existing controller already satisfied every requirement without changes.

Both the page background (alert colour), and the three contextual dialog entry points assert will be removed as the page is built out.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core new-tab wiring and protocol surfaces used by unified input and main chrome; the flag-off path should match prior behavior, but mis-routing or incomplete redesigned stubs could affect onboarding and handoff if the redesign flag is enabled.
> 
> **Overview**
> Introduces groundwork for the **New Tab Page redesign** by turning `NewTabPage` into the real integration contract and routing creation through a new **`NewTabPageBuilder`**.
> 
> `MainViewController` now holds `any NewTabPage` and builds pages via the builder instead of inlining a large `NewTabPageViewController` initializer. Delegate signatures across the app use the existential type. The `NewTabPage` protocol is split into smaller capability protocols (content handoff, chrome, escape hatch, onboarding) and picks up delegate/chrome hooks plus `widthChanged()`.
> 
> When **`newTabPageRedesign`** is on **and** the device is an iPhone **and** the tab is not a fire tab, the builder returns **`RedesignedNewTabPageViewController`**: a scrollable vertical stack of **`NewTabPageBlock`** units (currently a SwiftUI Dax logo placeholder). Otherwise behavior stays on the existing controller. **`NewTabPageRedesignFeature`** gates availability with an iPhone check before reading the remote flag so ineligible devices are not enrolled in the experiment.
> 
> Duck.ai completion presentation now passes an optional **`textEntryMode`** into `showDuckAIOnboardingCompletionWithActiveAddressBar`. The redesigned controller stubs most NTP behaviors (onboarding asserts, no escape hatch/favorites yet).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 685e987bd0b30987d96449a91917bf2e8ddf3343. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->