### PR TITLE
iOS: Defer Duck.ai cookie-store initialization during launch

### DIFF
--- a/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatModelsService.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatModelsService.swift
@@ -31,14 +31,19 @@ public protocol AIChatCookieProviding {
 
 @MainActor
 public struct WKHTTPCookieStoreProvider: AIChatCookieProviding {
-    private let cookieStore: any DDGHTTPCookieStore
+    private let cookieStore: @MainActor @Sendable () -> any DDGHTTPCookieStore
 
-    public nonisolated init(cookieStore: any DDGHTTPCookieStore = HTTPCookieStoreWrapper(wrapped: WKWebsiteDataStore.default().httpCookieStore)) {
+    public nonisolated init(
+        cookieStore: @autoclosure @escaping @MainActor @Sendable () -> any DDGHTTPCookieStore = HTTPCookieStoreWrapper(
+            wrapped: WKWebsiteDataStore.default().httpCookieStore
+        )
+    ) {
         self.cookieStore = cookieStore
     }
 
     public func cookies(for url: URL) async -> [HTTPCookie] {
-        let cookies = await cookieStore.allCookies()
+        // Accessing the default WebKit store can block; defer it until a fetch, not scene creation.
+        let cookies = await cookieStore().allCookies()
         let domain = url.host ?? ""
         return cookies.filter { cookie in
             let cookieDomain = cookie.domain.hasPrefix(".") ? String(cookie.domain.dropFirst()) : cookie.domain

--- a/SharedPackages/AIChat/Tests/AIChatTests/WKHTTPCookieStoreProviderTests.swift
+++ b/SharedPackages/AIChat/Tests/AIChatTests/WKHTTPCookieStoreProviderTests.swift
@@ -32,6 +32,23 @@ final class WKHTTPCookieStoreProviderTests: XCTestCase {
         ])!
     }
 
+    func testWhenProviderIsInitialized_ThenCookieStoreIsNotCreatedUntilCookiesAreRequested() async {
+        let cookie = makeCookie(name: "a", domain: "duck.ai")
+        var didCreateStore = false
+        func makeStore() -> MockHTTPCookieStore {
+            didCreateStore = true
+            return MockHTTPCookieStore(allCookiesReturnValue: [cookie])
+        }
+        let provider = WKHTTPCookieStoreProvider(cookieStore: makeStore())
+
+        XCTAssertFalse(didCreateStore)
+
+        let result = await provider.cookies(for: URL(string: "https://duck.ai/")!)
+
+        XCTAssertTrue(didCreateStore)
+        XCTAssertEqual(result.map(\.name), ["a"])
+    }
+
     func testWhenCookieDomainExactlyMatchesHost_ThenCookieIsReturned() async {
         let cookie = makeCookie(name: "a", domain: "duck.ai")
         let store = MockHTTPCookieStore(allCookiesReturnValue: [cookie])


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214294661819890/task/1218225519570829?focus=true
Tech Design URL: N/A
CC:

### Description

Delay cookie-store access until Duck.ai requests cookies, avoiding unnecessary WebKit initialization during iPad launch. This removes a potential contributor to launch timeouts; crash resolution is not yet confirmed.

### Testing Steps

1. Run `WKHTTPCookieStoreProviderTests` → construction does not create the store, and cookie reads still return the expected cookies.
2. On iPad with `iPadDuckAIBarControls` enabled, open the address bar's Duck.ai input → the model picker loads and allows model selection.

### Impact

Low: A timing change to cookie access; a regression could affect Duck.ai model loading.

### Quality Considerations

Cookie filtering and main-actor access are preserved.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow lazy-init change to AI Chat cookie reads; behavior after fetch is the same, with low risk aside from subtle timing around first cookie access.
> 
> **Overview**
> **Defers WebKit’s default HTTP cookie store** so it is not touched when `WKHTTPCookieStoreProvider` (or `AIChatModelsService` with the default provider) is created—only when `cookies(for:)` runs.
> 
> `WKHTTPCookieStoreProvider` now holds a `@MainActor @Sendable` factory closure (default still wraps `WKWebsiteDataStore.default().httpCookieStore`) instead of a store instance, avoiding synchronous WebKit work during scene/UI setup such as iPad address bar creation. Cookie filtering behavior is unchanged.
> 
> A regression test asserts the store factory is not invoked until the first `cookies(for:)` call.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5bd3d64e344eefda2a42719bc7771cb01d61f6ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
