### PR TITLE
Fix Fire Tab toolbar icon contrast in floating UI

### DIFF
--- a/iOS/DuckDuckGo/BrowserChromeButton.swift
+++ b/iOS/DuckDuckGo/BrowserChromeButton.swift
@@ -147,6 +147,7 @@ class BrowserChromeButton: UIButton {
     }
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
         if previousTraitCollection?.hasDifferentColorAppearance(comparedTo: traitCollection) == true {
             setNeedsDisplay()
         }

--- a/iOS/DuckDuckGo/BrowserToolbarView.swift
+++ b/iOS/DuckDuckGo/BrowserToolbarView.swift
@@ -610,6 +610,11 @@ final class BrowserToolbarView: UIView {
             materialBackgroundView.effect = nil
             materialBackgroundView.effect = materialEffect()
             materialBackgroundView.layoutIfNeeded()
+            // chromeContentHost (holding buttonStack's toolbar buttons) is a sibling of materialBackgroundView
+            // under chromeContainer, not a descendant, so it never inherited the override above. Its buttons'
+            // dynamic colors were left resolving against the ambient (light) trait while the glass they sit on
+            // was forced dark for fire mode, leaving them with no contrast.
+            chromeContentHost.overrideUserInterfaceStyle = interfaceStyle
         }
         scheduleHostedOmnibarMaterialRefresh()
     }

--- a/iOS/DuckDuckGo/BrowserToolbarView.swift
+++ b/iOS/DuckDuckGo/BrowserToolbarView.swift
@@ -610,10 +610,7 @@ final class BrowserToolbarView: UIView {
             materialBackgroundView.effect = nil
             materialBackgroundView.effect = materialEffect()
             materialBackgroundView.layoutIfNeeded()
-            // chromeContentHost (holding buttonStack's toolbar buttons) is a sibling of materialBackgroundView
-            // under chromeContainer, not a descendant, so it never inherited the override above. Its buttons'
-            // dynamic colors were left resolving against the ambient (light) trait while the glass they sit on
-            // was forced dark for fire mode, leaving them with no contrast.
+            // chromeContentHost is a sibling of materialBackgroundView, not a descendant — needs the override too.
             chromeContentHost.overrideUserInterfaceStyle = interfaceStyle
         }
         scheduleHostedOmnibarMaterialRefresh()

--- a/iOS/DuckDuckGo/DefaultOmniBarView.swift
+++ b/iOS/DuckDuckGo/DefaultOmniBarView.swift
@@ -1327,6 +1327,12 @@ final class DefaultOmniBarView: UIView, OmniBarView, ExpandableOmniBarView {
         }
         let style: UIUserInterfaceStyle = fireMode ? .dark : .unspecified
         searchAreaContainerView.subviews.forEach { $0.overrideUserInterfaceStyle = style }
+        // leadingButtonsContainer/trailingButtonsContainer are stackView siblings of searchAreaContainerView,
+        // not its subviews, so the loop above never reaches them. Their icons need the same override —
+        // otherwise in fire mode they keep resolving against the ambient (light) trait while their glass/fill
+        // background is forced dark via fireModeBackground/fireModeCardBackground, losing contrast.
+        leadingButtonsContainer.overrideUserInterfaceStyle = style
+        trailingButtonsContainer.overrideUserInterfaceStyle = style
         if isBottomFloatingField, !isFloatingMinimalChromeBar, !fireMode, let embeddedGlassInterfaceStyle {
             glassEffect.overrideUserInterfaceStyle = embeddedGlassInterfaceStyle
         }

--- a/iOS/DuckDuckGo/DefaultOmniBarView.swift
+++ b/iOS/DuckDuckGo/DefaultOmniBarView.swift
@@ -1327,10 +1327,7 @@ final class DefaultOmniBarView: UIView, OmniBarView, ExpandableOmniBarView {
         }
         let style: UIUserInterfaceStyle = fireMode ? .dark : .unspecified
         searchAreaContainerView.subviews.forEach { $0.overrideUserInterfaceStyle = style }
