### PR TITLE
[macOS] Fix Sync Favicons promo interrupting Sync UI tests

### DIFF
--- a/macOS/DuckDuckGo/Sync/Promo/SyncFaviconsPromoDelegate.swift
+++ b/macOS/DuckDuckGo/Sync/Promo/SyncFaviconsPromoDelegate.swift
@@ -18,6 +18,7 @@
 
 import AppKit
 import Combine
+import Common
 import DDGSync
 import Foundation
 import Persistence
@@ -69,8 +70,12 @@ final class SyncFaviconsPromoDelegate: InternalPromoDelegate {
     }
 
     private func computeEligibility() -> Bool {
-        guard featureFlagger.isFeatureOn(.promoQueueSyncFaviconsPromo) else { return false }
-        guard let syncService, let syncBookmarksAdapter else { return false }
+        guard AppVersion.runType != .uiTests,
+              featureFlagger.isFeatureOn(.promoQueueSyncFaviconsPromo),
+              let syncService,
+              let syncBookmarksAdapter else {
+            return false
+        }
         return syncService.featureFlags.contains(.userInterface)
             && !syncBookmarksAdapter.isFaviconsFetchingEnabled
             && syncBookmarksAdapter.isEligibleForFaviconsFetcherOnboarding


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ External contributors: file an issue before opening a PR.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1209825025475019/task/1218200877706415?focus=true
Tech Design URL:
CC:

### Description

Fixes Sync End-to-End tests by suppressing Sync Favicons promo. Before this promo was migrated to the Promo Queue, it was only shown in `normal` app runs. After migration, the promo was interrupting the Sync UI tests.

The promo needs to be enabled in both `normal` and `unitTests` runs now, but disabling it in `uiTests` runs will prevent the flaky UI test failures.

### Testing Steps
<!-- One action per step. Note expected outcome inline where relevant, e.g. "3. Tap Save → settings screen dismisses". Assume the reviewer is unfamiliar with this part of the app. -->
1. Confirm Sync End-to-End tests pass: https://github.com/duckduckgo/apple-browsers/actions/runs/34211613245
2. Confirm the promo still appears in normal app runs:

Prerequisites: 

* An internal build with `promoQueue` and `promoQueueSyncFaviconsPromo` both on (both default to enabled)
* A second device to sync with.
* If you have already seen this promo (on any earlier build), first clear the history:
   * Debug → Sync → Reset Favicons Fetcher Onboarding Dialog
   * Debug → Promo Queue → Reset All Promo State (If a different promo appears and the sync-favicons promo is listed as in cooldown under Debug → Promo Queue, you can use Debug → Promo Queue → Advance Simulated Date to advance past the cooldown)

Testing steps:

1. On device A (macOS device), set up Sync and connect device B, so Settings → Sync & Backup lists two devices.
3. On device A, in Settings → Sync & Backup, confirm "Auto-Download Icons" is **off**. → Visiting this screen while more than one device is listed is also what marks you eligible for the promo.
4. On device B, bookmark a site that device A has never visited, and wait for it to sync to A.
5. On device A, open Bookmarks → Manage Bookmarks and find the newly synced bookmark. → The "Download Missing Icons?" dialog appears as a sheet on the main window.
6. Click "Not Now" → Sheet dismisses.

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
3. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
4. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->
None: Internal tooling, documentation

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow test-run guard on promo eligibility with no changes to sync behavior or user-facing logic in production.
> 
> **Overview**
> **Prevents the Sync Favicons promo from becoming eligible during UI test runs**, which was causing flaky Sync end-to-end failures after the promo moved onto the Promo Queue.
> 
> `SyncFaviconsPromoDelegate.computeEligibility()` now returns `false` when `AppVersion.runType` is `.uiTests`, alongside the existing feature-flag and sync checks. **`import Common`** was added so `AppVersion` is available. Normal and unit-test runs are unchanged; only UI automation should no longer see the “Download Missing Icons?” sheet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfc666557e5b3b24e6173500e0a205a1e0438a61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->