### PR TITLE
Bump ddg_apple_automation to 4.2.2

### DIFF
--- a/iOS/Gemfile.lock
+++ b/iOS/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/duckduckgo/fastlane-plugin-ddg_apple_automation
-  revision: c7e9bd112cb2771fe5c2bc2fb0a19f8cd2d7d5e9
-  tag: 4.2.1
+  revision: 1fa03a406801995d6e7c5068935d88184df1eda7
+  tag: 4.2.2
   specs:
-    fastlane-plugin-ddg_apple_automation (4.2.1)
+    fastlane-plugin-ddg_apple_automation (4.2.2)
       asana
       climate_control
       httpparty

--- a/iOS/fastlane/Pluginfile
+++ b/iOS/fastlane/Pluginfile
@@ -2,4 +2,4 @@
 #
 # Ensure this file is checked in to source control!
 
-gem 'fastlane-plugin-ddg_apple_automation', git: 'https://github.com/duckduckgo/fastlane-plugin-ddg_apple_automation', tag: '4.2.1'
+gem 'fastlane-plugin-ddg_apple_automation', git: 'https://github.com/duckduckgo/fastlane-plugin-ddg_apple_automation', tag: '4.2.2'

--- a/macOS/Gemfile.lock
+++ b/macOS/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/duckduckgo/fastlane-plugin-ddg_apple_automation
-  revision: c7e9bd112cb2771fe5c2bc2fb0a19f8cd2d7d5e9
-  tag: 4.2.1
+  revision: 1fa03a406801995d6e7c5068935d88184df1eda7
+  tag: 4.2.2
   specs:
-    fastlane-plugin-ddg_apple_automation (4.2.1)
+    fastlane-plugin-ddg_apple_automation (4.2.2)
       asana
       climate_control
       httpparty

--- a/macOS/fastlane/Pluginfile
+++ b/macOS/fastlane/Pluginfile
@@ -2,4 +2,4 @@
 #
 # Ensure this file is checked in to source control!
 
-gem 'fastlane-plugin-ddg_apple_automation', git: 'https://github.com/duckduckgo/fastlane-plugin-ddg_apple_automation', tag: '4.2.1'
+gem 'fastlane-plugin-ddg_apple_automation', git: 'https://github.com/duckduckgo/fastlane-plugin-ddg_apple_automation', tag: '4.2.2'


### PR DESCRIPTION
Task/Issue URL:

### Description
Bumps the `ddg_apple_automation` fastlane plugin from 4.2.1 to 4.2.2 on both iOS and macOS, picking up duckduckgo/fastlane-plugin-ddg_apple_automation#77. That release adds the `pballart` → `@pballart` Mattermost mapping, so release lane notifications for that GitHub handle resolve instead of being skipped.

### Testing Steps
1. Check out this branch and run `bundle install` in `iOS/` and in `macOS/` → both resolve without changing `Gemfile.lock`.
2. Run `bundle exec fastlane lanes` in either directory → the lane list loads, confirming the plugin still loads at the new tag.

### Impact
Low

#### What could go wrong?
The `Gemfile.lock` files were updated by hand rather than by bundler, so they could in principle diverge from what `bundle install` would generate → the 4.2.1...4.2.2 diff touches only CI workflows, the Mattermost mapping asset, and `version.rb`, leaving the gemspec and therefore the locked dependency list unchanged, and step 1 above verifies the lock is a fixed point.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tooling-only dependency pin update for CI/release fastlane; no product code or security-sensitive paths touched.
> 
> **Overview**
> Bumps **`fastlane-plugin-ddg_apple_automation`** from **4.2.1** to **4.2.2** for both **iOS** and **macOS** by updating each `fastlane/Pluginfile` tag and the matching `Gemfile.lock` git revision.
> 
> The new plugin release adds a GitHub→Mattermost handle mapping (`pballart` → `@pballart`), so release-lane notifications for that author are mentioned instead of being skipped. No application or runtime code changes—only fastlane/Bundler lock metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79eed2b7d3d8c25d08dcdb259451f6c6b77c3bfb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->