### PR TITLE
[iOS] Fix app switcher snapshot clearing error telemetry

### DIFF
--- a/iOS/DuckDuckGo/Fire/AppSwitcherSnapshotCleaner.swift
+++ b/iOS/DuckDuckGo/Fire/AppSwitcherSnapshotCleaner.swift
@@ -56,7 +56,7 @@ actor AppSwitcherSnapshotCleaner {
         } catch {
             let errorDescription = error.localizedDescription
             Logger.general.error("Failed to enumerate app switcher snapshots: \(errorDescription, privacy: .public)")
-            pixelFiring?.fire(DataClearingPixels.appSwitcherSnapshotEnumerationFailed(error), frequency: .dailyAndCount)
+            pixelFiring?.fire(AppSwitcherSnapshotClearingPixel.failed(error), frequency: .dailyAndCount)
             return
         }
 
@@ -76,7 +76,24 @@ actor AppSwitcherSnapshotCleaner {
         }
 
         if let firstRemovalError {
-            pixelFiring?.fire(DataClearingPixels.appSwitcherSnapshotRemovalFailed(firstRemovalError), frequency: .dailyAndCount)
+            pixelFiring?.fire(AppSwitcherSnapshotClearingPixel.failed(firstRemovalError), frequency: .dailyAndCount)
         }
     }
+}
+
+private enum AppSwitcherSnapshotClearingPixel: PixelKit.Event {
+    case failed(Error)
+
+    var name: String { "app-switcher_snapshot_clearing_failed" }
+
+    var parameters: [String: String]? { nil }
+
+    var error: NSError? {
+        switch self {
+        case .failed(let error):
+            return error as NSError
+        }
+    }
+
+    var standardParameters: [PixelKitStandardParameter]? { [.pixelSource] }
 }

--- a/iOS/DuckDuckGo/Fire/AppSwitcherSnapshotCleaner.swift
+++ b/iOS/DuckDuckGo/Fire/AppSwitcherSnapshotCleaner.swift
@@ -49,6 +49,10 @@ actor AppSwitcherSnapshotCleaner {
             snapshotItems = try fileManager.contentsOfDirectory(at: snapshotsDirectory,
                                                                 includingPropertiesForKeys: nil,
                                                                 options: [])
+        } catch CocoaError.fileReadNoSuchFile {
+            // This system-owned directory may be absent. In that case, there are no snapshots at
+            // this path to clear.
+            return
         } catch {
             let errorDescription = error.localizedDescription
             Logger.general.error("Failed to enumerate app switcher snapshots: \(errorDescription, privacy: .public)")
@@ -56,14 +60,23 @@ actor AppSwitcherSnapshotCleaner {
             return
         }
 
+        var firstRemovalError: Error?
         for snapshotItem in snapshotItems {
             do {
                 try fileManager.removeItem(at: snapshotItem)
+            } catch CocoaError.fileNoSuchFile {
+                // The desired state is already reached if the item disappears after enumeration.
+                continue
             } catch {
+                firstRemovalError = firstRemovalError ?? error
                 let itemName = snapshotItem.lastPathComponent
                 let errorDescription = error.localizedDescription
                 Logger.general.error("Failed to remove snapshot \(itemName, privacy: .public): \(errorDescription, privacy: .public)")
             }
+        }
+
+        if let firstRemovalError {
+            pixelFiring?.fire(DataClearingPixels.appSwitcherSnapshotRemovalFailed(firstRemovalError), frequency: .dailyAndCount)
         }
     }
 }

