### PR TITLE
Reduce allocations during malicious-site URL checks

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/MaliciousSiteProtection/MaliciousSiteDetector.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/MaliciousSiteProtection/MaliciousSiteDetector.swift
@@ -92,8 +92,7 @@ public final class MaliciousSiteDetector: MaliciousSiteDetecting {
 
     /// Evaluates the given URL to determine its malicious category (e.g., phishing, malware).
     public func evaluate(_ url: URL) async -> ThreatKind? {
-        guard let canonicalHost = url.canonicalHost(),
-              let canonicalUrl = url.canonicalURL() else { return .none }
+        guard let canonicalHost = url.canonicalHost() else { return .none }
         let supportedThreats = supportedThreatsProvider()
 
         let hostHash = canonicalHost.sha256
@@ -112,6 +111,9 @@ public final class MaliciousSiteDetector: MaliciousSiteDetecting {
 
         // Return no threats if no matching hash prefixes are found in the database.
         guard !hashPrefixMatchingThreatKinds.isEmpty else { return .none }
+
+        // Canonicalization copies the full URL, which can be very large. Only do it for hosts that need URL matching.
+        guard let canonicalUrl = url.canonicalURL() else { return .none }
 
         // 2. Check local Filter Sets.
         // The filter set acts as a local cache of some database entries, containing

--- a/SharedPackages/BrowserServicesKit/Tests/MaliciousSiteProtectionTests/MaliciousSiteDetectorTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/MaliciousSiteProtectionTests/MaliciousSiteDetectorTests.swift
@@ -55,6 +55,34 @@ class MaliciousSiteDetectorTests: XCTestCase {
         XCTAssertEqual(result, .phishing)
     }
 
+    func testWhenMaliciousURLHasLargeQueryOrFragmentThenThreatIsStillDetected() async throws {
+        let filter = Filter(hash: "255a8a793097aeea1f06a19c08cde28db0eb34c660c6e4e7480c9525d034b16d", regex: "https://malicious.com/phishing")
+        try await mockDataManager.store(FilterDictionary(revision: 0, items: [filter]), for: .filterSet(threatKind: .phishing))
+        try await mockDataManager.store(HashPrefixSet(revision: 0, items: ["255a8a79"]), for: .hashPrefixes(threatKind: .phishing))
+
+        let payload = String(repeating: "A", count: 100_000)
+        for suffix in ["?q=\(payload)", "#\(payload)"] {
+            let url = try XCTUnwrap(URL(string: "https://malicious.com/PHISHING\(suffix)"))
+
+            let result = await detector.evaluate(url)
+
+            XCTAssertEqual(result, .phishing)
+        }
+    }
+
+    func testWhenLargeURLHasNoMatchingHostPrefixThenNoThreatIsDetected() async throws {
+        mockAPIClient.matchesForHashPrefix = { _ in
+            XCTFail("URLs without a matching host prefix must not reach the API")
+            throw URLError(.badServerResponse)
+        }
+        let url = try XCTUnwrap(URL(string: "https://example.com/?q=" + String(repeating: "A", count: 1_000_000)))
+
+        let result = await detector.evaluate(url)
+
+        XCTAssertNil(result)
+        XCTAssertTrue(mockEventMapping.events.isEmpty)
+    }
+
     func testIsScamWithLocalFilterHitReturnsNilIfFlagOff() async throws {
         isScamProtectionSupported = false
         let filter = Filter(hash: "5392ef04dc5f963fe5bc9545365de61312d7070df12aafff87e65ec55a7803a4", regex: ".*scam.*")

--- a/SharedPackages/BrowserServicesKit/Tests/MaliciousSiteProtectionTests/MaliciousSiteDetectorTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/MaliciousSiteProtectionTests/MaliciousSiteDetectorTests.swift
@@ -70,6 +70,34 @@ class MaliciousSiteDetectorTests: XCTestCase {
         }
     }
 
+    func testWhenThreatMarkerIsAtEndOfLargeQueryThenLocalAndAPIMatchesDetectIt() async throws {
+        let hostHash = "255a8a793097aeea1f06a19c08cde28db0eb34c660c6e4e7480c9525d034b16d"
+        let regex = #"^https://malicious\.com/phishing\?q=a+&marker=threat$"#
+        let filter = Filter(hash: hostHash, regex: regex)
+        let url = try XCTUnwrap(URL(string: "https://malicious.com/PHISHING?q=" + String(repeating: "A", count: 100_000) + "&MARKER=THREAT"))
+        try await mockDataManager.store(HashPrefixSet(revision: 0, items: ["255a8a79"]), for: .hashPrefixes(threatKind: .phishing))
+
+        var apiCallCount = 0
+        mockAPIClient.matchesForHashPrefix = { _ in
+            apiCallCount += 1
+            return .init(matches: [
+                Match(hostname: "malicious.com", url: url.absoluteString, regex: regex, hash: hostHash, category: "phishing")
+            ])
+        }
+
+        for useLocalFilter in [true, false] {
+            try await mockDataManager.store(
+                FilterDictionary(revision: 0, items: useLocalFilter ? [filter] : []),
+                for: .filterSet(threatKind: .phishing)
+            )
+
+            let result = await detector.evaluate(url)
+
+            XCTAssertEqual(result, .phishing)
+            XCTAssertEqual(apiCallCount, useLocalFilter ? 0 : 1)
+        }
+    }
+
     func testWhenLargeURLHasNoMatchingHostPrefixThenNoThreatIsDetected() async throws {
         mockAPIClient.matchesForHashPrefix = { _ in
             XCTFail("URLs without a matching host prefix must not reach the API")

--- a/SharedPackages/BrowserServicesKit/Tests/MaliciousSiteProtectionTests/MaliciousSiteProtectionURLTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/MaliciousSiteProtectionTests/MaliciousSiteProtectionURLTests.swift
@@ -43,4 +43,16 @@ class MaliciousSiteProtectionURLTests: XCTestCase {
         }
     }
 
+    func testWhenURLHasLargeFragmentThenCanonicalizationDiscardsIt() throws {
+        let url = try XCTUnwrap(URL(string: "http://www.example.com/PHISHING#" + String(repeating: "A", count: 1_000_000)))
+
+        XCTAssertEqual(url.canonicalURL()?.absoluteString, "http://example.com/phishing")
+    }
+
+    func testWhenURLHasEncodedFragmentDelimiterThenItRemainsInCanonicalization() throws {
+        let url = try XCTUnwrap(URL(string: "http://www.example.com/PHISHING%23SECTION#discarded"))
+
+        XCTAssertEqual(url.canonicalURL()?.absoluteString, "http://example.com/phishing#section")
+    }
+
 }

--- a/SharedPackages/Common/Sources/Common/Extensions/URLExtension.swift
+++ b/SharedPackages/Common/Sources/Common/Extensions/URLExtension.swift
@@ -675,12 +675,14 @@ extension URL {
      }
 
     public func canonicalURL() -> URL? {
-        // Step 1: Remove tab (0x09), CR (0x0d), and LF (0x0a) characters
-        var urlString = self.absoluteString.filter { $0 != "\t" && $0 != "\r" && $0 != "\n" }
+        // Remove the fragment before copying or transforming the URL: fragments can contain very large payloads.
+        let absoluteString = self.absoluteString
+        let fragmentStart = absoluteString.range(of: "#")?.lowerBound ?? absoluteString.endIndex
 
-        // Step 2: Remove the fragment
-        if let fragmentRange = urlString.range(of: "#") {
-            urlString.removeSubrange(fragmentRange.lowerBound..<urlString.endIndex)
+        // Steps 1 and 2: Remove tab (0x09), CR (0x0d), LF (0x0a), and the fragment.
+        var urlString = String(absoluteString[..<fragmentStart])
+        if urlString.contains(where: { $0 == "\t" || $0 == "\r" || $0 == "\n" }) {
+            urlString = urlString.filter { $0 != "\t" && $0 != "\r" && $0 != "\n" }
         }
 
         // Step 3: Repeatedly percent-unescape the URL until it has no more percent-escapes


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214294661819890/task/1218255584066978?focus=true

### Description

Reduce memory used by malicious-site protection when navigating to very large URLs. Avoid unnecessary URL processing and copies while preserving checks of complete URLs, including threats at the end of long queries.

This mitigates allocation pressure associated with [APPLE-IOS-FWRP](https://errors.duckduckgo.com/organizations/ddg/issues/APPLE-IOS-FWRP/?project=8). I couldn't reproduce the exact crash.

### Testing Steps

1. Run the Common tests filtered to `URLExtensionTests` → all 77 tests pass.
2. Run the `BrowserServicesKit-Package` scheme with `-only-testing:MaliciousSiteProtectionTests` → all 71 tests pass. Coverage includes large fragments, encoded fragment delimiters, and an anchored marker at the end of a large query through both local and API matching.

### Impact

High if incorrect: changes to malicious-site protection could affect which threats are blocked. The intended behavior is unchanged; this reduces unnecessary allocations.

#### What could go wrong?

- Shortening or skipping large URLs could bypass protection → tests require the query's final threat marker to match through both local filters and the API; no size cutoff or truncation is introduced.
- Moving fragment removal could alter percent-decoding behavior → tests cover literal and encoded fragment delimiters.

### Quality Considerations

- A synthetic 10 MB query benchmark reduced median macOS process RSS from approximately 83 MB to 67 MB across three runs per version. An independent rerun corroborated the reduction. These measurements do not reproduce WebKit navigation or iOS memory pressure.
- #6520 is a plausible release-specific trigger: its large-URL link-cleaning change first appears in local 7.236 tags at build 13. All crashes in Sentry point to build 18th.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches malicious-site threat detection and URL canonicalization; behavior is meant to be unchanged but a regression could miss blocks or alter regex matching on unusual URLs.
> 
> **Overview**
> Reduces memory and allocation pressure when malicious-site protection evaluates **very large URLs** (long queries or fragments), targeting crash reports tied to URL processing without changing the intended blocking rules.
> 
> **`MaliciousSiteDetector.evaluate`** now runs **host hash-prefix checks first** and only calls **`canonicalURL()`** when a prefix matches, so benign hosts with megabyte-sized URLs skip full URL canonicalization and regex/API work entirely.
> 
> **`URL.canonicalURL()`** drops the **fragment before** building the working string (fragments are ignored for matching anyway), and only filters tab/CR/LF when those characters appear—so huge `#…` payloads are not copied through the rest of the pipeline. Query strings stay intact so threats at the end of long queries still match locally and via the API.
> 
> New tests lock in detection with large query/fragment suffixes, anchored markers at the end of long queries, no API calls when the host prefix does not match, and canonicalization edge cases for large fragments vs encoded `%23` delimiters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12ce6ac1439f0b58a07a76b9dd6485bcd5c54dbe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->