### PR TITLE
[macOS] Add V2 Sync E2E UI tests for the simplified sync setup

### DIFF
--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
@@ -1184,6 +1184,7 @@
 		37598F002D5A383A00720EAF /* HistoryViewDataProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37598EFF2D5A383600720EAF /* HistoryViewDataProviderTests.swift */; };
 		37598F012D5A383A00720EAF /* HistoryViewDataProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37598EFF2D5A383600720EAF /* HistoryViewDataProviderTests.swift */; };
 		376113CC2B29CD5B00E794BB /* CriticalPathsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 565E46DF2B2725DD0013AC2A /* CriticalPathsTests.swift */; };
+		0A1B2C3D4E5F60718293A4B1 /* CriticalPathsV2Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A1B2C3D4E5F60718293A4B0 /* CriticalPathsV2Tests.swift */; };
 		376325C12F86964C00B6B0DB /* TabSuspensionDebugMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 376325C02F86964C00B6B0DB /* TabSuspensionDebugMenu.swift */; };
 		376325C22F86964C00B6B0DB /* TabSuspensionDebugMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 376325C02F86964C00B6B0DB /* TabSuspensionDebugMenu.swift */; };
 		37657FC42DB8D564003D749E /* TabCrashRecoveryExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37657FC32DB8D55F003D749E /* TabCrashRecoveryExtensionTests.swift */; };
@@ -1978,6 +1979,7 @@
 		56534DED29DF252C00121467 /* CapturingDefaultBrowserProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56534DEC29DF252C00121467 /* CapturingDefaultBrowserProvider.swift */; };
 		56534DEE29DF252C00121467 /* CapturingDefaultBrowserProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56534DEC29DF252C00121467 /* CapturingDefaultBrowserProvider.swift */; };
 		565E46E02B2725DD0013AC2A /* CriticalPathsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 565E46DF2B2725DD0013AC2A /* CriticalPathsTests.swift */; };
+		0A1B2C3D4E5F60718293A4B2 /* CriticalPathsV2Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A1B2C3D4E5F60718293A4B0 /* CriticalPathsV2Tests.swift */; };
 		566B195D29CDB692007E38F4 /* MoreOptionsMenuTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 566B195C29CDB692007E38F4 /* MoreOptionsMenuTests.swift */; };
 		566B196429CDB824007E38F4 /* MoreOptionsMenuTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 566B195C29CDB692007E38F4 /* MoreOptionsMenuTests.swift */; };
 		566B196529CDB828007E38F4 /* CapturingOptionsButtonMenuDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 566B196029CDB7C9007E38F4 /* CapturingOptionsButtonMenuDelegate.swift */; };
@@ -5909,6 +5911,7 @@
 		56534DEC29DF252C00121467 /* CapturingDefaultBrowserProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CapturingDefaultBrowserProvider.swift; sourceTree = "<group>"; };
 		565E46DD2B2725DC0013AC2A /* SyncE2EUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SyncE2EUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		565E46DF2B2725DD0013AC2A /* CriticalPathsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CriticalPathsTests.swift; sourceTree = "<group>"; };
+		0A1B2C3D4E5F60718293A4B0 /* CriticalPathsV2Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CriticalPathsV2Tests.swift; sourceTree = "<group>"; };
 		566B195C29CDB692007E38F4 /* MoreOptionsMenuTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoreOptionsMenuTests.swift; sourceTree = "<group>"; };
 		566B196029CDB7C9007E38F4 /* CapturingOptionsButtonMenuDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CapturingOptionsButtonMenuDelegate.swift; sourceTree = "<group>"; };
 		566B73682BECBF8400FF1959 /* SyncAlertsPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncAlertsPresenter.swift; sourceTree = "<group>"; };
@@ -10005,6 +10008,7 @@
 			isa = PBXGroup;
 			children = (
 				565E46DF2B2725DD0013AC2A /* CriticalPathsTests.swift */,
+				0A1B2C3D4E5F60718293A4B0 /* CriticalPathsV2Tests.swift */,
 			);
 			path = SyncE2EUITests;
 			sourceTree = "<group>";