--- a/iOS/DuckDuckGo/Fire/Statistics/DataClearingPixels.swift
+++ b/iOS/DuckDuckGo/Fire/Statistics/DataClearingPixels.swift
@@ -28,28 +28,13 @@ enum DataClearingPixels {
 
     /// User performed action before data clearing completed
     case userActionBeforeCompletion
-
-    /// App switcher snapshot directory enumeration failed
-    case appSwitcherSnapshotEnumerationFailed(Error)
-
-    /// App switcher snapshot removal failed
-    case appSwitcherSnapshotRemovalFailed(Error)
 }
 
 // MARK: - PixelKit.Event Protocol
 
 extension DataClearingPixels: PixelKit.Event {
-    var platformSuffixPolicy: PixelKitPlatformSuffixPolicy {
-        switch self {
-        case .appSwitcherSnapshotRemovalFailed:
-            return .standard
-        case .retriggerIn20s,
-             .userActionBeforeCompletion,
-             .appSwitcherSnapshotEnumerationFailed:
-            // These existing pixel signatures predate the current PixelKit defaults and do not send the platform marker suffix.
-            return .legacyOmitted
-        }
-    }
+    /// This pixel signature is non-standard and not aligned to the current PixelKit defaults. This policy freezes the signature by not sending the platform marker suffix.
+    var platformSuffixPolicy: PixelKitPlatformSuffixPolicy { .legacyOmitted }
 
     var name: String {
         switch self {
@@ -57,10 +42,6 @@ extension DataClearingPixels: PixelKit.Event {
             return "m_fire_retrigger_in_20s"
         case .userActionBeforeCompletion:
             return "m_fire_user_action_before_completion"
-        case .appSwitcherSnapshotEnumerationFailed:
-            return "app-switcher_snapshot_enumeration_failed"
-        case .appSwitcherSnapshotRemovalFailed:
-            return "app-switcher_snapshot_removal_failed"
         }
     }
 
@@ -69,13 +50,7 @@ extension DataClearingPixels: PixelKit.Event {
     }
 
     var error: NSError? {
-        switch self {
-        case .appSwitcherSnapshotEnumerationFailed(let error),
-             .appSwitcherSnapshotRemovalFailed(let error):
-            return error as NSError
-        default:
-            return nil
-        }
+        return nil
     }
 
     var standardParameters: [PixelKitStandardParameter]? {
@@ -89,9 +64,9 @@ extension DataClearingPixels: PixelKit.Event {
 ///
 /// Kept separate from `DataClearingPixels` for two reasons, both of which would otherwise change
 /// pixels this type does not own:
-/// - these four have always sent the `_ios_phone` / `_ios_tablet` marker while the legacy cases on
-///   `DataClearingPixels` have not. Merging them would start marking `m_fire_retrigger_in_20s` and
-///   `m_fire_user_action_before_completion` too.
+/// - these four have always sent the `_ios_phone` / `_ios_tablet` marker and `DataClearingPixels`
+///   never has, so the two need different `platformSuffixPolicy` values. Merging them would start
+///   marking `m_fire_retrigger_in_20s` and `m_fire_user_action_before_completion` too.
 /// - `DataClearingPixels` reports `pixelSource`, which these four do not declare in
 ///   `forget_all.json5`.
 enum DataClearingCompletionPixels {

--- a/iOS/DuckDuckGo/Fire/Statistics/DataClearingPixels.swift
+++ b/iOS/DuckDuckGo/Fire/Statistics/DataClearingPixels.swift
@@ -31,13 +31,25 @@ enum DataClearingPixels {
 
     /// App switcher snapshot directory enumeration failed
     case appSwitcherSnapshotEnumerationFailed(Error)
+
+    /// App switcher snapshot removal failed
+    case appSwitcherSnapshotRemovalFailed(Error)
 }
 
 // MARK: - PixelKit.Event Protocol
 
 extension DataClearingPixels: PixelKit.Event {
-    /// This pixel signature is non-standard and not aligned to the current PixelKit defaults. This policy freezes the signature by not sending the platform marker suffix.
-    var platformSuffixPolicy: PixelKitPlatformSuffixPolicy { .legacyOmitted }
+    var platformSuffixPolicy: PixelKitPlatformSuffixPolicy {
+        switch self {
+        case .appSwitcherSnapshotRemovalFailed:
+            return .standard
+        case .retriggerIn20s,
+             .userActionBeforeCompletion,
+             .appSwitcherSnapshotEnumerationFailed:
+            // These existing pixel signatures predate the current PixelKit defaults and do not send the platform marker suffix.
+            return .legacyOmitted
+        }
+    }
 
     var name: String {
         switch self {
@@ -47,6 +59,8 @@ extension DataClearingPixels: PixelKit.Event {
             return "m_fire_user_action_before_completion"
         case .appSwitcherSnapshotEnumerationFailed:
             return "app-switcher_snapshot_enumeration_failed"
+        case .appSwitcherSnapshotRemovalFailed:
+            return "app-switcher_snapshot_removal_failed"
         }
     }
 
@@ -56,7 +70,8 @@ extension DataClearingPixels: PixelKit.Event {
 
     var error: NSError? {
         switch self {
-        case .appSwitcherSnapshotEnumerationFailed(let error):
+        case .appSwitcherSnapshotEnumerationFailed(let error),
+             .appSwitcherSnapshotRemovalFailed(let error):
             return error as NSError
         default:
             return nil
@@ -74,9 +89,9 @@ extension DataClearingPixels: PixelKit.Event {
 ///
 /// Kept separate from `DataClearingPixels` for two reasons, both of which would otherwise change
 /// pixels this type does not own:
-/// - these four have always sent the `_ios_phone` / `_ios_tablet` marker and `DataClearingPixels`
-///   never has, so the two need different `platformSuffixPolicy` values. Merging them would start
-///   marking `m_fire_retrigger_in_20s` and `m_fire_user_action_before_completion` too.
+/// - these four have always sent the `_ios_phone` / `_ios_tablet` marker while the legacy cases on
+///   `DataClearingPixels` have not. Merging them would start marking `m_fire_retrigger_in_20s` and
+///   `m_fire_user_action_before_completion` too.
 /// - `DataClearingPixels` reports `pixelSource`, which these four do not declare in
 ///   `forget_all.json5`.
 enum DataClearingCompletionPixels {

--- a/iOS/DuckDuckGoTests/Fire/AppSwitcherSnapshotCleanerTests.swift
+++ b/iOS/DuckDuckGoTests/Fire/AppSwitcherSnapshotCleanerTests.swift
@@ -61,7 +61,7 @@ final class AppSwitcherSnapshotCleanerTests: XCTestCase {
         XCTAssertTrue(pixelFiring.actualFireCalls.isEmpty)
     }
 
-    func testWhenSnapshotsDirectoryCannotBeEnumeratedThenEnumerationFailurePixelIsFired() async throws {
+    func testWhenSnapshotsDirectoryCannotBeEnumeratedThenClearingFailurePixelIsFired() async throws {
         let libraryDirectory = makeTemporaryLibraryDirectory()
         let pixelFiring = PixelKitMock()
         let cleaner = AppSwitcherSnapshotCleaner(fileManager: FailingEnumerationFileManager(),
@@ -72,34 +72,14 @@ final class AppSwitcherSnapshotCleanerTests: XCTestCase {
 
         let fireCall = try XCTUnwrap(pixelFiring.actualFireCalls.first)
         XCTAssertEqual(pixelFiring.actualFireCalls.count, 1)
-        XCTAssertEqual(fireCall.pixel.name, "app-switcher_snapshot_enumeration_failed")
+        XCTAssertEqual(fireCall.pixel.name, "app-switcher_snapshot_clearing_failed")
         XCTAssertEqual(fireCall.pixel.error?.domain, NSCocoaErrorDomain)
         XCTAssertEqual(fireCall.pixel.error?.code, CocoaError.fileReadNoPermission.rawValue)
-        XCTAssertEqual(fireCall.pixel.platformSuffixPolicy, .legacyOmitted)
+        XCTAssertEqual(fireCall.pixel.platformSuffixPolicy, .standard)
         XCTAssertEqual(fireCall.frequency, .dailyAndCount)
     }
 
-    func testWhenSnapshotItemIsAlreadyGoneThenNoRemovalFailurePixelIsFired() async throws {
-        let libraryDirectory = makeTemporaryLibraryDirectory()
-        defer { try? FileManager.default.removeItem(at: libraryDirectory) }
-
-        let snapshotItem = libraryDirectory
-            .appendingPathComponent("SplashBoard", isDirectory: true)
-            .appendingPathComponent("Snapshots", isDirectory: true)
-            .appendingPathComponent("scene", isDirectory: true)
-        try FileManager.default.createDirectory(at: snapshotItem, withIntermediateDirectories: true)
-
-        let pixelFiring = PixelKitMock()
-        let cleaner = AppSwitcherSnapshotCleaner(fileManager: AlreadyRemovedFileManager(),
-                                                  libraryDirectoryOverride: libraryDirectory,
-                                                  pixelFiring: pixelFiring)
-        await cleaner.clearSnapshots()
-
-        XCTAssertFalse(FileManager.default.fileExists(atPath: snapshotItem.path))
-        XCTAssertTrue(pixelFiring.actualFireCalls.isEmpty)
-    }
-
-    func testClearSnapshotsContinuesAfterItemsCannotBeRemovedAndFiresOneRemovalFailurePixel() async throws {
+    func testWhenSnapshotItemsCannotBeRemovedThenCleanerContinuesAndFiresOneClearingFailurePixel() async throws {
         let libraryDirectory = makeTemporaryLibraryDirectory()
         defer { try? FileManager.default.removeItem(at: libraryDirectory) }
 
@@ -124,10 +104,9 @@ final class AppSwitcherSnapshotCleanerTests: XCTestCase {
 
         let fireCall = try XCTUnwrap(pixelFiring.actualFireCalls.first)
         XCTAssertEqual(pixelFiring.actualFireCalls.count, 1)
-        XCTAssertEqual(fireCall.pixel.name, "app-switcher_snapshot_removal_failed")
+        XCTAssertEqual(fireCall.pixel.name, "app-switcher_snapshot_clearing_failed")
         XCTAssertEqual(fireCall.pixel.error?.domain, NSCocoaErrorDomain)
         XCTAssertEqual(fireCall.pixel.error?.code, CocoaError.fileWriteNoPermission.rawValue)
-        XCTAssertEqual(fireCall.pixel.platformSuffixPolicy, .standard)
         XCTAssertEqual(fireCall.frequency, .dailyAndCount)
     }
 
@@ -143,14 +122,6 @@ private final class FailingEnumerationFileManager: FileManager, @unchecked Senda
                                       includingPropertiesForKeys keys: [URLResourceKey]?,
                                       options mask: FileManager.DirectoryEnumerationOptions = []) throws -> [URL] {
         throw CocoaError(.fileReadNoPermission)
-    }
-}
-
-private final class AlreadyRemovedFileManager: FileManager, @unchecked Sendable {
-
-    override func removeItem(at URL: URL) throws {
-        try super.removeItem(at: URL)
-        try super.removeItem(at: URL)
     }
 }
 

--- a/iOS/DuckDuckGoTests/Fire/AppSwitcherSnapshotCleanerTests.swift
+++ b/iOS/DuckDuckGoTests/Fire/AppSwitcherSnapshotCleanerTests.swift
@@ -43,9 +43,12 @@ final class AppSwitcherSnapshotCleanerTests: XCTestCase {
                                                                    includingPropertiesForKeys: nil), [])
     }
 
-    func testWhenSnapshotsDirectoryIsMissingThenEnumerationFailurePixelIsFired() async throws {
+    func testWhenSnapshotsDirectoryIsMissingThenNoFailurePixelIsFired() async throws {
         let libraryDirectory = makeTemporaryLibraryDirectory()
         defer { try? FileManager.default.removeItem(at: libraryDirectory) }
+
+        let splashBoardDirectory = libraryDirectory.appendingPathComponent("SplashBoard", isDirectory: true)
+        try FileManager.default.createDirectory(at: splashBoardDirectory, withIntermediateDirectories: true)
 
         let pixelFiring = PixelKitMock()
         let cleaner = AppSwitcherSnapshotCleaner(libraryDirectoryOverride: libraryDirectory, pixelFiring: pixelFiring)
@@ -55,16 +58,48 @@ final class AppSwitcherSnapshotCleanerTests: XCTestCase {
             .appendingPathComponent("SplashBoard", isDirectory: true)
             .appendingPathComponent("Snapshots", isDirectory: true)
         XCTAssertFalse(FileManager.default.fileExists(atPath: snapshotsDirectory.path))
+        XCTAssertTrue(pixelFiring.actualFireCalls.isEmpty)
+    }
+
+    func testWhenSnapshotsDirectoryCannotBeEnumeratedThenEnumerationFailurePixelIsFired() async throws {
+        let libraryDirectory = makeTemporaryLibraryDirectory()
+        let pixelFiring = PixelKitMock()
+        let cleaner = AppSwitcherSnapshotCleaner(fileManager: FailingEnumerationFileManager(),
+                                                  libraryDirectoryOverride: libraryDirectory,
+                                                  pixelFiring: pixelFiring)
+
+        await cleaner.clearSnapshots()
 
         let fireCall = try XCTUnwrap(pixelFiring.actualFireCalls.first)
         XCTAssertEqual(pixelFiring.actualFireCalls.count, 1)
         XCTAssertEqual(fireCall.pixel.name, "app-switcher_snapshot_enumeration_failed")
         XCTAssertEqual(fireCall.pixel.error?.domain, NSCocoaErrorDomain)
-        XCTAssertEqual(fireCall.pixel.error?.code, CocoaError.fileReadNoSuchFile.rawValue)
+        XCTAssertEqual(fireCall.pixel.error?.code, CocoaError.fileReadNoPermission.rawValue)
+        XCTAssertEqual(fireCall.pixel.platformSuffixPolicy, .legacyOmitted)
         XCTAssertEqual(fireCall.frequency, .dailyAndCount)
     }
 
-    func testClearSnapshotsContinuesAfterAnItemCannotBeRemoved() async throws {
+    func testWhenSnapshotItemIsAlreadyGoneThenNoRemovalFailurePixelIsFired() async throws {
+        let libraryDirectory = makeTemporaryLibraryDirectory()
+        defer { try? FileManager.default.removeItem(at: libraryDirectory) }
+
+        let snapshotItem = libraryDirectory
+            .appendingPathComponent("SplashBoard", isDirectory: true)
+            .appendingPathComponent("Snapshots", isDirectory: true)
+            .appendingPathComponent("scene", isDirectory: true)
+        try FileManager.default.createDirectory(at: snapshotItem, withIntermediateDirectories: true)
+
+        let pixelFiring = PixelKitMock()
+        let cleaner = AppSwitcherSnapshotCleaner(fileManager: AlreadyRemovedFileManager(),
+                                                  libraryDirectoryOverride: libraryDirectory,
+                                                  pixelFiring: pixelFiring)
+        await cleaner.clearSnapshots()
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: snapshotItem.path))
+        XCTAssertTrue(pixelFiring.actualFireCalls.isEmpty)
+    }
+
+    func testClearSnapshotsContinuesAfterItemsCannotBeRemovedAndFiresOneRemovalFailurePixel() async throws {
         let libraryDirectory = makeTemporaryLibraryDirectory()
         defer { try? FileManager.default.removeItem(at: libraryDirectory) }
 
@@ -76,14 +111,24 @@ final class AppSwitcherSnapshotCleanerTests: XCTestCase {
         try FileManager.default.createDirectory(at: firstSceneDirectory, withIntermediateDirectories: true)
         try FileManager.default.createDirectory(at: secondSceneDirectory, withIntermediateDirectories: true)
 
-        let fileManager = FailFirstRemovalFileManager()
-        let cleaner = AppSwitcherSnapshotCleaner(fileManager: fileManager, libraryDirectoryOverride: libraryDirectory)
+        let fileManager = FailingRemovalFileManager()
+        let pixelFiring = PixelKitMock()
+        let cleaner = AppSwitcherSnapshotCleaner(fileManager: fileManager,
+                                                  libraryDirectoryOverride: libraryDirectory,
+                                                  pixelFiring: pixelFiring)
         await cleaner.clearSnapshots()
 
-        let failedItem = try XCTUnwrap(fileManager.removalAttempts.first)
-        let laterItem = try XCTUnwrap(fileManager.removalAttempts.dropFirst().first)
-        XCTAssertTrue(fileManager.fileExists(atPath: failedItem.path))
-        XCTAssertFalse(fileManager.fileExists(atPath: laterItem.path))
+        XCTAssertEqual(Set(fileManager.removalAttempts), Set([firstSceneDirectory, secondSceneDirectory]))
+        XCTAssertTrue(fileManager.fileExists(atPath: firstSceneDirectory.path))
+        XCTAssertTrue(fileManager.fileExists(atPath: secondSceneDirectory.path))
+
+        let fireCall = try XCTUnwrap(pixelFiring.actualFireCalls.first)
+        XCTAssertEqual(pixelFiring.actualFireCalls.count, 1)
+        XCTAssertEqual(fireCall.pixel.name, "app-switcher_snapshot_removal_failed")
+        XCTAssertEqual(fireCall.pixel.error?.domain, NSCocoaErrorDomain)
+        XCTAssertEqual(fireCall.pixel.error?.code, CocoaError.fileWriteNoPermission.rawValue)
+        XCTAssertEqual(fireCall.pixel.platformSuffixPolicy, .standard)
+        XCTAssertEqual(fireCall.frequency, .dailyAndCount)
     }
 
     private func makeTemporaryLibraryDirectory() -> URL {
@@ -92,14 +137,28 @@ final class AppSwitcherSnapshotCleanerTests: XCTestCase {
     }
 }
 
-private final class FailFirstRemovalFileManager: FileManager, @unchecked Sendable {
+private final class FailingEnumerationFileManager: FileManager, @unchecked Sendable {
+
+    override func contentsOfDirectory(at url: URL,
+                                      includingPropertiesForKeys keys: [URLResourceKey]?,
+                                      options mask: FileManager.DirectoryEnumerationOptions = []) throws -> [URL] {
+        throw CocoaError(.fileReadNoPermission)
+    }
+}
+
+private final class AlreadyRemovedFileManager: FileManager, @unchecked Sendable {
+
+    override func removeItem(at URL: URL) throws {
+        try super.removeItem(at: URL)
+        try super.removeItem(at: URL)
+    }
+}
+
+private final class FailingRemovalFileManager: FileManager, @unchecked Sendable {
     private(set) var removalAttempts: [URL] = []
 
     override func removeItem(at URL: URL) throws {
         removalAttempts.append(URL)
-        guard removalAttempts.count > 1 else {
-            throw NSError(domain: NSCocoaErrorDomain, code: CocoaError.fileWriteNoPermission.rawValue)
-        }
-        try super.removeItem(at: URL)
+        throw CocoaError(.fileWriteNoPermission)
     }
 }

--- a/iOS/PixelDefinitions/pixels/definitions/data_clearing_pixels.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/data_clearing_pixels.json5
@@ -16,15 +16,15 @@
     },
 
     "app-switcher_snapshot_enumeration_failed": {
-        "description": "Fired when the app cannot enumerate the iOS app switcher snapshot directory. Does not fire when the directory is absent, because there are no snapshots to clear",
+        "description": "Legacy pixel fired by older app versions when the app cannot enumerate the iOS app switcher snapshot directory, including when the expected private OS path is missing",
         "owners": ["bkunat"],
         "triggers": ["other"],
         "suffixes": ["daily_count"],
         "parameters": ["appVersion", "pixelSource", "errorCode", "errorDomain", "underlyingErrorCode", "underlyingErrorDomain"]
     },
 
-    "app-switcher_snapshot_removal_failed": {
-        "description": "Fired once per cleanup attempt when the app cannot remove one or more items from the iOS app switcher snapshot directory. Error parameters describe the first removal failure",
+    "app-switcher_snapshot_clearing_failed": {
+        "description": "Fired once per cleanup attempt when app-switcher snapshot clearing fails for a reason other than a missing directory or item. Error parameters describe the first failure",
         "owners": ["bkunat"],
         "triggers": ["other"],
         "suffixes": ["daily_count", "platform", "form_factor"],

--- a/iOS/PixelDefinitions/pixels/definitions/data_clearing_pixels.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/data_clearing_pixels.json5
@@ -15,14 +15,6 @@
         "parameters": ["appVersion", "pixelSource"]
     },
 
-    "app-switcher_snapshot_enumeration_failed": {
-        "description": "Legacy pixel fired by older app versions when the app cannot enumerate the iOS app switcher snapshot directory, including when the expected private OS path is missing",
-        "owners": ["bkunat"],
-        "triggers": ["other"],
-        "suffixes": ["daily_count"],
-        "parameters": ["appVersion", "pixelSource", "errorCode", "errorDomain", "underlyingErrorCode", "underlyingErrorDomain"]
-    },
-
     "app-switcher_snapshot_clearing_failed": {
         "description": "Fired once per cleanup attempt when app-switcher snapshot clearing fails for a reason other than a missing directory or item. Error parameters describe the first failure",
         "owners": ["bkunat"],

--- a/iOS/PixelDefinitions/pixels/definitions/data_clearing_pixels.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/data_clearing_pixels.json5
@@ -16,10 +16,18 @@
     },
 
     "app-switcher_snapshot_enumeration_failed": {
-        "description": "Fired when the app cannot enumerate the iOS app switcher snapshot directory, including when the expected private OS path is missing",
+        "description": "Fired when the app cannot enumerate the iOS app switcher snapshot directory. Does not fire when the directory is absent, because there are no snapshots to clear",
         "owners": ["bkunat"],
         "triggers": ["other"],
         "suffixes": ["daily_count"],
+        "parameters": ["appVersion", "pixelSource", "errorCode", "errorDomain", "underlyingErrorCode", "underlyingErrorDomain"]
+    },
+
+    "app-switcher_snapshot_removal_failed": {
+        "description": "Fired once per cleanup attempt when the app cannot remove one or more items from the iOS app switcher snapshot directory. Error parameters describe the first removal failure",
+        "owners": ["bkunat"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count", "platform", "form_factor"],
         "parameters": ["appVersion", "pixelSource", "errorCode", "errorDomain", "underlyingErrorCode", "underlyingErrorDomain"]
     },
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1215172677539195/task/1218243925655966?focus=true
Tech Design URL:
CC:

### Description

Stops reporting the normal absence of the iOS app-switcher snapshot directory as an error. Production data for 7.235.0.7 showed that the previous event fired frequently but contained only no-such-file errors, so it measured an expected system state rather than a snapshot-clearing failure.

Replaces it with one daily-and-count event that reports genuine directory-reading or snapshot-removal errors once per clearing attempt. Missing directories and items remain successful no-ops because there is nothing left to clear.

### Testing Steps

General regression testing around app launcher snapshot clearing should be enough. Use testing steps form the original PR: https://github.com/duckduckgo/apple-browsers/pull/6409

### Impact

Low: this changes error classification and telemetry only. Snapshot deletion remains best effort and all available snapshot items are still attempted.

#### What could go wrong?

N/A

### Quality Considerations

The replacement event includes error domain and code but does not include paths, filenames, or error descriptions. Multiple removal failures during one clearing attempt produce one event, preventing volume from scaling with the number of snapshot directories.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only error classification and analytics for snapshot cleanup; deletion behavior stays best-effort with the same file operations.
> 
> **Overview**
> **Fixes noisy app-switcher snapshot telemetry** by no longer firing an error when the system `SplashBoard/Snapshots` path is absent or an item vanishes after enumeration (`CocoaError.fileReadNoSuchFile` / `fileNoSuchFile`). Those cases are treated as nothing to clear.
> 
> **Replaces** `app-switcher_snapshot_enumeration_failed` (removed from `DataClearingPixels`) with **`app-switcher_snapshot_clearing_failed`**, fired **once per cleanup attempt** via a local `AppSwitcherSnapshotClearingPixel` when enumeration or removal fails for other reasons (first removal error only if several items fail). Pixel definitions gain platform/form_factor suffixes alongside daily_count.
> 
> Unit tests now assert no pixel when the directory is missing, and assert the new event for simulated read-permission and removal failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 620b0c961bf575bd30ae0a10e27a8c9566d9efb3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->