### PR TITLE
[iOS] Refresh floating glass appearance when attaching new tab pages

### DIFF
--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -2203,6 +2203,9 @@ class MainViewController: UIViewController {
             return
         }
 
+        pageBackgroundColorObservation = nil
+        refreshSettledFloatingGlassAppearance()
+
         // Reset chrome state on every NTP attach — the previous tab may have been a Duck.ai tab
         // with the AI header shown and the standard toolbar hidden. Some attach paths
         // (e.g. tab switcher long-press → newTab) don't go through `refreshControls`, so


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/392891325557410/task/1218275160095579?focus=true
Tech Design URL:
CC:

### Description

Fixes floating browser controls remaining dark after opening a New Tab Page from a dark website. The controls now immediately return to the correct light appearance.

### Testing Steps

1. Enable Floating UI.
2. Set the app to light appearance.
3. Open a dark website such as `https://musio.com` → floating controls use a dark appearance with legible light icons.
4. Open the browsing menu.
5. Tap **New Tab** → the New Tab Page opens and the floating controls immediately return to a light appearance.
6. Return to the dark website → the floating controls return to a dark appearance.
7. Repeat with the address bar at both the top and bottom → the appearance updates correctly in both layouts.

### Impact

Low: Fixes a visual inconsistency when transitioning from a dark website to the New Tab Page.

### Quality Considerations

- The iOS app builds successfully.
- All four focused floating-glass appearance tests pass.
- Verified the dark website → New Tab Page transition on a clean iPhone 17 Pro simulator running iOS 26.5.
- No privacy, security, data-storage, or analytics changes.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, UI-only change on the NTP attach path with no auth, data, or analytics impact.
> 
> **Overview**
> Fixes floating browser chrome staying in a **dark** glass style after opening the New Tab Page from a dark website.
> 
> In `attachHomeScreen`, the NTP attach path now **clears** `pageBackgroundColorObservation` (so the previous tab’s web view background KVO no longer drives appearance) and calls **`refreshSettledFloatingGlassAppearance()`** before the existing AI/toolbar chrome reset. Floating controls should match the NTP/light policy immediately instead of waiting for another page-color update.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 256e762a430b723cc371a1e583a6f2d423f02f18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->