### PR TITLE
Fix contrast regression on Duck.ai fire tabs from #6729

### DIFF
--- a/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/UnifiedToggleInputView.swift
@@ -967,10 +967,12 @@ final class UnifiedToggleInputView: UIView {
     }
 
     private var fireModeContentSubviews: [UIView] {
-        // aiTabCollapsed buttons no longer excluded — the glass they sit on goes dark for fire mode too.
+        // aiTabCollapsed buttons keep their own regular glass, so they must stay on the OS trait.
         subviews.filter {
             $0 !== cardView &&
-            $0 !== expandedShadowView
+            $0 !== expandedShadowView &&
+            $0 !== aiTabCollapsedFireButton &&
+            $0 !== aiTabCollapsedMenuButton
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1218141258886143
Tech Design URL:
CC:

Follow-up to #6729 (merged) — fixes two review findings on that PR's `fireModeContentSubviews` change.

### Description
**Medium:** Including `aiTabCollapsedFireButton`/`aiTabCollapsedMenuButton` in `fireModeContentSubviews` forced a fire-mode dark trait onto buttons that keep their own regular glass and were originally excluded so they'd follow the OS trait. On Duck.ai fire tabs in light mode, that left their icons resolving light against a light `.glass()`, dropping contrast — the opposite problem from the one #6729 fixed. Restored the exclusion.

**Low:** The comment left behind ("no longer excluded") was PR-situational changelog phrasing rather than an ongoing why. Replaced with one that states the actual invariant.

### Testing Steps
1. Open a Duck.ai fire tab in light mode.
2. Confirm the fire/menu accessory buttons are visible against their own glass (not washed out).
3. Re-check the toolbar contrast fix from #6729 still holds (bookmarks/passwords/fire/tabs/menu icons visible on the dark bar).

### Impact
Low: visual contrast fix, no functional/behavioral change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual contrast-only tweak to which subviews inherit fire-mode trait overrides; no logic or API changes.
> 
> **Overview**
> Reverts part of #6729 by **excluding** `aiTabCollapsedFireButton` and `aiTabCollapsedMenuButton` from `fireModeContentSubviews` again. Those views were incorrectly receiving fire mode’s forced `.dark` `overrideUserInterfaceStyle`, which made their icons render for a dark surface while they still use regular `.glass()` in light mode—washed-out fire/menu controls on Duck.ai fire tabs in light mode.
> 
> The inline comment now documents the invariant: collapsed accessories keep their own glass and must follow the **OS** trait; only the other direct subviews (toggle, text entry, toolbar, etc.) still get the dark override for contrast on the fire card.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a755c98432fcd82f7c8d4b618f063257f65ee14c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->