@@ -17646,6 +17650,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				376113CC2B29CD5B00E794BB /* CriticalPathsTests.swift in Sources */,
+				0A1B2C3D4E5F60718293A4B1 /* CriticalPathsV2Tests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -17876,6 +17881,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				565E46E02B2725DD0013AC2A /* CriticalPathsTests.swift in Sources */,
+				0A1B2C3D4E5F60718293A4B2 /* CriticalPathsV2Tests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/macOS/LocalPackages/SyncUI-macOS/Sources/SyncUI-macOS/Views/ManagementView/SyncSetupViewV2.swift
+++ b/macOS/LocalPackages/SyncUI-macOS/Sources/SyncUI-macOS/Views/ManagementView/SyncSetupViewV2.swift
@@ -98,6 +98,7 @@ struct SyncSetupViewV2<ViewModel>: View where ViewModel: ManagementViewModel {
             .labelsHidden()
             .toggleStyle(.switch)
             .accessibilityLabel(Text(UserText.syncThisDeviceTitleV2))
+            .accessibilityIdentifier("SyncSettings.syncThisDeviceToggle")
             .disabled(!model.isAccountCreationAvailable)
         }
         .padding(.horizontal, 16)

--- a/macOS/LocalPackages/SyncUI-macOS/Sources/SyncUI-macOS/Views/ManagementView/SyncedDevicesListV2.swift
+++ b/macOS/LocalPackages/SyncUI-macOS/Sources/SyncUI-macOS/Views/ManagementView/SyncedDevicesListV2.swift
@@ -81,6 +81,21 @@ struct SyncedDevicesListV2: View {
             hoveredDevice = hovering ? device : nil
         }
         .accessibilityElement(children: .combine)
+        .accessibilityIdentifier(accessibilityIdentifier(for: device))
+    }
+
+    private func accessibilityIdentifier(for device: SyncDevice) -> String {
+        if device.isCurrent {
+            return "SyncSettings.deviceRow.current"
+        }
+        switch device.kind {
+        case .current, .desktop:
+            return "SyncSettings.deviceRow.desktop"
+        case .mobile:
+            return "SyncSettings.deviceRow.mobile"
+        case .thirdParty:
+            return "SyncSettings.deviceRow.thirdParty"
+        }
     }
 
     @ViewBuilder

--- a/macOS/SyncE2EUITests/CriticalPathsTests.swift
+++ b/macOS/SyncE2EUITests/CriticalPathsTests.swift
@@ -80,6 +80,13 @@ final class CriticalPathsTests: XCTestCase {
         return bookmarksWindow
     }
 
+    private func ensureSyncSettingsWindowOpen() {
+        let settingsWindow = app.windows.containing(.button, identifier: "Sync & Backup").firstMatch
+        guard !settingsWindow.exists else { return }
+        app.typeKey(",", modifierFlags: [.command])
+        XCTAssertTrue(settingsWindow.waitForExistence(timeout: XCUIElement.Timeouts.elementExistence), "Settings window is not visible")
+    }
+
     private func accessSettings() {
         app.menuItems["MainMenu.preferencesMenuItem"].assertExists().click()
         _ = syncSettingsWindow()
@@ -268,6 +275,7 @@ final class CriticalPathsTests: XCTestCase {
         checkFavoriteNonUnified()
 
         // Remove Bookmarks
+        ensureSyncSettingsWindowOpen()
         settingsWindow.popUpButtons["Settings"].click()
         settingsWindow.menuItems["Bookmarks"].click()
         bookmarksWindow.staticTexts["www.spreadprivacy.com"].rightClick()
@@ -434,7 +442,7 @@ final class CriticalPathsTests: XCTestCase {
         let spreadPrivacy = newTabPage.staticTexts["www.spreadprivacy.com"]
         spreadPrivacy.assertExists()
         XCTAssertFalse(gitHub.exists)
-        app.typeKey("w", modifierFlags: [.command])
+        newTabPage.typeKey("w", modifierFlags: [.command])
     }
 
     private func checkBookmarks() {
@@ -472,7 +480,7 @@ final class CriticalPathsTests: XCTestCase {
         let spreadPrivacy = newTabPage.staticTexts["www.spreadprivacy.com"]
         gitHub.assertExists()
         spreadPrivacy.assertExists()
-        app.typeKey("w", modifierFlags: [.command])
+        newTabPage.typeKey("w", modifierFlags: [.command])
     }
 
     private func checkLogins() {

--- a/macOS/SyncE2EUITests/CriticalPathsV2Tests.swift
+++ b/macOS/SyncE2EUITests/CriticalPathsV2Tests.swift
@@ -155,6 +155,7 @@ final class CriticalPathsV2Tests: XCTestCase {
 
         checkFavoriteNonUnified()
 
+        ensureSyncSettingsWindowOpen()
         settingsWindow.popUpButtons["Settings"].click()
         settingsWindow.menuItems["Bookmarks"].click()
         bookmarksWindow.staticTexts["www.spreadprivacy.com"].rightClick()
@@ -201,6 +202,13 @@ final class CriticalPathsV2Tests: XCTestCase {
         let bookmarksWindow = app.windows.containing(.button, identifier: "BookmarkManagementDetailViewController.newBookmarkButton").firstMatch
         XCTAssertTrue(bookmarksWindow.waitForExistence(timeout: XCUIElement.Timeouts.elementExistence), "Bookmarks window is not visible")
         return bookmarksWindow
+    }
+
+    private func ensureSyncSettingsWindowOpen() {
+        let settingsWindow = app.windows.containing(.button, identifier: Titles.syncAndBackupPane).firstMatch
+        guard !settingsWindow.exists else { return }
+        app.typeKey(",", modifierFlags: [.command])
+        XCTAssertTrue(settingsWindow.waitForExistence(timeout: XCUIElement.Timeouts.elementExistence), "Settings window is not visible")
     }
 
     private func accessSettings() {
@@ -447,7 +455,7 @@ final class CriticalPathsV2Tests: XCTestCase {
         let spreadPrivacy = newTabPage.staticTexts["www.spreadprivacy.com"]
         spreadPrivacy.assertExists()
         XCTAssertFalse(gitHub.exists)
-        app.typeKey("w", modifierFlags: [.command])
+        newTabPage.typeKey("w", modifierFlags: [.command])
     }
 
     private func checkBookmarks() {
@@ -485,7 +493,7 @@ final class CriticalPathsV2Tests: XCTestCase {
         let spreadPrivacy = newTabPage.staticTexts["www.spreadprivacy.com"]
         gitHub.assertExists()
         spreadPrivacy.assertExists()
-        app.typeKey("w", modifierFlags: [.command])
+        newTabPage.typeKey("w", modifierFlags: [.command])
     }
 
     private func checkLogins() {

--- a/macOS/SyncE2EUITests/CriticalPathsV2Tests.swift
+++ b/macOS/SyncE2EUITests/CriticalPathsV2Tests.swift
@@ -1,7 +1,7 @@
 //
-//  CriticalPathsTests.swift
+//  CriticalPathsV2Tests.swift
 //
-//  Copyright © 2023 DuckDuckGo. All rights reserved.
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.
@@ -17,37 +17,49 @@
 //
 
 import XCTest
-import JavaScriptCore
 
-extension XCUIElement {
-    /// Timeout constants for different test requirements
-    enum Timeouts {
-        /// Mostly, we use timeouts to wait for element existence. This is about 3x longer than needed, for CI resilience
-        static let elementExistence: Double = 5.0
+final class CriticalPathsV2Tests: XCTestCase {
+
+    private enum Timeouts {
+        static let syncOperation: Double = 30.0
     }
 
-    @discardableResult
-    func assertExists(with timeout: TimeInterval = Timeouts.elementExistence) -> XCUIElement {
-        XCTAssertTrue(waitForExistence(timeout: timeout), "UI element didn't become available in a reasonable timeframe.")
-        return self
+    private enum Identifiers {
+        static let syncThisDeviceToggle = "SyncSettings.syncThisDeviceToggle"
+        static let currentDeviceRow = "SyncSettings.deviceRow.current"
+        static let mobileDeviceRow = "SyncSettings.deviceRow.mobile"
+        static let successCopyCodeButton = "SyncSuccessCopyCodeButton"
+        static let successDoneButton = "SyncSuccessDoneButton"
     }
-}
 
-final class CriticalPathsTests: XCTestCase {
-
-    var isCI: Bool {
-        !(ProcessInfo.processInfo.environment["CI"]?.isEmpty ?? true)
+    private enum Titles {
+        static let syncAndBackupPane = "Sync & Backup"
+        static let beginSync = "Keep DuckDuckGo in sync!"
+        static let myDevices = "My Devices"
+        static let syncWithAnotherDevice = "Sync With Another Device"
+        static let syncThisDeviceOnly = "Sync This Device Only"
+        static let recoveryCode = "I Have a Recovery Code"
+        static let getStarted = "Get Started"
+        static let enterCodeTab = "Enter Code"
+        static let pasteCode = "Paste Code"
+        static let paste = "Paste"
+        static let deviceDetails = "Details..."
+        static let turnOffSync = "Turn Off Sync & Backup"
+        static let removeDevice = "Remove Device"
+        static let turnOffAndDeleteServerData = "Turn Off and Delete Server Data"
+        static let deleteServerData = "Delete Server Data"
+        static let shareFavorites = "Share Favorites Across Devices"
+        static let syncFailed = "Sync failed."
+        static let gotIt = "Got It"
     }
 
     var app: XCUIApplication!
     var debugMenuBarItem: XCUIElement!
-    var internaluserstateMenuItem: XCUIElement!
 
     override func setUp() {
-        // Launch App
         app = XCUIApplication(bundleIdentifier: "com.duckduckgo.macos.browser.review")
         app.launchEnvironment["UITEST_MODE"] = "1"
-        app.launchEnvironment["FEATURE_FLAGS"] = "simplifiedSyncSetupV2=false"
+        app.launchEnvironment["FEATURE_FLAGS"] = "simplifiedSyncSetupV2=true"
         app.launch()
         ensureMainWindowOpen()
         selectDevelopmentEnvironment()
@@ -59,6 +71,117 @@ final class CriticalPathsTests: XCTestCase {
         app.typeKey(",", modifierFlags: [.command, .option, .shift])
     }
 
+    // MARK: - Tests
+
+    func testCanCreateSyncAccount() throws {
+        openSyncSettings()
+
+        createAccountForThisDeviceOnly()
+        assertSyncIsEnabled()
+
+        deleteServerData()
+        assertSyncIsDisabled()
+    }
+
+    func testCanRecoverSyncAccount() throws {
+        openSyncSettings()
+
+        createAccountForThisDeviceOnly(copyingRecoveryCode: true)
+        assertSyncIsEnabled()
+
+        turnOffSync()
+        assertSyncIsDisabled()
+
+        recoverSyncedData()
+        assertSyncIsEnabled()
+
+        deleteServerData()
+        assertSyncIsDisabled()
+    }
+
+    func testCanRemoveData() {
+        openSyncSettings()
+
+        createAccountForThisDeviceOnly(copyingRecoveryCode: true)
+        assertSyncIsEnabled()
+
+        deleteServerData()
+        assertSyncIsDisabled()
+
+        pasteCodeOnConnectScreen()
+
+        let settingsWindow = syncSettingsWindow()
+        let alertSheet = settingsWindow.sheets.sheets["alert"]
+        alertSheet.staticTexts[Titles.syncFailed].assertExists(with: Timeouts.syncOperation)
+        alertSheet.buttons[Titles.gotIt].assertExists().click()
+    }
+
+    func testCanLoginToExistingSyncAccount() {
+        guard let code = ProcessInfo.processInfo.environment["CODE"] else {
+            XCTFail("CODE not set")
+            return
+        }
+
+        openSyncSettings()
+        copyToClipboard(code: code)
+
+        logIn()
+
+        logOut()
+    }
+
+    func testCanSyncData() {
+        guard let code = ProcessInfo.processInfo.environment["CODE"] else {
+            XCTFail("CODE not set")
+            return
+        }
+
+        addBookmarksAndFavorites()
+        addLogin()
+        addCreditCard()
+        addIdentity()
+
+        copyToClipboard(code: code)
+
+        let bookmarksWindow = bookmarkManagerWindow()
+        bookmarksWindow.splitGroups.children(matching: .popUpButton).element.click()
+        bookmarksWindow.menuItems["Settings"].click()
+        logIn()
+
+        let settingsWindow = syncSettingsWindow()
+        XCTAssertFalse(settingsWindow.checkBoxes[Titles.shareFavorites].value as! Bool)
+
+        logOut()
+
+        checkFavoriteNonUnified()
+
+        settingsWindow.popUpButtons["Settings"].click()
+        settingsWindow.menuItems["Bookmarks"].click()
+        bookmarksWindow.staticTexts["www.spreadprivacy.com"].rightClick()
+        bookmarksWindow.menus.menuItems["ContextualMenu.deleteBookmark"].click()
+        bookmarksWindow.staticTexts["www.duckduckgo.com"].rightClick()
+        bookmarksWindow.menus.menuItems["ContextualMenu.deleteBookmark"].click()
+
+        bookmarksWindow.splitGroups.children(matching: .popUpButton).element.click()
+        bookmarksWindow.menuItems["Settings"].click()
+        logIn()
+
+        settingsWindow.checkBoxes[Titles.shareFavorites].click()
+        XCTAssertTrue(settingsWindow.checkBoxes[Titles.shareFavorites].value as! Bool)
+
+        checkBookmarks()
+        checkUnifiedFavorites()
+        checkLogins()
+        checkCreditCards()
+        checkIdentities()
+
+        app.typeKey(",", modifierFlags: [.command])
+        XCTAssertTrue(settingsWindow.checkBoxes[Titles.shareFavorites].value as! Bool)
+        settingsWindow.checkBoxes[Titles.shareFavorites].click()
+    }
+
+    // MARK: - App and window helpers
+
     private func ensureMainWindowOpen() {
         if app.windows.firstMatch.exists {
             return
@@ -69,7 +192,7 @@ final class CriticalPathsTests: XCTestCase {
     }
 
     private func syncSettingsWindow() -> XCUIElement {
-        let settingsWindow = app.windows.containing(.button, identifier: "Sync & Backup").firstMatch
+        let settingsWindow = app.windows.containing(.button, identifier: Titles.syncAndBackupPane).firstMatch
         XCTAssertTrue(settingsWindow.waitForExistence(timeout: XCUIElement.Timeouts.elementExistence), "Settings window is not visible")
         return settingsWindow
     }
@@ -109,223 +232,111 @@ final class CriticalPathsTests: XCTestCase {
         app.menuItems["MainMenu.resetSecureVaultData"].click()
     }
 
-    func testCanCreateSyncAccount() throws {
-        // Go to Sync Set up
-        accessSettings()
-        let settingsWindow = syncSettingsWindow()
-        settingsWindow.buttons["Sync & Backup"].click()
+    // MARK: - Sync setup helpers
 
-        // Create Account
-        let sheetsQuery = settingsWindow.sheets
-        settingsWindow/*@START_MENU_TOKEN@*/.buttons["Sync and Back Up This Device"]/*[[".groups",".scrollViews.buttons[\"Sync and Back Up This Device\"]",".buttons[\"Sync and Back Up This Device\"]"],[[[-1,2],[-1,1],[-1,0,1]],[[-1,2],[-1,1]]],[0]]@END_MENU_TOKEN@*/.click()
-        sheetsQuery.buttons["Turn On Sync & Backup"].click()
-        _ = sheetsQuery.buttons["Next"].waitForExistence(timeout: 5)
-        sheetsQuery.buttons["Next"].click()
-        sheetsQuery.buttons["Done"].click()
-        let syncEnabledElement = settingsWindow.staticTexts["Sync Enabled"]
-        XCTAssertTrue(syncEnabledElement.exists, "Sync Enabled text is not visible")
-
-        // Clean Up
-        settingsWindow.swipeUp()
-        settingsWindow/*@START_MENU_TOKEN@*/.buttons["Turn Off and Delete Server Data…"]/*[[".groups",".scrollViews.buttons[\"Turn Off and Delete Server Data…\"]",".buttons[\"Turn Off and Delete Server Data…\"]"],[[[-1,2],[-1,1],[-1,0,1]],[[-1,2],[-1,1]]],[0]]@END_MENU_TOKEN@*/.click()
-        sheetsQuery.buttons["Delete Data"].click()
-        let beginSync = settingsWindow.staticTexts["Begin Syncing"]
-        beginSync.click()
-        XCTAssertTrue(beginSync.exists, "Begin Syncing text is not visible")
+    private func element(_ identifier: String, in container: XCUIElement) -> XCUIElement {
+        container.descendants(matching: .any).matching(identifier: identifier).firstMatch
     }
 
