### PR TITLE
[iOS] improve pull to refresh on floating ui (2nd pass)

### DIFF
--- a/iOS/DuckDuckGo/PullToRefreshViewAdapter.swift
+++ b/iOS/DuckDuckGo/PullToRefreshViewAdapter.swift
@@ -81,7 +81,7 @@ final class PullToRefreshViewAdapter: NSObject {
 
     static func refreshBackgroundColor(pageBackgroundColor: UIColor?, isFloatingUIEnabled: Bool) -> UIColor {
         isFloatingUIEnabled
-            ? UIColor(designSystemColor: .surfaceCanvas)
+            ? UIColor(designSystemColor: .background)
             : pageBackgroundColor ?? UIColor(designSystemColor: .background)
     }
 

--- a/iOS/DuckDuckGo/PullToRefreshViewAdapter.swift
+++ b/iOS/DuckDuckGo/PullToRefreshViewAdapter.swift
@@ -18,6 +18,7 @@
 //
 
 import UIKit
+import WebKit
 
 /**
  *
@@ -44,17 +45,23 @@ final class PullToRefreshViewAdapter: NSObject {
         // Base values for portrait orientation on standard devices
         static let refreshTriggerRatio: CGFloat = 0.3 // % of container height as float
 
-        // Minimum values to ensure usability on very small screens
-        static let minimumPullLimit: CGFloat = 120
         static let minimumTriggerThreshold: CGFloat = 80
+        static let maximumFloatingUITriggerThreshold: CGFloat = 120
     }
 
     private var refreshTriggerThreshold: CGFloat {
         let containerHeight = pullableView?.bounds.height ?? UIScreen.main.bounds.height
-        let calculatedThreshold = containerHeight * Constant.refreshTriggerRatio
-        return max(calculatedThreshold, Constant.minimumTriggerThreshold)
+        return Self.refreshTriggerThreshold(containerHeight: containerHeight,
+                                            isFloatingUIEnabled: isFloatingUIEnabled)
     }
 
+    static func refreshTriggerThreshold(containerHeight: CGFloat, isFloatingUIEnabled: Bool) -> CGFloat {
+        let calculatedThreshold = containerHeight * Constant.refreshTriggerRatio
+        let threshold = max(calculatedThreshold, Constant.minimumTriggerThreshold)
+        return isFloatingUIEnabled ? min(threshold, Constant.maximumFloatingUITriggerThreshold) : threshold
+    }
+
+    private let backdropView = UIView()
     private let fakeScrollView = UIScrollView()
     private let refreshControl = UIRefreshControl()
     private var topConstraint: NSLayoutConstraint?
@@ -67,9 +74,13 @@ final class PullToRefreshViewAdapter: NSObject {
     private var didEndRefreshing = false
     private var initialTranslationY: CGFloat = 0
     private var pullableViewClipsToBoundsBeforePull: Bool?
+    private var pullableViewBackgroundColorBeforePull: UIColor?
+    private var scrollViewBackgroundColorBeforePull: UIColor?
+    private var webViewBackgroundColorsBeforePull: (background: UIColor?, underPage: UIColor?)?
 
     private weak var scrollView: UIScrollView?
     private weak var pullableView: UIView?
+    private weak var webView: WKWebView?
     private let isFloatingUIEnabled: Bool
     private let onRefresh: () -> Void
 
@@ -83,6 +94,12 @@ final class PullToRefreshViewAdapter: NSObject {
         isFloatingUIEnabled
             ? UIColor(designSystemColor: .background)
             : pageBackgroundColor ?? UIColor(designSystemColor: .background)
+    }
+
+    static func applyRefreshBackgroundColor(_ backgroundColor: UIColor, to webView: WKWebView) {
+        webView.backgroundColor = backgroundColor
+        webView.scrollView.backgroundColor = backgroundColor
+        webView.underPageBackgroundColor = backgroundColor
     }
 
     private func determineRefreshControlTintColor(for backgroundColor: UIColor?) -> UIColor {
@@ -109,10 +126,12 @@ final class PullToRefreshViewAdapter: NSObject {
      */
     init(with scrollView: UIScrollView,
          pullableView: UIView,
+         webView: WKWebView? = nil,
          isFloatingUIEnabled: Bool,
          onRefresh: @escaping () -> Void) {
         self.scrollView = scrollView
         self.pullableView = pullableView
+        self.webView = webView
         self.isFloatingUIEnabled = isFloatingUIEnabled
         self.onRefresh = onRefresh
 
@@ -130,22 +149,39 @@ final class PullToRefreshViewAdapter: NSObject {
     private func applyBackgroundColor() {
         let refreshBackgroundColor = Self.refreshBackgroundColor(pageBackgroundColor: backgroundColor,
                                                                  isFloatingUIEnabled: isFloatingUIEnabled)
-        fakeScrollView.backgroundColor = refreshBackgroundColor
+        backdropView.backgroundColor = refreshBackgroundColor
+        fakeScrollView.backgroundColor = .clear
+        refreshControl.backgroundColor = refreshBackgroundColor
         refreshControl.tintColor = determineRefreshControlTintColor(for: refreshBackgroundColor)
     }
 
     private func setupBackgroundScrollView(basedOn view: UIView) {
+        guard let superview = view.superview else { return }
+
+        backdropView.translatesAutoresizingMaskIntoConstraints = false
+        superview.insertSubview(backdropView, at: 0)
+
         // Set up the background scroll view that will be visible when pulling down
         fakeScrollView.backgroundColor = .clear
         fakeScrollView.translatesAutoresizingMaskIntoConstraints = false
         fakeScrollView.isScrollEnabled = true // Enable scrolling for refresh control
-
-        view.superview?.addSubview(fakeScrollView)
-        view.superview?.sendSubviewToBack(fakeScrollView)
+        fakeScrollView.clipsToBounds = false
+        if isFloatingUIEnabled {
+            fakeScrollView.isUserInteractionEnabled = false
+            fakeScrollView.contentInsetAdjustmentBehavior = .never
+            superview.insertSubview(fakeScrollView, aboveSubview: view)
+        } else {
+            superview.insertSubview(fakeScrollView, aboveSubview: backdropView)
+        }
 
         let topConstraint = fakeScrollView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor)
         self.topConstraint = topConstraint
+
         NSLayoutConstraint.activate([
+            backdropView.topAnchor.constraint(equalTo: superview.topAnchor),
+            backdropView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            backdropView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            backdropView.bottomAnchor.constraint(equalTo: superview.bottomAnchor),
             topConstraint,
             fakeScrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             fakeScrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
@@ -209,6 +245,12 @@ final class PullToRefreshViewAdapter: NSObject {
             if !isPulling, isFloatingUIEnabled, pullableViewClipsToBoundsBeforePull == nil {
                 pullableViewClipsToBoundsBeforePull = pullableView?.clipsToBounds
                 pullableView?.clipsToBounds = true
+                pullableViewBackgroundColorBeforePull = pullableView?.backgroundColor
+                scrollViewBackgroundColorBeforePull = scrollView.backgroundColor
+                if let webView {
+                    webViewBackgroundColorsBeforePull = (webView.backgroundColor, webView.underPageBackgroundColor)
+                }
+                applyFloatingRefreshBackground()
             }
             scrollView.bounces = false
             isPulling = true
@@ -233,6 +275,8 @@ final class PullToRefreshViewAdapter: NSObject {
     }
 
     private func handlePullEffect(pullDistance: CGFloat) {
+        applyFloatingRefreshBackground()
+
         // Move the pullable view down based on pull distance
         pullableView?.transform = CGAffineTransform(translationX: pullableView?.frame.origin.x ?? 0,
                                                     y: pullDistance)
@@ -241,6 +285,17 @@ final class PullToRefreshViewAdapter: NSObject {
         // We only adjust the content offset if not refreshing to avoid hiding the refresh spinner
         if !refreshControl.isRefreshing {
             fakeScrollView.contentOffset.y = -pullDistance * 0.5
+        }
+    }
+
+    private func applyFloatingRefreshBackground() {
+        guard isFloatingUIEnabled else { return }
+        let refreshBackgroundColor = Self.refreshBackgroundColor(pageBackgroundColor: backgroundColor,
+                                                                 isFloatingUIEnabled: true)
+        pullableView?.backgroundColor = refreshBackgroundColor
+        scrollView?.backgroundColor = refreshBackgroundColor
+        if let webView {
+            Self.applyRefreshBackgroundColor(refreshBackgroundColor, to: webView)
         }
     }
 
@@ -275,6 +330,15 @@ final class PullToRefreshViewAdapter: NSObject {
     private func restorePullableViewClippingIfNeeded() {
         guard !isPulling, let pullableViewClipsToBoundsBeforePull else { return }
         pullableView?.clipsToBounds = pullableViewClipsToBoundsBeforePull
+        pullableView?.backgroundColor = pullableViewBackgroundColorBeforePull
+        pullableViewBackgroundColorBeforePull = nil
+        scrollView?.backgroundColor = scrollViewBackgroundColorBeforePull
+        scrollViewBackgroundColorBeforePull = nil
+        if let webViewBackgroundColorsBeforePull {
+            webView?.backgroundColor = webViewBackgroundColorsBeforePull.background
+            webView?.underPageBackgroundColor = webViewBackgroundColorsBeforePull.underPage
+            self.webViewBackgroundColorsBeforePull = nil
+        }
         self.pullableViewClipsToBoundsBeforePull = nil
     }
 

--- a/iOS/DuckDuckGo/PullToRefreshViewAdapter.swift
+++ b/iOS/DuckDuckGo/PullToRefreshViewAdapter.swift
@@ -66,17 +66,23 @@ final class PullToRefreshViewAdapter: NSObject {
     private var didTriggerRefresh = false
     private var didEndRefreshing = false
     private var initialTranslationY: CGFloat = 0
+    private var pullableViewClipsToBoundsBeforePull: Bool?
 
     private weak var scrollView: UIScrollView?
     private weak var pullableView: UIView?
+    private let isFloatingUIEnabled: Bool
     private let onRefresh: () -> Void
 
     var backgroundColor: UIColor? {
         didSet {
-            fakeScrollView.backgroundColor = backgroundColor ?? UIColor(designSystemColor: .background)
-            // Set refresh control tint color based on background brightness
-            refreshControl.tintColor = determineRefreshControlTintColor(for: backgroundColor)
+            applyBackgroundColor()
         }
+    }
+
+    static func refreshBackgroundColor(pageBackgroundColor: UIColor?, isFloatingUIEnabled: Bool) -> UIColor {
+        isFloatingUIEnabled
+            ? UIColor(designSystemColor: .surfaceCanvas)
+            : pageBackgroundColor ?? UIColor(designSystemColor: .background)
     }
 
     private func determineRefreshControlTintColor(for backgroundColor: UIColor?) -> UIColor {
@@ -103,16 +109,29 @@ final class PullToRefreshViewAdapter: NSObject {
      */
     init(with scrollView: UIScrollView,
          pullableView: UIView,
+         isFloatingUIEnabled: Bool,
          onRefresh: @escaping () -> Void) {
         self.scrollView = scrollView
         self.pullableView = pullableView
+        self.isFloatingUIEnabled = isFloatingUIEnabled
         self.onRefresh = onRefresh
 
         super.init()
         setupBackgroundScrollView(basedOn: pullableView)
         fakeScrollView.refreshControl = refreshControl
         setupPanGestureRecognizer()
-        refreshControl.tintColor = UIColor(designSystemColor: .iconsSecondary)
+        if isFloatingUIEnabled {
+            applyBackgroundColor()
+        } else {
+            refreshControl.tintColor = UIColor(designSystemColor: .iconsSecondary)
+        }
+    }
+
+    private func applyBackgroundColor() {
+        let refreshBackgroundColor = Self.refreshBackgroundColor(pageBackgroundColor: backgroundColor,
+                                                                 isFloatingUIEnabled: isFloatingUIEnabled)
+        fakeScrollView.backgroundColor = refreshBackgroundColor
+        refreshControl.tintColor = determineRefreshControlTintColor(for: refreshBackgroundColor)
     }
 
     private func setupBackgroundScrollView(basedOn view: UIView) {
@@ -187,6 +206,10 @@ final class PullToRefreshViewAdapter: NSObject {
 
     private func startPullingIfAtTop(of scrollView: UIScrollView) {
         if scrollView.contentOffset.y < 0 {
+            if !isPulling, isFloatingUIEnabled, pullableViewClipsToBoundsBeforePull == nil {
+                pullableViewClipsToBoundsBeforePull = pullableView?.clipsToBounds
+                pullableView?.clipsToBounds = true
+            }
             scrollView.bounces = false
             isPulling = true
         }
@@ -244,7 +267,15 @@ final class PullToRefreshViewAdapter: NSObject {
             if !self.refreshControl.isRefreshing {
                 self.fakeScrollView.contentOffset.y = 0
             }
+        } completion: { _ in
+            self.restorePullableViewClippingIfNeeded()
         }
+    }
+
+    private func restorePullableViewClippingIfNeeded() {
+        guard !isPulling, let pullableViewClipsToBoundsBeforePull else { return }
+        pullableView?.clipsToBounds = pullableViewClipsToBoundsBeforePull
+        self.pullableViewClipsToBoundsBeforePull = nil
     }
 
     private func beginRefreshing() {

--- a/iOS/DuckDuckGo/TabViewController.swift
+++ b/iOS/DuckDuckGo/TabViewController.swift
@@ -1356,6 +1356,7 @@ class TabViewController: UIViewController {
 
         pullToRefreshViewAdapter = PullToRefreshViewAdapter(with: webView.scrollView,
                                                             pullableView: webViewContainer,
+                                                            isFloatingUIEnabled: floatingUIManager.isFloatingUIEnabled,
                                                             onRefresh: { [weak self] in
             self?.handlePullToRefresh()
         })

--- a/iOS/DuckDuckGo/TabViewController.swift
+++ b/iOS/DuckDuckGo/TabViewController.swift
@@ -1371,6 +1371,7 @@ class TabViewController: UIViewController {
 
         pullToRefreshViewAdapter = PullToRefreshViewAdapter(with: webView.scrollView,
                                                             pullableView: webViewContainer,
+                                                            webView: webView,
                                                             isFloatingUIEnabled: floatingUIManager.isFloatingUIEnabled,
                                                             onRefresh: { [weak self] in
             self?.handlePullToRefresh()

--- a/iOS/DuckDuckGoTests/FloatingUITests.swift
+++ b/iOS/DuckDuckGoTests/FloatingUITests.swift
@@ -124,6 +124,27 @@ final class FloatingUIManagerTests: XCTestCase {
 
 }
 
+final class FloatingUIPullToRefreshTests: XCTestCase {
+
+    func testWhenFloatingUIIsEnabledThenRefreshBackgroundUsesSurfaceCanvas() {
+        let pageBackgroundColor = UIColor.red
+        let refreshBackgroundColor = PullToRefreshViewAdapter.refreshBackgroundColor(pageBackgroundColor: pageBackgroundColor,
+                                                                                      isFloatingUIEnabled: true)
+        let traits = UITraitCollection(userInterfaceStyle: .light)
+
+        XCTAssertEqual(refreshBackgroundColor.resolvedColor(with: traits),
+                       UIColor(designSystemColor: .surfaceCanvas).resolvedColor(with: traits))
+    }
+
+    func testWhenFloatingUIIsDisabledThenRefreshBackgroundUsesPageColor() {
+        let pageBackgroundColor = UIColor.red
+        let refreshBackgroundColor = PullToRefreshViewAdapter.refreshBackgroundColor(pageBackgroundColor: pageBackgroundColor,
+                                                                                      isFloatingUIEnabled: false)
+
+        XCTAssertEqual(refreshBackgroundColor, pageBackgroundColor)
+    }
+}
+
 final class FloatingGlassAppearancePolicyTests: XCTestCase {
 
     func testWhenFireModeIsActiveThenInterfaceStyleIsDarkRegardlessOfDeviceAndPageAppearance() {

--- a/iOS/DuckDuckGoTests/FloatingUITests.swift
+++ b/iOS/DuckDuckGoTests/FloatingUITests.swift
@@ -18,6 +18,7 @@
 //
 
 import UIKit
+import WebKit
 import XCTest
 @testable import Core
 @testable import DuckDuckGo
@@ -126,14 +127,14 @@ final class FloatingUIManagerTests: XCTestCase {
 
 final class FloatingUIPullToRefreshTests: XCTestCase {
 
-    func testWhenFloatingUIIsEnabledThenRefreshBackgroundUsesSurfaceCanvas() {
+    func testWhenFloatingUIIsEnabledThenRefreshBackgroundUsesBackgroundColor() {
         let pageBackgroundColor = UIColor.red
         let refreshBackgroundColor = PullToRefreshViewAdapter.refreshBackgroundColor(pageBackgroundColor: pageBackgroundColor,
                                                                                       isFloatingUIEnabled: true)
         let traits = UITraitCollection(userInterfaceStyle: .light)
 
         XCTAssertEqual(refreshBackgroundColor.resolvedColor(with: traits),
-                       UIColor(designSystemColor: .surfaceCanvas).resolvedColor(with: traits))
+                       UIColor(designSystemColor: .background).resolvedColor(with: traits))
     }
 
     func testWhenFloatingUIIsDisabledThenRefreshBackgroundUsesPageColor() {
@@ -142,6 +143,81 @@ final class FloatingUIPullToRefreshTests: XCTestCase {
                                                                                       isFloatingUIEnabled: false)
 
         XCTAssertEqual(refreshBackgroundColor, pageBackgroundColor)
+    }
+
+    func testApplyingRefreshBackgroundUpdatesEveryVisibleWebViewLayer() {
+        let webView = WKWebView()
+        let refreshBackgroundColor = UIColor(designSystemColor: .background)
+        let traits = UITraitCollection(userInterfaceStyle: .light)
+        let expectedComponents = refreshBackgroundColor.resolvedColor(with: traits).cgColor.components
+
+        PullToRefreshViewAdapter.applyRefreshBackgroundColor(refreshBackgroundColor, to: webView)
+
+        XCTAssertEqual(webView.backgroundColor?.resolvedColor(with: traits).cgColor.components, expectedComponents)
+        XCTAssertEqual(webView.scrollView.backgroundColor?.resolvedColor(with: traits).cgColor.components, expectedComponents)
+        XCTAssertEqual(webView.underPageBackgroundColor?.resolvedColor(with: traits).cgColor.components, expectedComponents)
+    }
+
+    func testRefreshTriggerThresholdIsBoundedForFloatingUIWithoutChangingClassicUI() {
+        XCTAssertEqual(PullToRefreshViewAdapter.refreshTriggerThreshold(containerHeight: 844, isFloatingUIEnabled: true), 120)
+        XCTAssertEqual(PullToRefreshViewAdapter.refreshTriggerThreshold(containerHeight: 200, isFloatingUIEnabled: true), 80)
+        XCTAssertEqual(PullToRefreshViewAdapter.refreshTriggerThreshold(containerHeight: 844, isFloatingUIEnabled: false), 253.2,
+                       accuracy: 0.01)
+    }
+
+    func testWhenFloatingUIIsDisabledThenRefreshHostRemainsBehindPullableView() throws {
+        let hostView = UIView(frame: CGRect(x: 0, y: 0, width: 390, height: 844))
+        let pullableView = UIView(frame: hostView.bounds)
+        let pageScrollView = UIScrollView(frame: pullableView.bounds)
+        hostView.addSubview(pullableView)
+        pullableView.addSubview(pageScrollView)
+        _ = PullToRefreshViewAdapter(with: pageScrollView,
+                                     pullableView: pullableView,
+                                     isFloatingUIEnabled: false,
+                                     onRefresh: {})
+        let refreshHost = try XCTUnwrap(hostView.subviews.compactMap { $0 as? UIScrollView }.first)
+
+        XCTAssertLessThan(try XCTUnwrap(hostView.subviews.firstIndex(of: refreshHost)),
+                          try XCTUnwrap(hostView.subviews.firstIndex(of: pullableView)))
+        XCTAssertTrue(refreshHost.isUserInteractionEnabled)
+        XCTAssertEqual(refreshHost.contentInsetAdjustmentBehavior, .automatic)
+    }
+
+    func testWhenTopOffsetChangesThenBackdropStaysFixedAndRefreshHostAllowsOverflow() throws {
+        let hostView = UIView(frame: CGRect(x: 0, y: 0, width: 390, height: 844))
+        let pullableView = UIView(frame: hostView.bounds)
+        let pageScrollView = UIScrollView(frame: pullableView.bounds)
+        hostView.addSubview(pullableView)
+        pullableView.addSubview(pageScrollView)
+        let adapter = PullToRefreshViewAdapter(with: pageScrollView,
+                                               pullableView: pullableView,
+                                               isFloatingUIEnabled: true,
+                                               onRefresh: {})
+        hostView.layoutIfNeeded()
+        let refreshHost = try XCTUnwrap(hostView.subviews.compactMap { $0 as? UIScrollView }.first)
+        let backdrop = try XCTUnwrap(hostView.subviews.first { $0 !== pullableView && !($0 is UIScrollView) })
+        let initialBackdropMinY = backdrop.frame.minY
+        let refreshHostTopConstraint = try XCTUnwrap(hostView.constraints.first {
+            guard let constrainedView = $0.firstItem as? UIView else { return false }
+            return constrainedView === refreshHost && $0.firstAttribute == .top
+        })
+
+        adapter.setTopOffset(72)
+        hostView.layoutIfNeeded()
+
+        XCTAssertEqual(backdrop.frame.minY, initialBackdropMinY)
+        XCTAssertEqual(backdrop.frame.maxY, hostView.bounds.maxY)
+        XCTAssertEqual(refreshHostTopConstraint.constant, 72)
+        XCTAssertEqual(backdrop.backgroundColor?.resolvedColor(with: .init(userInterfaceStyle: .light)),
+                       UIColor(designSystemColor: .background).resolvedColor(with: .init(userInterfaceStyle: .light)))
+        XCTAssertEqual(refreshHost.backgroundColor, .clear)
+        XCTAssertEqual(refreshHost.refreshControl?.backgroundColor?.resolvedColor(with: .init(userInterfaceStyle: .light)),
+                       UIColor(designSystemColor: .background).resolvedColor(with: .init(userInterfaceStyle: .light)))
+        XCTAssertEqual(refreshHost.contentInsetAdjustmentBehavior, .never)
+        XCTAssertGreaterThan(try XCTUnwrap(hostView.subviews.firstIndex(of: refreshHost)),
+                             try XCTUnwrap(hostView.subviews.firstIndex(of: pullableView)))
+        XCTAssertFalse(refreshHost.isUserInteractionEnabled)
+        XCTAssertFalse(refreshHost.clipsToBounds)
     }
 }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/392891325557410/task/1218233582452894?focus=true
Tech Design URL:
CC:

### Description

Improves pull-to-refresh with Floating UI so the spinner appears promptly below the top address bar, remains fully visible, and uses a consistent design-system background. The refresh distance now feels deliberate without requiring an excessive pull, while classic UI behavior remains unchanged.

### Testing Steps

1. Enable Floating UI in the feature flag settings → floating browser controls appear.
2. Set the address bar position to Top.
3. Open a website with a background color that contrasts with the browser UI.
4. Begin pulling down from the top of the page → the spinner appears promptly below the address bar on a uniform browser-owned background.
5. Release after a short pull → the page does not reload.
6. Pull down approximately the height of the top browser area and release → the page reloads.
7. Set the address bar position to Bottom.
8. Pull down and release after reaching the refresh threshold → the spinner displays correctly and the page reloads.
9. Disable Floating UI.
10. Pull down and release after reaching the refresh threshold → classic pull-to-refresh continues to work normally.

### Impact

Low

#### What could go wrong?

Pull-to-refresh could become too sensitive or fail in classic UI → mitigated by bounded refresh distances and focused tests covering both UI modes.

### Quality Considerations

- Floating UI uses a bounded refresh distance across different screen heights.
- Website colors are restored after the pull interaction completes.
- No privacy, security, or data-handling changes.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only pull-to-refresh behavior with explicit classic-mode tests; no auth, data, or security surface.
> 
> **Overview**
> **Floating UI pull-to-refresh** is reworked so the spinner shows promptly under the address bar on a consistent design-system backdrop, while **classic pull-to-refresh stays the same**.
> 
> `PullToRefreshViewAdapter` now takes `isFloatingUIEnabled` and an optional `WKWebView`. When floating UI is on, the refresh trigger distance is **capped** (80–120pt) instead of scaling with tall containers; a full-height **backdrop** stays fixed while `setTopOffset` moves only the refresh host; the fake scroll view sits **above** the web container, does not take touches, and can overflow (`clipsToBounds = false`). During a pull, page/web scroll backgrounds switch to the browser background (including `underPageBackgroundColor`), clipping is saved and restored after the gesture ends. Classic mode keeps the refresh host behind the pullable view and still uses the page background color.
> 
> `TabViewController` wires in the web view and floating UI flag. New unit tests cover background color choice, WKWebView layer updates, threshold bounds, and view stacking for both modes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6345a11bfe2ceb46998869b030772a706d393268. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->