### PR TITLE
Restore dark glass response on dark websites in light mode

### DIFF
--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -441,6 +441,15 @@ class MainViewController: UIViewController {
                               isFloatingUIEnabled: isFloatingUIEnabled)
     }()
 
+    // Re-run the glass policy when WebKit's page-derived color changes; otherwise it only ran on tab-switch/trait changes.
+    private var pageBackgroundColorObservation: NSKeyValueObservation?
+
+    private func observePageBackgroundColor(for tab: TabViewController) {
+        pageBackgroundColorObservation = tab.webView.observe(\.underPageBackgroundColor, options: [.initial, .new]) { [weak self] _, _ in
+            self?.refreshSettledFloatingGlassAppearance()
+        }
+    }
+
     private lazy var browsingMenuSheetCapability = BrowsingMenuSheetCapability.create()
 
     let themeManager: ThemeManaging
@@ -2843,6 +2852,7 @@ class MainViewController: UIViewController {
         chromeManager.attach(to: tab.webView.scrollView)
         chromeManager.reset(animated: false)
         themeColorManager.attach(to: tab)
+        observePageBackgroundColor(for: tab)
         tab.chromeDelegate = self
         tab.updateWebViewBottomAnchor(for: currentBarsVisibility)
 

--- a/iOS/DuckDuckGo/SiteThemeColorManager.swift
+++ b/iOS/DuckDuckGo/SiteThemeColorManager.swift
@@ -152,9 +152,14 @@ final class SiteThemeColorManager {
         }
         viewCoordinator.setStandardStatusBackgroundColor(statusBackgroundColor)
         tabViewController?.pullToRefreshViewAdapter?.backgroundColor = newColor
-        let webViewBackgroundColor = isFloatingUIEnabled ? UIColor(designSystemColor: .surfaceCanvas) : newColor
-        tabViewController?.webView?.underPageBackgroundColor = webViewBackgroundColor
-        tabViewController?.webView?.scrollView.backgroundColor = webViewBackgroundColor
+        if isFloatingUIEnabled {
+            // nil = WebKit's page-derived color (what the glass policy reads); still never the site theme color (#6554).
+            tabViewController?.webView?.underPageBackgroundColor = nil
+            tabViewController?.webView?.scrollView.backgroundColor = UIColor(designSystemColor: .surfaceCanvas)
+        } else {
+            tabViewController?.webView?.underPageBackgroundColor = newColor
+            tabViewController?.webView?.scrollView.backgroundColor = newColor
+        }
     }
 
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1218233582452852
Tech Design URL:
CC:

Stacked on #6731. Follows #6729, which made the toolbar icons track the glass's dark trait — this fixes why the glass never went dark on a dark *website* in the first place.

### Description
On a dark website with the app in light mode (most visible with a top address bar), the bottom toolbar glass stayed light-trait, so its icons had no contrast against the dark page showing through it.

The floating glass decides light/dark from the page's background colour, which WebKit derives automatically from the page. #6554 started writing a fixed canvas colour over that value (to keep websites' theme-colour off the bar edges) — a side effect of writing it is that WebKit stops deriving it, so the glass could no longer see a dark page at all. This resets the value instead, which restores WebKit's derivation while still never applying the site theme-colour, so #6554's fix holds. It also observes that value per tab so the glass re-evaluates on navigation; before, it only did so after a tab-switcher transition or a system appearance change.

### Testing Steps
1. Floating UI on, app in light mode, address bar at the top.
2. Open a dark site with no theme-colour meta tag (e.g. musio.com) → bottom toolbar glass and icons go dark/light-on-dark and stay legible; the top address bar adapts too.
3. Navigate to a light site (e.g. apple.com) in the same tab → glass and icons return to light.
4. Repeat with the address bar at the bottom → same result.
5. Open a Fire Tab → still dark as before (#6729 unaffected).
6. Pull down to overscroll on the dark site → the bounce area is the page's own colour, not a brand theme-colour.

### Impact
Low: visual contrast fix, no functional change.

#### What could go wrong?
- Overscroll bounce area under floating UI is now the page-derived colour instead of the canvas colour → intentional; it is the page's actual background, not the site theme-colour #6554 removed, and it is what makes the glass response coherent.
- WebKit may update the derived colour a few times while a page paints, each re-running the glass refresh → cosmetic; an "unchanged → skip" guard was deliberately not added because the tab-switcher path relies on forcing a re-snapshot.

### Quality Considerations
Verified live on iPhone 17 Pro Max (iOS 26.5) for steps 1–3. `FloatingGlassAppearancePolicyTests` pass. `BrowserToolbarViewTests` has two inset assertions (`testWhenEmbeddedFloatingThenOuterInsetIsEqualOnEveryEdge`, `testWhenBottomOmnibarDetachesForFocusThenOuterInsetsStayUnchanged`) that fail identically on the base branch without these changes — pre-existing and geometry-related, not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual/contrast-only changes around WebKit background colour and glass refresh; no auth, data, or core navigation logic touched.
> 
> **Overview**
> Fixes floating toolbar/omnibar glass staying **light-trait** on dark websites when the app is in light mode, so icons lacked contrast against the page showing through the bar.
> 
> **`SiteThemeColorManager`** no longer forces `underPageBackgroundColor` to the canvas colour when floating UI is on—it sets it to **`nil`** so WebKit keeps a **page-derived** background (what `FloatingGlassAppearancePolicy` reads), while the scroll view still uses the canvas colour so site theme colours don’t bleed at the edges (#6554 behaviour preserved).
> 
> **`MainViewController`** **KVO-observes** `underPageBackgroundColor` on the active tab and calls **`refreshSettledFloatingGlassAppearance()`** when it changes, so glass re-evaluates on navigation—not only on tab switch or trait changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59d6c4d6cf368177651521c7f41e7e64cfb1d23c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->