### PR TITLE
[macOS] Wait for the joining device before ending V2 pairing on the host

### DIFF
--- a/iOS/Gemfile.lock
+++ b/iOS/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/duckduckgo/fastlane-plugin-ddg_apple_automation
-  revision: c7e9bd112cb2771fe5c2bc2fb0a19f8cd2d7d5e9
-  tag: 4.2.1
+  revision: 1fa03a406801995d6e7c5068935d88184df1eda7
+  tag: 4.2.2
   specs:
-    fastlane-plugin-ddg_apple_automation (4.2.1)
+    fastlane-plugin-ddg_apple_automation (4.2.2)
       asana
       climate_control
       httpparty

--- a/iOS/fastlane/Pluginfile
+++ b/iOS/fastlane/Pluginfile
@@ -2,4 +2,4 @@
 #
 # Ensure this file is checked in to source control!
 
-gem 'fastlane-plugin-ddg_apple_automation', git: 'https://github.com/duckduckgo/fastlane-plugin-ddg_apple_automation', tag: '4.2.1'
+gem 'fastlane-plugin-ddg_apple_automation', git: 'https://github.com/duckduckgo/fastlane-plugin-ddg_apple_automation', tag: '4.2.2'

--- a/macOS/DuckDuckGo/Preferences/Model/SyncDialogController.swift
+++ b/macOS/DuckDuckGo/Preferences/Model/SyncDialogController.swift
@@ -252,16 +252,21 @@ final class SyncDialogController {
     }
 
     private func completeV2HostFlow(shouldWaitForDevicesToChange: Bool) {
-        guard didCreateSyncAccountDuringPairing else {
-            managementDialogModel.endFlow()
-            return
+        let shouldPresentSuccess = didCreateSyncAccountDuringPairing
+        didCreateSyncAccountDuringPairing = false
+
+        let complete: (SyncDialogController) -> Void = { controller in
+            if shouldPresentSuccess {
+                controller.showSyncSuccess()
+            } else {
+                controller.managementDialogModel.endFlow()
+            }
         }
 
-        didCreateSyncAccountDuringPairing = false
         if shouldWaitForDevicesToChange {
-            waitForDevicesToChangeThenPresentSuccess()
+            waitForDevicesToChange(then: complete)
         } else {
-            showSyncSuccess()
+            complete(self)
         }
     }
 
@@ -334,14 +339,14 @@ final class SyncDialogController {
         }
     }
 
