### PR TITLE
[iOS] Adjust floating toolbar layout metrics

### DIFF
--- a/SharedPackages/Infrastructure/DesignResourcesKit/Sources/DesignResourcesKit/Colors/ColorPalettes/DefaultColorPalette.swift
+++ b/SharedPackages/Infrastructure/DesignResourcesKit/Sources/DesignResourcesKit/Colors/ColorPalettes/DefaultColorPalette.swift
@@ -343,7 +343,7 @@ struct DefaultColorPalette: ColorPaletteDefinition {
         case .floatingAddressBarBackground:
             return DynamicColor(lightColor: .shade(0.05), darkColor: .tint(0.08))
         case .floatingEmbeddedAddressBarBackground:
-            return DynamicColor(lightColor: .tint(0.8), darkColor: .tint(0.08))
+            return DynamicColor(lightColor: .shade(0.05), darkColor: .tint(0.08))
         case .unifiedToggleInputAttachmentErrorBannerBackground:
             return DynamicColor(lightColor: xF6CDD1, darkColor: x5A2A2A)
         case .unifiedToggleInputAttachmentErrorText:

--- a/iOS/DuckDuckGo/BrowserToolbarView.swift
+++ b/iOS/DuckDuckGo/BrowserToolbarView.swift
@@ -138,8 +138,9 @@ final class BrowserToolbarView: UIView {
 
     /// In the floating style the toolbar is laid out against the safe-area bottom (so the chrome
     /// hide/show math stays valid), but the capsule should float this close to the physical device
-    /// bottom. The glass is shifted down into the home-indicator region by the difference.
-    static let floatingEmbeddedBottomMargin: CGFloat = 12
+    /// bottom. The glass is shifted down into the home-indicator region by the difference. Matches
+    /// `floatingEmbeddedHorizontalInset` so the capsule keeps an even inset on every edge.
+    static let floatingEmbeddedBottomMargin: CGFloat = floatingEmbeddedHorizontalInset
     static let floatingStandaloneBottomMargin: CGFloat = 21
 
     static func floatingOuterHorizontalInset(for addressBarPosition: AddressBarPosition) -> CGFloat {
@@ -601,6 +602,8 @@ final class BrowserToolbarView: UIView {
         buttonRowCollapseProgress = 0
         omnibarHeightConstraint.constant = 0
         buttonsHeightConstraint.constant = buttonsOnlyHeight
+        // Settled into the buttons-only pose now, so drop the embedded (bottom omnibar) metrics.
+        isOmnibarMorphing = false
         applyContentStackMetrics()
         rebuildButtonRow()
         updateCornerStyle()

--- a/iOS/DuckDuckGo/BrowserToolbarView.swift
+++ b/iOS/DuckDuckGo/BrowserToolbarView.swift
@@ -139,12 +139,12 @@ final class BrowserToolbarView: UIView {
     /// In the floating style the toolbar is laid out against the safe-area bottom (so the chrome
     /// hide/show math stays valid), but the capsule should float this close to the physical device
     /// bottom. The glass is shifted down into the home-indicator region by the difference.
-    static let floatingEmbeddedBottomMargin: CGFloat = 16
+    static let floatingEmbeddedBottomMargin: CGFloat = 12
     static let floatingStandaloneBottomMargin: CGFloat = 21
 
     static func floatingOuterHorizontalInset(for addressBarPosition: AddressBarPosition) -> CGFloat {
         if #available(iOS 26.0, *) {
-            return floatingEmbeddedConcentricInset
+            return addressBarPosition.isBottom ? floatingEmbeddedHorizontalInset : floatingEmbeddedConcentricInset
         }
         return addressBarPosition.isBottom ? floatingEmbeddedHorizontalInset : floatingStandaloneHorizontalInset
     }
@@ -152,7 +152,7 @@ final class BrowserToolbarView: UIView {
     /// Physical edge inset: the guide's own inset plus a tuck, or the fallback if unresolved.
     static func floatingPhysicalInset(guideInsets: (left: CGFloat, right: CGFloat)) -> CGFloat {
         let resolved = min(max(0, guideInsets.left), max(0, guideInsets.right))
-        return resolved > 0 ? resolved + floatingConcentricTuck : floatingEmbeddedConcentricInset
+        return max(resolved + floatingConcentricTuck, floatingEmbeddedConcentricInset)
     }
 
     /// Extra inset needed inside the guide to reach `physicalInset`; zero once the guide covers it.
@@ -162,14 +162,15 @@ final class BrowserToolbarView: UIView {
 
     static func floatingBottomMargin(for addressBarPosition: AddressBarPosition) -> CGFloat {
         if #available(iOS 26.0, *) {
-            return floatingEmbeddedConcentricInset
+            return addressBarPosition.isBottom ? floatingEmbeddedBottomMargin : floatingEmbeddedConcentricInset
         }
         return addressBarPosition.isBottom ? floatingEmbeddedBottomMargin : floatingStandaloneBottomMargin
     }
 
     /// Inner padding of the combined bottom floating chrome (address field + buttons). The standalone
     /// floating toolbar used in top-address-bar mode keeps the original 2pt padding.
-    private static let floatingEmbeddedVerticalContentPadding: CGFloat = 16
+    static let floatingEmbeddedTopContentPadding: CGFloat = 14
+    static let floatingEmbeddedBottomContentPadding: CGFloat = 16
     private static let floatingEmbeddedOmnibarToButtonsSpacing: CGFloat = 12
     private static let defaultVerticalContentPadding: CGFloat = 2
     private static let defaultOmnibarToButtonsSpacing: CGFloat = 2
@@ -313,9 +314,15 @@ final class BrowserToolbarView: UIView {
         return usesEmbeddedBottomChromeMetrics ? Self.floatingEmbeddedBarOuterInsets : Self.floatingStandaloneBarOuterInsets
     }
 
-    /// Compensates the corner-adapted guide so the glass sits at the same physical inset every edge.
+    /// Adds only the inset not already provided by the guide.
     @available(iOS 26.0, *)
     private var floatingRestStateOuterInsets: UIEdgeInsets {
+        if usesEmbeddedBottomChromeMetrics {
+            return UIEdgeInsets(top: 0,
+                                left: Self.floatingEmbeddedHorizontalInset,
+                                bottom: 0,
+                                right: Self.floatingEmbeddedHorizontalInset)
+        }
         guard let host = superview, host.bounds.width > 0 else {
             return UIEdgeInsets(
                 top: 0,
@@ -327,9 +334,9 @@ final class BrowserToolbarView: UIView {
         let physicalInset = Self.floatingPhysicalInset(guideInsets: guideInsets)
         return UIEdgeInsets(
             top: 0,
-            left: Self.embeddedRestStateInnerInset(guideInset: guideInsets.left, physicalInset: physicalInset),
+            left: max(guideInsets.left, physicalInset),
             bottom: 0,
-            right: Self.embeddedRestStateInnerInset(guideInset: guideInsets.right, physicalInset: physicalInset))
+            right: max(guideInsets.right, physicalInset))
     }
 
     /// Distance from the physical bottom edge to the corner-adapted safe area guide.
@@ -345,9 +352,12 @@ final class BrowserToolbarView: UIView {
         guideBottomGap - physicalInset
     }
 
-    /// Physical inset the glass keeps from every screen edge.
+    /// Physical horizontal inset for the current chrome layout.
     @available(iOS 26.0, *)
-    private var floatingPhysicalInset: CGFloat {
+    private var floatingHorizontalInset: CGFloat {
+        if usesEmbeddedBottomChromeMetrics {
+            return Self.floatingEmbeddedHorizontalInset
+        }
         guard let host = superview, host.bounds.width > 0 else { return Self.floatingEmbeddedConcentricInset }
         return Self.floatingPhysicalInset(guideInsets: Self.horizontalGuideInsets(in: host))
     }
@@ -386,11 +396,15 @@ final class BrowserToolbarView: UIView {
     }
 
     private var usesEmbeddedBottomChromeMetrics: Bool {
-        isFloatingStyleEnabled && hasEmbeddedOmnibar
+        isFloatingStyleEnabled && (hasEmbeddedOmnibar || isOmnibarMorphing)
     }
 
-    private var currentVerticalContentPadding: CGFloat {
-        usesEmbeddedBottomChromeMetrics ? Self.floatingEmbeddedVerticalContentPadding : Self.defaultVerticalContentPadding
+    private var currentTopContentPadding: CGFloat {
+        usesEmbeddedBottomChromeMetrics ? Self.floatingEmbeddedTopContentPadding : Self.defaultVerticalContentPadding
+    }
+
+    private var currentBottomContentPadding: CGFloat {
+        usesEmbeddedBottomChromeMetrics ? Self.floatingEmbeddedBottomContentPadding : Self.defaultVerticalContentPadding
     }
 
     private var currentOmnibarToButtonsSpacing: CGFloat {
@@ -402,7 +416,8 @@ final class BrowserToolbarView: UIView {
             return isFloating ? floatingButtonsHeight : legacyButtonsHeight
         }
         if isFloating {
-            return (floatingEmbeddedVerticalContentPadding * 2)
+            return floatingEmbeddedTopContentPadding
+                + floatingEmbeddedBottomContentPadding
                 + floatingEmbeddedButtonsHeight
                 + omnibarHeight
                 + floatingEmbeddedOmnibarToButtonsSpacing
@@ -411,7 +426,7 @@ final class BrowserToolbarView: UIView {
     }
 
     static func singleRowHeight(withOmnibarHeight omnibarHeight: CGFloat) -> CGFloat {
-        (floatingEmbeddedVerticalContentPadding * 2) + omnibarHeight
+        floatingEmbeddedTopContentPadding + floatingEmbeddedBottomContentPadding + omnibarHeight
     }
 
     override init(frame: CGRect) {
@@ -510,9 +525,9 @@ final class BrowserToolbarView: UIView {
     }
 
     private func applyContentStackMetrics() {
-        contentStackTopConstraint.constant = currentVerticalContentPadding
+        contentStackTopConstraint.constant = currentTopContentPadding
         if !hasExpandedContent {
-            contentStackBottomConstraint.constant = -currentVerticalContentPadding
+            contentStackBottomConstraint.constant = -currentBottomContentPadding
         }
         let collapse = usesEmbeddedBottomChromeMetrics ? buttonRowCollapseProgress.clamped(to: 0...1) : 0
         contentStack.spacing = currentOmnibarToButtonsSpacing * (1 - collapse)
@@ -788,7 +803,7 @@ final class BrowserToolbarView: UIView {
             let collapseLayout = {
                 self.expandedContentHeightConstraint.constant = 0
                 self.contentStack.setCustomSpacing(0, after: self.expandedContentContainer)
-                self.contentStackBottomConstraint.constant = -self.currentVerticalContentPadding
+                self.contentStackBottomConstraint.constant = -self.currentBottomContentPadding
                 self.materialBackgroundTopConstraint.constant = self.currentBarOuterInsets.top
                 self.layoutIfNeeded()
             }
@@ -820,7 +835,7 @@ final class BrowserToolbarView: UIView {
         expandedContentHeightConstraint.constant = expandedContainerHeight
         expandedContentContainer.isHidden = false
         contentStack.setCustomSpacing(Self.expandedContentToOmnibarSpacing, after: expandedContentContainer)
-        contentStackBottomConstraint.constant = -(currentVerticalContentPadding + Self.expandedButtonsBottomPadding)
+        contentStackBottomConstraint.constant = -(currentBottomContentPadding + Self.expandedButtonsBottomPadding)
         materialBackgroundTopConstraint.constant = currentBarOuterInsets.top - expandedContainerHeight - Self.expandedContentToOmnibarSpacing
 
         view.translatesAutoresizingMaskIntoConstraints = false
@@ -862,7 +877,7 @@ final class BrowserToolbarView: UIView {
 
     var floatingBottomMargin: CGFloat {
         if #available(iOS 26.0, *) {
-            return floatingPhysicalInset
+            return usesEmbeddedBottomChromeMetrics ? Self.floatingEmbeddedBottomMargin : floatingHorizontalInset
         }
         return hasEmbeddedOmnibar ? Self.floatingEmbeddedBottomMargin : Self.floatingStandaloneBottomMargin
     }
@@ -885,11 +900,17 @@ final class BrowserToolbarView: UIView {
         let right: CGFloat
         let bottom: CGFloat
         if #available(iOS 26.0, *) {
-            let guideInsets = Self.horizontalGuideInsets(in: view)
-            let physicalInset = Self.floatingPhysicalInset(guideInsets: guideInsets)
-            left = guideInsets.left + Self.embeddedRestStateInnerInset(guideInset: guideInsets.left, physicalInset: physicalInset)
-            right = guideInsets.right + Self.embeddedRestStateInnerInset(guideInset: guideInsets.right, physicalInset: physicalInset)
-            bottom = bounds.maxY - physicalInset
+            if usesEmbeddedBottomChromeMetrics {
+                left = Self.floatingEmbeddedHorizontalInset
+                right = Self.floatingEmbeddedHorizontalInset
+                bottom = bounds.maxY - Self.floatingEmbeddedBottomMargin
+            } else {
+                let guideInsets = Self.horizontalGuideInsets(in: view)
+                let horizontalInset = Self.floatingPhysicalInset(guideInsets: guideInsets)
+                left = guideInsets.left + Self.embeddedRestStateInnerInset(guideInset: guideInsets.left, physicalInset: horizontalInset)
+                right = guideInsets.right + Self.embeddedRestStateInnerInset(guideInset: guideInsets.right, physicalInset: horizontalInset)
+                bottom = bounds.maxY - horizontalInset
+            }
         } else {
             let insets = currentBarOuterInsets
             left = insets.left
@@ -952,7 +973,8 @@ final class BrowserToolbarView: UIView {
         if #available(iOS 26.0, *), isFloatingStyleEnabled {
             if let host = superview, host.bounds.height > 0 {
                 let guideBottomGap = Self.verticalGuideBottomInset(in: host)
-                target = Self.embeddedRestStateBottomOffset(guideBottomGap: guideBottomGap, physicalInset: floatingPhysicalInset)
+                let bottomMargin = usesEmbeddedBottomChromeMetrics ? Self.floatingEmbeddedBottomMargin : floatingHorizontalInset
+                target = Self.embeddedRestStateBottomOffset(guideBottomGap: guideBottomGap, physicalInset: bottomMargin)
             } else {
                 target = 0
             }

--- a/iOS/DuckDuckGo/MainView.swift
+++ b/iOS/DuckDuckGo/MainView.swift
@@ -639,12 +639,11 @@ extension MainViewFactory {
         coordinator.constraints.toolbarHeight = toolbar.constrainAttribute(.height, to: initialToolbarHeight)
 
         if #available(iOS 26.0, *), isFloatingUIEnabled {
-            let horizontalGuide = superview.layoutGuide(for: .safeArea(cornerAdaptation: .horizontal))
             let verticalGuide = superview.layoutGuide(for: .safeArea(cornerAdaptation: .vertical))
             coordinator.constraints.toolbarBottom = toolbar.bottomAnchor.constraint(equalTo: verticalGuide.bottomAnchor)
             NSLayoutConstraint.activate([
-                toolbar.leadingAnchor.constraint(equalTo: horizontalGuide.leadingAnchor),
-                toolbar.trailingAnchor.constraint(equalTo: horizontalGuide.trailingAnchor),
+                toolbar.leadingAnchor.constraint(equalTo: superview.leadingAnchor),
+                toolbar.trailingAnchor.constraint(equalTo: superview.trailingAnchor),
                 coordinator.constraints.toolbarHeight,
                 coordinator.constraints.toolbarBottom,
             ])

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInputIntentHandling.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInputIntentHandling.swift
@@ -347,13 +347,13 @@ private extension MainViewController {
             self?.applyUnifiedInputChromeBackground(.standardChrome)
             self?.applyFloatingUIIfNeeded()
             if fadesForFloatingBottom {
-                // Hide UTI before revealing NTP chrome so logo/favorites don't flash under the
-                // still-visible focused content (especially seamless logo/favorites handoff).
-                self?.viewCoordinator.hideUnifiedInputContent()
+                // Lay out favorites while still covered by UTI, so a tall grid's last row doesn't pop in late.
                 self?.newTabPageViewController?.setLogoHidden(false)
                 self?.newTabPageViewController?.setFavoritesHidden(false)
                 self?.newTabPageViewController?.view.setNeedsLayout()
                 self?.newTabPageViewController?.view.layoutIfNeeded()
+                // Hide UTI last so logo/favorites don't flash under the still-visible focused content.
+                self?.viewCoordinator.hideUnifiedInputContent()
             }
             self?.refreshFloatingToolbarBackdrop()
         }

--- a/iOS/DuckDuckGoTests/BrowserToolbarViewTests.swift
+++ b/iOS/DuckDuckGoTests/BrowserToolbarViewTests.swift
@@ -174,16 +174,17 @@ final class BrowserToolbarViewTests: XCTestCase {
     }
 
     func testWhenFloatingThenCombinedChromeHeightMatchesTheSpacingSpec() {
-        // 16 top + 48 field + 12 gap + 44 buttons + 16 bottom — bottom address bar only. The outer
-        // padding matches the field's side inset so the glass keeps one gap on every edge.
+        // 14 top + 48 field + 12 gap + 44 buttons + 16 bottom.
         XCTAssertEqual(BrowserToolbarView.floatingEmbeddedButtonsHeight, 44)
+        XCTAssertEqual(BrowserToolbarView.floatingEmbeddedTopContentPadding, 14)
+        XCTAssertEqual(BrowserToolbarView.floatingEmbeddedBottomContentPadding, 16)
         XCTAssertEqual(
             BrowserToolbarView.totalHeight(withOmnibarHeight: 48, isFloating: true),
-            136,
+            134,
             accuracy: 0.01)
         XCTAssertEqual(
             BrowserToolbarView.singleRowHeight(withOmnibarHeight: 48),
-            80,
+            78,
             accuracy: 0.01)
     }
 
@@ -221,7 +222,7 @@ final class BrowserToolbarViewTests: XCTestCase {
         }
     }
 
-    func testWhenEmbeddedFloatingThenOuterInsetIsEqualOnEveryEdge() {
+    func testWhenEmbeddedFloatingThenOuterInsetsMatchTheBottomChromeSpec() {
         let sut = makeSUT(embeddedOmnibar: true)
         let container = UIView(frame: CGRect(x: 0, y: 0, width: 390, height: 800))
         container.addSubview(sut)
@@ -230,11 +231,9 @@ final class BrowserToolbarViewTests: XCTestCase {
         let frame = sut.restingCapsuleFrame(in: container)
 
         if #available(iOS 26.0, *) {
-            // Device-specific inset (guide + tuck), equal on every edge.
-            let physical = BrowserToolbarView.floatingPhysicalInset(guideInsets: BrowserToolbarView.horizontalGuideInsets(in: container))
-            XCTAssertEqual(frame.minX, physical, accuracy: 0.01)
-            XCTAssertEqual(container.bounds.width - frame.maxX, physical, accuracy: 0.01)
-            XCTAssertEqual(container.bounds.maxY - frame.maxY, physical, accuracy: 0.01)
+            XCTAssertEqual(frame.minX, BrowserToolbarView.floatingEmbeddedHorizontalInset, accuracy: 0.01)
+            XCTAssertEqual(container.bounds.width - frame.maxX, BrowserToolbarView.floatingEmbeddedHorizontalInset, accuracy: 0.01)
+            XCTAssertEqual(container.bounds.maxY - frame.maxY, BrowserToolbarView.floatingEmbeddedBottomMargin, accuracy: 0.01)
         } else {
             XCTAssertEqual(BrowserToolbarView.floatingEmbeddedHorizontalInset, 16)
             XCTAssertEqual(frame.minX, 16, accuracy: 0.01)
@@ -268,7 +267,7 @@ final class BrowserToolbarViewTests: XCTestCase {
 
         let frame = sut.restingCapsuleFrame(in: container)
         let guideInsets = BrowserToolbarView.horizontalGuideInsets(in: container)
-        let physical = BrowserToolbarView.floatingPhysicalInset(guideInsets: guideInsets)
+        let physical = BrowserToolbarView.floatingEmbeddedHorizontalInset
 
         // Each edge sits at its own guide, or at the physical inset when the guide is smaller.
         XCTAssertEqual(frame.minX, max(guideInsets.left, physical), accuracy: 0.01)
@@ -289,6 +288,7 @@ final class BrowserToolbarViewTests: XCTestCase {
     func testWhenConcentricGuideIsUnresolvedThenTheFallbackInsetIsUsed() {
         let concentric = BrowserToolbarView.floatingEmbeddedConcentricInset
         XCTAssertEqual(BrowserToolbarView.floatingPhysicalInset(guideInsets: (left: 0, right: 0)), concentric, accuracy: 0.01)
+        XCTAssertEqual(BrowserToolbarView.floatingPhysicalInset(guideInsets: (left: 0.5, right: 0.5)), concentric, accuracy: 0.01)
         XCTAssertEqual(BrowserToolbarView.floatingPhysicalInset(guideInsets: (left: 57, right: 0)), concentric, accuracy: 0.01)
     }
 
@@ -345,11 +345,9 @@ final class BrowserToolbarViewTests: XCTestCase {
         let frame = sut.restingCapsuleFrame(in: container)
 
         if #available(iOS 26.0, *) {
-            // Device-specific inset (guide + tuck), equal on every edge.
-            let physical = BrowserToolbarView.floatingPhysicalInset(guideInsets: BrowserToolbarView.horizontalGuideInsets(in: container))
-            XCTAssertEqual(frame.minX, physical, accuracy: 0.01)
-            XCTAssertEqual(container.bounds.width - frame.maxX, physical, accuracy: 0.01)
-            XCTAssertEqual(container.bounds.maxY - frame.maxY, physical, accuracy: 0.01)
+            XCTAssertEqual(frame.minX, BrowserToolbarView.floatingEmbeddedHorizontalInset, accuracy: 0.01)
+            XCTAssertEqual(container.bounds.width - frame.maxX, BrowserToolbarView.floatingEmbeddedHorizontalInset, accuracy: 0.01)
+            XCTAssertEqual(container.bounds.maxY - frame.maxY, BrowserToolbarView.floatingEmbeddedBottomMargin, accuracy: 0.01)
         }
     }
 
@@ -371,15 +369,15 @@ final class BrowserToolbarViewTests: XCTestCase {
     func testWhenEmbeddedFloatingThenBottomMarginMatchesPlatformGeometry() {
         let sut = makeSUT(embeddedOmnibar: true)
 
-        XCTAssertEqual(BrowserToolbarView.floatingEmbeddedBottomMargin, 16)
+        XCTAssertEqual(BrowserToolbarView.floatingEmbeddedBottomMargin, 12)
         if #available(iOS 26.0, *) {
-            XCTAssertEqual(sut.floatingBottomMargin, 20, accuracy: 0.01)
-            XCTAssertEqual(BrowserToolbarView.floatingOuterHorizontalInset(for: .bottom), 20)
-            XCTAssertEqual(BrowserToolbarView.floatingBottomMargin(for: .bottom), 20)
-        } else {
-            XCTAssertEqual(sut.floatingBottomMargin, 16, accuracy: 0.01)
+            XCTAssertEqual(sut.floatingBottomMargin, 12, accuracy: 0.01)
             XCTAssertEqual(BrowserToolbarView.floatingOuterHorizontalInset(for: .bottom), 16)
-            XCTAssertEqual(BrowserToolbarView.floatingBottomMargin(for: .bottom), 16)
+            XCTAssertEqual(BrowserToolbarView.floatingBottomMargin(for: .bottom), 12)
+        } else {
+            XCTAssertEqual(sut.floatingBottomMargin, 12, accuracy: 0.01)
+            XCTAssertEqual(BrowserToolbarView.floatingOuterHorizontalInset(for: .bottom), 16)
+            XCTAssertEqual(BrowserToolbarView.floatingBottomMargin(for: .bottom), 12)
         }
     }
 

--- a/iOS/DuckDuckGoTests/BrowserToolbarViewTests.swift
+++ b/iOS/DuckDuckGoTests/BrowserToolbarViewTests.swift
@@ -334,7 +334,7 @@ final class BrowserToolbarViewTests: XCTestCase {
         }
     }
 
-    func testWhenBottomOmnibarDetachesForFocusThenOuterInsetsStayUnchanged() {
+    func testWhenBottomOmnibarDetachmentSettlesThenOuterInsetsMatchStandaloneConcentricSpec() {
         let sut = makeSUT(embeddedOmnibar: true)
         let container = UIView(frame: CGRect(x: 0, y: 0, width: 390, height: 800))
         container.addSubview(sut)
@@ -345,9 +345,10 @@ final class BrowserToolbarViewTests: XCTestCase {
         let frame = sut.restingCapsuleFrame(in: container)
 
         if #available(iOS 26.0, *) {
-            XCTAssertEqual(frame.minX, BrowserToolbarView.floatingEmbeddedHorizontalInset, accuracy: 0.01)
-            XCTAssertEqual(container.bounds.width - frame.maxX, BrowserToolbarView.floatingEmbeddedHorizontalInset, accuracy: 0.01)
-            XCTAssertEqual(container.bounds.maxY - frame.maxY, BrowserToolbarView.floatingEmbeddedBottomMargin, accuracy: 0.01)
+            // Settled: it's a standalone capsule again, not tucked at the tight embedded margin.
+            XCTAssertEqual(frame.minX, BrowserToolbarView.floatingEmbeddedConcentricInset, accuracy: 0.01)
+            XCTAssertEqual(container.bounds.width - frame.maxX, BrowserToolbarView.floatingEmbeddedConcentricInset, accuracy: 0.01)
+            XCTAssertEqual(container.bounds.maxY - frame.maxY, BrowserToolbarView.floatingEmbeddedConcentricInset, accuracy: 0.01)
         }
     }
 
@@ -369,15 +370,16 @@ final class BrowserToolbarViewTests: XCTestCase {
     func testWhenEmbeddedFloatingThenBottomMarginMatchesPlatformGeometry() {
         let sut = makeSUT(embeddedOmnibar: true)
 
-        XCTAssertEqual(BrowserToolbarView.floatingEmbeddedBottomMargin, 12)
+        // Even on every edge: the bottom margin matches the horizontal inset.
+        XCTAssertEqual(BrowserToolbarView.floatingEmbeddedBottomMargin, 16)
         if #available(iOS 26.0, *) {
-            XCTAssertEqual(sut.floatingBottomMargin, 12, accuracy: 0.01)
+            XCTAssertEqual(sut.floatingBottomMargin, 16, accuracy: 0.01)
             XCTAssertEqual(BrowserToolbarView.floatingOuterHorizontalInset(for: .bottom), 16)
-            XCTAssertEqual(BrowserToolbarView.floatingBottomMargin(for: .bottom), 12)
+            XCTAssertEqual(BrowserToolbarView.floatingBottomMargin(for: .bottom), 16)
         } else {
-            XCTAssertEqual(sut.floatingBottomMargin, 12, accuracy: 0.01)
+            XCTAssertEqual(sut.floatingBottomMargin, 16, accuracy: 0.01)
             XCTAssertEqual(BrowserToolbarView.floatingOuterHorizontalInset(for: .bottom), 16)
-            XCTAssertEqual(BrowserToolbarView.floatingBottomMargin(for: .bottom), 12)
+            XCTAssertEqual(BrowserToolbarView.floatingBottomMargin(for: .bottom), 16)
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/392891325557410/task/1218271374960448?focus=true
Tech Design URL:
CC:

### Description

Tightens the bottom floating address bar spacing to match the design specification and gives the input field a darker background for better contrast against light webpages. The top address bar layout is unchanged.

### Testing Steps

1. Enable the floating UI feature on an iPhone running iOS 26.
2. Move the address bar to the bottom → the container has 16pt side margins and a 12pt bottom margin.
3. Inspect the space above the address field → the top padding is 14pt.
4. Open a white webpage or search results page → the address field remains clearly distinguishable from the page.
5. Tap the address field and dismiss it → the focus transition completes without jumps or visual artifacts.
6. Scroll a webpage until the browser controls collapse and reappear → the container transitions smoothly and retains the correct spacing.
7. Move the address bar to the top → the top address bar and standalone bottom toolbar retain their previous layout.
8. Repeat the bottom-address-bar checks on narrow and wide iPhones → the container remains correctly inset without clipping.

### Impact

Low: Visual changes limited to the floating bottom address bar.

#### What could go wrong?

The bottom container could be incorrectly positioned on different screen sizes → mitigated by focused geometry tests and simulator checks on multiple iPhone sizes.

The top-position toolbar could change unintentionally → mitigated by position-specific layout handling and regression coverage.

### Quality Considerations

- Verified on iPhone 16e, iPhone 16 Pro, and iPhone 17 Pro Max simulators.
- Existing focus, collapse, and address-bar transition structure is unchanged.
- No performance, privacy, or security impact.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual and layout-only changes scoped mainly to floating bottom chrome on iOS 26, with regression tests; top address bar paths are explicitly preserved.
> 
> **Overview**
> Tightens **floating bottom address bar** layout to match design: **16pt** side and bottom capsule inset (even on all edges), **14pt** top inner padding and **16pt** bottom inner padding (replacing symmetric 16pt vertical padding), and slightly shorter combined chrome height.
> 
> On **iOS 26**, bottom embedded chrome uses these fixed margins while **top / standalone** floating toolbar keeps concentric safe-area geometry; `MainView` anchors the toolbar to the superview width so inset math is applied inside `BrowserToolbarView`. Omnibar detach/attach keeps embedded metrics during morph and switches to standalone insets once the buttons-only pose settles.
> 
> **`floatingEmbeddedAddressBarBackground`** light appearance shifts from a heavy tint to a subtle shade so the field reads clearly on bright pages.
> 
> Unified input dismiss on floating bottom NTP now **lays out logo/favorites before hiding UTI** to avoid a late favorites pop-in. Tests updated for the new spacing constants and inset rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4bb60ecff0927e5485881364c6a8d4bb4ca76a05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->