-    func testCanRecoverSyncAccount() throws {
-        // Go to Sync Set up
+    private func openSyncSettings() {
         accessSettings()
         let settingsWindow = syncSettingsWindow()
-        settingsWindow.buttons["Sync & Backup"].click()
-
-        // Create Account
-        let sheetsQuery = settingsWindow.sheets
-        settingsWindow.buttons["Sync and Back Up This Device"].click()
-        sheetsQuery.buttons["Turn On Sync & Backup"].click()
-        sheetsQuery.buttons["Copy Code"].click()
-        sheetsQuery.buttons["Next"].click()
-        sheetsQuery.buttons["Done"].click()
-        let syncEnabledElement = settingsWindow.staticTexts["Sync Enabled"]
-        XCTAssertTrue(syncEnabledElement.exists, "Sync Enabled text is not visible")
-
-        // Log out
-        settingsWindow.buttons["Turn Off Sync…"].click()
-        sheetsQuery.buttons["Turn Off"].click()
-
-        // Recover Account
-        settingsWindow.buttons["Recover Synced Data"].click()
-        sheetsQuery.buttons["Get Started"].click()
-        sheetsQuery.buttons["Paste"].click()
-        sheetsQuery.buttons["Next"].click()
-        sheetsQuery.buttons["Done"].click()
-        XCTAssertTrue(syncEnabledElement.exists, "Sync Enabled text is not visible")
-
-        // Clean Up
-        settingsWindow.swipeUp()
-        settingsWindow.buttons["Turn Off and Delete Server Data…"].click()
-        sheetsQuery.buttons["Delete Data"].click()
-        let beginSync = settingsWindow.staticTexts["Begin Syncing"]
-        beginSync.click()
-        XCTAssertTrue(beginSync.exists, "Begin Sync text is not visible")
-
+        settingsWindow.buttons[Titles.syncAndBackupPane].click()
     }
 
-    func testCanRemoveData() {
-
-        // Go to Sync Set up
-        accessSettings()
-
+    private func createAccountForThisDeviceOnly(copyingRecoveryCode: Bool = false) {
         let settingsWindow = syncSettingsWindow()
-        settingsWindow.buttons["Sync & Backup"].click()
-
-        // Create Account
         let sheetsQuery = settingsWindow.sheets
-        settingsWindow.buttons["Sync and Back Up This Device"].click()
-        sheetsQuery.buttons["Turn On Sync & Backup"].click()
-        sheetsQuery.buttons["Copy Code"].click()
-        sheetsQuery.buttons["Next"].click()
-        sheetsQuery.buttons["Done"].click()
-        let syncEnabledElement = settingsWindow.staticTexts["Sync Enabled"]
-        XCTAssertTrue(syncEnabledElement.exists, "Sync Enabled text is not visible")
 
-        // Delete Data
-        settingsWindow.swipeUp()
-        settingsWindow.buttons["Turn Off and Delete Server Data…"].click()
-        sheetsQuery.buttons["Delete Data"].click()
-        let beginSync = settingsWindow.staticTexts["Begin Syncing"]
-        beginSync.click()
-        XCTAssertTrue(beginSync.exists, "Begyn Sync text is not visible")
+        element(Identifiers.syncThisDeviceToggle, in: settingsWindow).assertExists().click()
+        sheetsQuery.buttons[Titles.syncThisDeviceOnly].assertExists().click()
 
-        // Log In and check error
-        settingsWindow.buttons["Sync With Another Device"].click()
-        let settingsSheetsQuery = settingsWindow.sheets
-        settingsSheetsQuery.buttons["Enter Code"].click()
-        settingsSheetsQuery.buttons["Paste"].click()
-        let alertSheet = sheetsQuery.sheets["alert"]
-        alertSheet.staticTexts["Sync failed."].assertExists()
-        alertSheet.buttons["Got It"].assertExists().click()
-
-    }
-
-    func testCanLoginToExistingSyncAccount() {
-        guard let code = ProcessInfo.processInfo.environment["CODE"] else {
-            XCTFail("CODE not set")
-            return
+        let doneButton = sheetsQuery.buttons[Identifiers.successDoneButton]
+        doneButton.assertExists(with: Timeouts.syncOperation)
+        if copyingRecoveryCode {
+            sheetsQuery.buttons[Identifiers.successCopyCodeButton].assertExists().click()
         }
-
-        // Go to Sync Set up
-        accessSettings()
-        let settingsWindow = syncSettingsWindow()
-        settingsWindow.buttons["Sync & Backup"].click()
-
-        // Copy code to clipboard
-        copyToClipboard(code: code)
-
-        // Log In
-        logIn()
-
-        // Clean Up
-        logOut()
+        doneButton.click()
     }
 
-    func testCanSyncData() {
-        guard let code = ProcessInfo.processInfo.environment["CODE"] else {
-            XCTFail("CODE not set")
-            return
-        }
-
-        // Add Bookmarks and Favorite
-        addBookmarksAndFavorites()
-
-        // Add Login
-        addLogin()
-
-        // Add Credit Card
-        addCreditCard()
-
-        // Add Identity
-        addIdentity()
-
-        // Copy code to clipboard
-        copyToClipboard(code: code)
-
-        // Log In
-        let bookmarksWindow = bookmarkManagerWindow()
-        bookmarksWindow.splitGroups.children(matching: .popUpButton).element.click()
-        bookmarksWindow.menuItems["Settings"].click()
-        logIn()
-
-        // Ensure Unify Favorites not checked
+    private func recoverSyncedData() {
         let settingsWindow = syncSettingsWindow()
-        XCTAssertFalse(settingsWindow.checkBoxes["Unify Favorites Across Devices"].value as! Bool)
+        let sheetsQuery = settingsWindow.sheets
 
-        // Log Out
-        logOut()
+        settingsWindow.buttons[Titles.recoveryCode].assertExists().click()
+        sheetsQuery.buttons[Titles.getStarted].assertExists().click()
+        sheetsQuery.buttons[Titles.paste].assertExists(with: Timeouts.syncOperation).click()
 
-        // Check Favorites not unified
-        checkFavoriteNonUnified()
+        sheetsQuery.buttons[Identifiers.successDoneButton].assertExists(with: Timeouts.syncOperation).click()
+    }
 
-        // Remove Bookmarks
-        settingsWindow.popUpButtons["Settings"].click()
-        settingsWindow.menuItems["Bookmarks"].click()
-        bookmarksWindow.staticTexts["www.spreadprivacy.com"].rightClick()
-        bookmarksWindow.menus.menuItems["ContextualMenu.deleteBookmark"].click()
-        bookmarksWindow.staticTexts["www.duckduckgo.com"].rightClick()
-        bookmarksWindow.menus.menuItems["ContextualMenu.deleteBookmark"].click()
+    private func pasteCodeOnConnectScreen() {
+        let settingsWindow = syncSettingsWindow()
+        let sheetsQuery = settingsWindow.sheets
 
-        // Log In
-        bookmarksWindow.splitGroups.children(matching: .popUpButton).element.click()
-        bookmarksWindow.menuItems["Settings"].click()
-        logIn()
-
-        // Toggle Unified Favorite
-        settingsWindow.checkBoxes["Unify Favorites Across Devices"].click()
-        XCTAssertTrue(settingsWindow.checkBoxes["Unify Favorites Across Devices"].value as! Bool)
-
-        // Check Bookmarks
-        checkBookmarks()
-
-        // Check Unified favorites
-        checkUnifiedFavorites()
-
-        // Check Logins
-        checkLogins()
-
-        // Check Credit Cards
-        checkCreditCards()
-
-        // Check Identities
-        checkIdentities()
-
-        // Switch Unified Favorite back off
-        app.typeKey(",", modifierFlags: [.command])
-        XCTAssertTrue(settingsWindow.checkBoxes["Unify Favorites Across Devices"].value as! Bool)
-        settingsWindow.checkBoxes["Unify Favorites Across Devices"].click()
+        settingsWindow.buttons[Titles.syncWithAnotherDevice].assertExists().click()
+        sheetsQuery.buttons[Titles.enterCodeTab].assertExists(with: Timeouts.syncOperation).click()
+        sheetsQuery.buttons[Titles.pasteCode].assertExists().click()
     }
 
     private func logIn() {
         let settingsWindow = syncSettingsWindow()
-        settingsWindow.buttons["Sync & Backup"].click()
-        settingsWindow.buttons["Sync With Another Device"].click()
-        let settingsSheetsQuery = settingsWindow.sheets
-        settingsSheetsQuery.buttons["Enter Code"].click()
-        settingsSheetsQuery.buttons["Paste"].click()
-        settingsSheetsQuery.buttons["Next"].click()
-        settingsSheetsQuery.buttons["Done"].click()
-        let secondDevice = settingsWindow.images["SyncSettings.syncedDevice.mobile"]
-        XCTAssertTrue(secondDevice.exists, "Original Device not visible")
+        settingsWindow.buttons[Titles.syncAndBackupPane].click()
+
+        pasteCodeOnConnectScreen()
+
+        settingsWindow.sheets.buttons[Identifiers.successDoneButton].assertExists(with: Timeouts.syncOperation).click()
+
+        element(Identifiers.mobileDeviceRow, in: settingsWindow).assertExists(with: Timeouts.syncOperation)
     }
 
     private func logOut() {
+        turnOffSync()
+        assertSyncIsDisabled()
+    }
+
+    private func turnOffSync() {
         let settingsWindow = syncSettingsWindow()
-        let settingsSheetsQuery = settingsWindow.sheets
-        settingsWindow.buttons["Turn Off Sync…"].click()
-        settingsSheetsQuery.buttons["Turn Off"].click()
-        let beginSync = settingsWindow.staticTexts["Begin Syncing"]
-        beginSync.click()
-        XCTAssertTrue(beginSync.exists, "Begyn Sync text is not visible")
+        let sheetsQuery = settingsWindow.sheets
+
+        openCurrentDeviceDetails()
+        sheetsQuery.buttons[Titles.turnOffSync].assertExists().click()
+        sheetsQuery.buttons[Titles.removeDevice].assertExists().click()
+    }
+
+    private func deleteServerData() {
+        let settingsWindow = syncSettingsWindow()
+        let sheetsQuery = settingsWindow.sheets
+
+        settingsWindow.swipeUp()
+        settingsWindow.buttons[Titles.turnOffAndDeleteServerData].assertExists().click()
+        sheetsQuery.buttons[Titles.deleteServerData].assertExists().click()
+    }
+
+    private func openCurrentDeviceDetails() {
+        let settingsWindow = syncSettingsWindow()
+        let deviceRow = element(Identifiers.currentDeviceRow, in: settingsWindow)
+        deviceRow.assertExists(with: Timeouts.syncOperation)
+        deviceRow.hover()
+
+        let detailsButton = settingsWindow.buttons[Titles.deviceDetails]
+        if detailsButton.waitForExistence(timeout: 1.0) {
+            detailsButton.click()
+        } else {
+            deviceRow.coordinate(withNormalizedOffset: CGVector(dx: 1.0, dy: 0.5))
+                .withOffset(CGVector(dx: -45.0, dy: 0.0))
+                .click()
+        }
+
+        settingsWindow.sheets.buttons[Titles.turnOffSync].assertExists()
+    }
+
+    private func assertSyncIsEnabled() {
+        syncSettingsWindow().staticTexts[Titles.myDevices].assertExists(with: Timeouts.syncOperation)
+    }
+
+    private func assertSyncIsDisabled() {
+        syncSettingsWindow().staticTexts[Titles.beginSync].assertExists(with: Timeouts.syncOperation)
     }
 
     private func copyToClipboard(code: String) {
@@ -333,6 +344,8 @@ final class CriticalPathsTests: XCTestCase {
         pasteboard.declareTypes([.string], owner: nil)
         pasteboard.setString(code, forType: .string)
     }
+
+    // MARK: - Data helpers
 
     private func addBookmarksAndFavorites() {
         app.menuItems["MainMenu.manageBookmarksMenuItem"].click()
@@ -445,8 +458,8 @@ final class CriticalPathsTests: XCTestCase {
         if bookmarksWindow.sheets.buttons["Not Now"].exists {
             bookmarksWindow.sheets.buttons["Not Now"].click()
         }
-        let duckduckgoBookmark =  bookmarksWindow.staticTexts["www.duckduckgo.com"]
-        let stackOverflow =  bookmarksWindow.staticTexts["Stack Overflow - Where Developers Learn, Share, & Build Careers"]
+        let duckduckgoBookmark = bookmarksWindow.staticTexts["www.duckduckgo.com"]
+        let stackOverflow = bookmarksWindow.staticTexts["Stack Overflow - Where Developers Learn, Share, & Build Careers"]
         let privacySimplified = bookmarksWindow.staticTexts["DuckDuckGo — Privacy, simplified."]
         let wolfram = bookmarksWindow.staticTexts["Wolfram|Alpha: Computational Intelligence"]
         let news = bookmarksWindow.staticTexts["news"]


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1217193469998960

### Description
Duplicates the five sync critical paths against the simplified sync setup UI, so both the current and the new setup flow are covered while `simplifiedSyncSetupV2` is still behind a flag. The new suite forces the flag on and the existing one pins it off, so each stays deterministic regardless of how the flag is rolled out remotely. The V1 suite and the flag pin are deleted when the flag is removed.

Also adds two accessibility identifiers the new tests need: the "Sync this Device" toggle and the synced device rows.

### Testing Steps
1. Check both suites pass in this Sync E2E run: https://github.com/duckduckgo/apple-browsers/actions/runs/34245046065 → 10 tests run, 10 passed on macos-26-xlarge (`CriticalPathsTests` 5/5, `CriticalPathsV2Tests` 5/5).

### Impact
None: test-only, plus two accessibility identifiers that don't change behaviour.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only coverage plus non-functional accessibility identifiers; no production sync logic changes.
> 
> **Overview**
> Adds **`CriticalPathsV2Tests`**, mirroring the five existing sync critical-path E2E tests against the **simplified sync setup** UI while `simplifiedSyncSetupV2` is still flag-gated. The new suite launches with `FEATURE_FLAGS=simplifiedSyncSetupV2=true` and drives V2 flows (toggle, recovery, device details, updated copy/controls); **`CriticalPathsTests`** now pins `simplifiedSyncSetupV2=false` so each suite stays deterministic during rollout.
> 
> **Sync UI** gains accessibility identifiers for UI tests only: `SyncSettings.syncThisDeviceToggle` on the sync-this-device switch and per-row IDs (`SyncSettings.deviceRow.current`, `.desktop`, `.mobile`, `.thirdParty`) in **`SyncedDevicesListV2`**.
> 
> **`CriticalPathsTests`** gets small stability fixes: `ensureSyncSettingsWindowOpen()` before bookmark cleanup in the data sync test, and closing the New Tab via `newTabPage.typeKey("w", …)` instead of the app root.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c9545241e158862d686f26ceb3ce3e20f1540de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->