-    private func waitForDevicesToChangeThenPresentSuccess() {
+    private func waitForDevicesToChange(then action: @escaping (SyncDialogController) -> Void) {
         $devices.removeDuplicates()
             .dropFirst()
             .prefix(1)
             .sink { [weak self] _ in
                 guard let self else { return }
                 Task {
-                    self.showSyncSuccess()
+                    action(self)
                 }
             }.store(in: &cancellables)
     }
@@ -761,7 +766,7 @@ extension SyncDialogController: SyncConnectionControllerDelegate {
 
         // Temporary handling as devices don't update when 3p device added to account
         if shouldWaitForDevicesToChange {
-            waitForDevicesToChangeThenPresentSuccess()
+            waitForDevicesToChange { $0.showSyncSuccess() }
         } else {
             showSyncSuccess()
         }

--- a/macOS/Gemfile.lock
+++ b/macOS/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/duckduckgo/fastlane-plugin-ddg_apple_automation
-  revision: c7e9bd112cb2771fe5c2bc2fb0a19f8cd2d7d5e9
-  tag: 4.2.1
+  revision: 1fa03a406801995d6e7c5068935d88184df1eda7
+  tag: 4.2.2
   specs:
-    fastlane-plugin-ddg_apple_automation (4.2.1)
+    fastlane-plugin-ddg_apple_automation (4.2.2)
       asana
       climate_control
       httpparty

--- a/macOS/UnitTests/Sync/SyncDialogControllerTests.swift
+++ b/macOS/UnitTests/Sync/SyncDialogControllerTests.swift
@@ -1403,11 +1403,31 @@ final class SyncDialogControllerTests: XCTestCase {
         XCTAssertEqual(managementDialogModel.currentDialog, .saveRecoveryCode(testRecoveryCode))
     }
 
-    func testControllerDidFinishTransmittingRecoveryKey_whenV2EnabledForExistingHost_endsWithoutPresentingSuccess() {
+    func testControllerDidFinishTransmittingRecoveryKey_whenV2EnabledForExistingHost_waitsForDevicesBeforeEndingFlow() async {
+        managementDialogModel.isSimplifiedSyncSetupV2Enabled = true
+        managementDialogModel.currentDialog = .prepareToSync(.twoDevicePairing)
+        let expectation = expectation(description: "V2 existing-host flow ended")
+
+        managementDialogModel.$currentDialog
+            .filter { $0 == nil }
+            .prefix(1)
+            .sink { _ in expectation.fulfill() }
+            .store(in: &cancellables)
+
+        syncDialogController.controllerDidFinishTransmittingRecoveryKey(shouldWaitForDevicesToChange: true)
+        XCTAssertEqual(managementDialogModel.currentDialog, .prepareToSync(.twoDevicePairing))
+
+        syncDialogController.devices = [SyncDevice(kind: .mobile, name: "Test Device", id: "test-id")]
+
+        await fulfillment(of: [expectation], timeout: 1)
+        XCTAssertNil(managementDialogModel.currentDialog)
+    }
+
+    func testControllerDidFinishTransmittingRecoveryKey_whenV2EnabledForExistingHostAndNoDeviceChangeExpected_endsWithoutPresentingSuccess() {
         managementDialogModel.isSimplifiedSyncSetupV2Enabled = true
         managementDialogModel.currentDialog = .prepareToSync(.twoDevicePairing)
 
-        syncDialogController.controllerDidFinishTransmittingRecoveryKey(shouldWaitForDevicesToChange: true)
+        syncDialogController.controllerDidFinishTransmittingRecoveryKey(shouldWaitForDevicesToChange: false)
 
         XCTAssertNil(managementDialogModel.currentDialog)
     }

--- a/macOS/fastlane/Pluginfile
+++ b/macOS/fastlane/Pluginfile
@@ -2,4 +2,4 @@
 #
 # Ensure this file is checked in to source control!
 
-gem 'fastlane-plugin-ddg_apple_automation', git: 'https://github.com/duckduckgo/fastlane-plugin-ddg_apple_automation', tag: '4.2.1'
+gem 'fastlane-plugin-ddg_apple_automation', git: 'https://github.com/duckduckgo/fastlane-plugin-ddg_apple_automation', tag: '4.2.2'


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214200115953388/task/1218231939766475?focus=true

### Description
In the simplified Sync setup (V2), both devices show a "Sync Now" confirmation. If you confirmed on a Mac that already had Sync turned on, the Mac closed the setup dialog immediately instead of waiting for the other device to confirm, and cancelled its side of the connection. The Mac now stays on the connecting screen until the other device has joined. This regressed in #6671.

It also update the fastlane-plugin-ddg_apple_automation dependency so that I can make a macOS build and get the proper link in MM.

### Testing Steps
1. Enable the `simplifiedSyncSetupV2` feature flag on a Mac and an iOS device. Turn Sync on on the Mac, and leave Sync off on the iOS device.
2. On the Mac, go to Settings → Sync & Backup → Sync With Another Device, and scan the code with the iOS device → both devices show a "Sync Now" confirmation.
3. Tap **Sync Now** on the Mac first, and leave the iOS confirmation untouched for a few seconds → the Mac stays on the connecting screen (before this change it closed immediately).
4. Tap **Sync Now** on the iOS device → the Mac closes the dialog and the iOS device appears in the Mac's synced devices list.
5. Regression check: repeat with Sync turned **off** on the Mac and the Mac acting as the new host → the Mac still shows the recovery-code success screen once pairing completes.

### Impact
Low

#### What could go wrong?
The Mac now waits on the synced-devices list refresh (a 3s timer that only ticks while the Sync settings pane is visible) before closing, so the dialog could linger if that refresh doesn't fire → the pairing session still has its own 5 minute timeout, and this is the same mechanism the pre-#6671 behaviour relied on.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped macOS sync setup UX fix; dialog may linger if device list refresh does not fire, with existing pairing timeout as fallback.
> 
> **Overview**
> Fixes a regression where a Mac that **already had Sync on** closed the simplified V2 pairing dialog as soon as the host tapped “Sync Now,” which cancelled the connection before the other device could confirm.
> 
> **`completeV2HostFlow`** now always honors `shouldWaitForDevicesToChange`: it waits for the synced-devices list to update, then either shows the recovery-code success UI (new host) or **`endFlow()`** (existing host). The wait helper is generalized from “then show success” to **`waitForDevicesToChange(then:)`** so the same device-change signal drives both paths; the legacy (non-V2) finish path uses it to call **`showSyncSuccess()`** unchanged.
> 
> Unit tests split the existing-host V2 case into “wait for device change then dismiss” vs “no wait, dismiss immediately.” iOS/macOS **fastlane-plugin-ddg_apple_automation** is bumped **4.2.1 → 4.2.2** in Pluginfiles and lockfiles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 415cc2261f356a1d3162916519de9b899892331a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->