-        // leadingButtonsContainer/trailingButtonsContainer are stackView siblings of searchAreaContainerView,
-        // not its subviews, so the loop above never reaches them. Their icons need the same override —
-        // otherwise in fire mode they keep resolving against the ambient (light) trait while their glass/fill
-        // background is forced dark via fireModeBackground/fireModeCardBackground, losing contrast.
+        // Stack siblings of searchAreaContainerView, so the loop above misses them — same override needed.
         leadingButtonsContainer.overrideUserInterfaceStyle = style
         trailingButtonsContainer.overrideUserInterfaceStyle = style
         if isBottomFloatingField, !isFloatingMinimalChromeBar, !fireMode, let embeddedGlassInterfaceStyle {

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputToolbarView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputToolbarView.swift
@@ -76,7 +76,7 @@ final class UnifiedToggleInputToolbarView: UIView {
 
     func refreshFireMode(fireMode: Bool) {
         isFireTab = fireMode
-        overrideUserInterfaceStyle = fireMode ? .dark : .unspecified
+        // Toolbar stays on the OS trait — it sits on the light card surface even in fire mode, so its icons must not be forced dark or they lose contrast against it.
         updateSubmitButtonAppearance()
     }
 

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputToolbarView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputToolbarView.swift
@@ -76,7 +76,7 @@ final class UnifiedToggleInputToolbarView: UIView {
 
     func refreshFireMode(fireMode: Bool) {
         isFireTab = fireMode
-        // Toolbar stays on the OS trait — it sits on the light card surface even in fire mode, so its icons must not be forced dark or they lose contrast against it.
+        overrideUserInterfaceStyle = fireMode ? .dark : .unspecified
         updateSubmitButtonAppearance()
     }
 

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
@@ -847,9 +847,9 @@ final class UnifiedToggleInputView: UIView {
     private func applyFireModeAppearance(isFireTab: Bool) {
         let background = cardBackgroundColor(isFireTab: isFireTab)
         applyCardBackgroundColor(background)
-        // cardView keeps the OS trait so `fireModeCardBackground` picks its light variant in light OS; the text input forces `.dark` so its dynamic colors resolve against the dark input fill.
+        // cardView keeps the OS trait so `fireModeCardBackground` picks its light variant in light OS; content subviews force `.dark` so their dynamic colors resolve against the dark surface.
         let style: UIUserInterfaceStyle = isFireTab ? .dark : .unspecified
-        // Only the text input should force dark; the toolbar sits on the still-light card surface, so its icons must keep resolving against the OS trait or they lose contrast against it.
+        // Future direct content subviews inherit fire-mode appearance by default; card chrome and collapsed flanking accessories keep the OS trait.
         fireModeContentSubviews.forEach {
             $0.overrideUserInterfaceStyle = style
         }
@@ -967,8 +967,7 @@ final class UnifiedToggleInputView: UIView {
             $0 !== cardView &&
             $0 !== expandedShadowView &&
             $0 !== aiTabCollapsedFireButton &&
-            $0 !== aiTabCollapsedMenuButton &&
-            $0 !== toolsToolbar
+            $0 !== aiTabCollapsedMenuButton
         }
     }
 

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
@@ -963,11 +963,7 @@ final class UnifiedToggleInputView: UIView {
     }
 
     private var fireModeContentSubviews: [UIView] {
-        // aiTabCollapsedFireButton/aiTabCollapsedMenuButton are NOT excluded here: they sit on the
-        // surrounding BrowserToolbarView glass (materialBackgroundView), which FloatingGlassAppearancePolicy
-        // forces to `.dark` whenever fire mode is active — independently of this card's own background.
-        // Leaving them at the OS trait made their icons resolve light-mode tints against that now-dark
-        // glass, with no contrast. They must track fire mode like the rest of the card content.
+        // aiTabCollapsed buttons no longer excluded — the glass they sit on goes dark for fire mode too.
         subviews.filter {
             $0 !== cardView &&
             $0 !== expandedShadowView

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
@@ -847,9 +847,9 @@ final class UnifiedToggleInputView: UIView {
     private func applyFireModeAppearance(isFireTab: Bool) {
         let background = cardBackgroundColor(isFireTab: isFireTab)
         applyCardBackgroundColor(background)
-        // cardView keeps the OS trait so `fireModeCardBackground` picks its light variant in light OS; content subviews force `.dark` so their dynamic colors resolve against the dark surface.
+        // cardView keeps the OS trait so `fireModeCardBackground` picks its light variant in light OS; the text input forces `.dark` so its dynamic colors resolve against the dark input fill.
         let style: UIUserInterfaceStyle = isFireTab ? .dark : .unspecified
-        // Future direct content subviews inherit fire-mode appearance by default; card chrome and collapsed flanking accessories keep the OS trait.
+        // Only the text input should force dark; the toolbar sits on the still-light card surface, so its icons must keep resolving against the OS trait or they lose contrast against it.
         fireModeContentSubviews.forEach {
             $0.overrideUserInterfaceStyle = style
         }
@@ -967,7 +967,8 @@ final class UnifiedToggleInputView: UIView {
             $0 !== cardView &&
             $0 !== expandedShadowView &&
             $0 !== aiTabCollapsedFireButton &&
-            $0 !== aiTabCollapsedMenuButton
+            $0 !== aiTabCollapsedMenuButton &&
+            $0 !== toolsToolbar
         }
     }
 

--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
@@ -963,11 +963,14 @@ final class UnifiedToggleInputView: UIView {
     }
 
     private var fireModeContentSubviews: [UIView] {
+        // aiTabCollapsedFireButton/aiTabCollapsedMenuButton are NOT excluded here: they sit on the
+        // surrounding BrowserToolbarView glass (materialBackgroundView), which FloatingGlassAppearancePolicy
+        // forces to `.dark` whenever fire mode is active — independently of this card's own background.
+        // Leaving them at the OS trait made their icons resolve light-mode tints against that now-dark
+        // glass, with no contrast. They must track fire mode like the rest of the card content.
         subviews.filter {
             $0 !== cardView &&
-            $0 !== expandedShadowView &&
-            $0 !== aiTabCollapsedFireButton &&
-            $0 !== aiTabCollapsedMenuButton
+            $0 !== expandedShadowView
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1218141258886143
Tech Design URL:
CC:

### Description
In Fire Tabs, the floating bottom bar's glass background is forced dark for fire mode, but the toolbar buttons (bookmarks, passwords, fire, tabs, menu) live in a sibling view that never inherited that dark trait. Their icons kept resolving against the light OS trait while sitting on a now-dark glass, so they were nearly invisible.

Also fixed two related instances of the same pattern (a container needing the fire-mode dark trait but not being reached by the existing per-subview override) in `UnifiedToggleInputView` and `DefaultOmniBarView`, and a missing `super.traitCollectionDidChange` call in `BrowserChromeButton` that was silently preventing icon tints from ever re-resolving on a trait change — without it, none of the above overrides would have any visible effect.

### Testing Steps
1. Open a new Fire Tab (long-press the tab count → New Fire Tab).
2. Look at the floating bottom bar → bookmarks/passwords/fire/tabs/menu icons are clearly visible (white) against the dark bar.
3. Switch to a regular (non-fire) tab → toolbar icons still render normally, no regression.

### Impact
Low: visual contrast fix, no functional/behavioral change.

### Quality Considerations
Verified live in the iOS Simulator (iPhone 17 Pro Max, iOS 26.5) across multiple Fire Tabs, and confirmed no change to normal-tab appearance.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only contrast and trait-override fixes in browser chrome; no auth, data, or navigation behavior changes.
> 
> **Overview**
> Fixes **nearly invisible toolbar icons** in Fire Tabs when the floating bottom bar forces a dark glass background but chrome controls still resolved tints against the light system appearance.
> 
> **Trait propagation:** `BrowserToolbarView.refreshMaterialAppearance` now sets `overrideUserInterfaceStyle` on `chromeContentHost` (sibling of the glass, not under `materialBackgroundView`). `DefaultOmniBarView.updateFireModeAppearance` applies the same fire-mode `.dark` / `.unspecified` override to `leadingButtonsContainer`, `trailingButtonsContainer`, and `floatingGlassContentHostView`, which sit outside the existing `searchAreaContainerView` subview loop. `UnifiedToggleInputView` stops excluding collapsed AI-tab fire/menu buttons from `fireModeContentSubviews` so they pick up fire-mode styling too.
> 
> **Trait updates:** `BrowserChromeButton` calls `super.traitCollectionDidChange` so border/icon colors refresh when appearance changes—without that, the overrides above would not visibly update toolbar buttons.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e7efbc5760db9a7e0fb7d7e87ec9d62706caee7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->