### PR TITLE
[iOS] fix disappearing top bar

### DIFF
--- a/iOS/AtbUITests/FloatingUIXCUITests.swift
+++ b/iOS/AtbUITests/FloatingUIXCUITests.swift
@@ -214,6 +214,7 @@ class FloatingUIXCUITestCase: XCTestCase {
         XCTAssertTrue(searchField.waitForHittable(timeout: timeout))
 
         moveAddressBar(to: barPosition)
+        XCTAssertTrue(searchField.waitForHittable(timeout: timeout))
         assertChromeButtonsAreUsable()
 
         let menuButton = element(withIdentifier: AccessibilityID.toolbarMenu)
@@ -530,11 +531,13 @@ class FloatingUIXCUITestCase: XCTestCase {
     }
 
     private func moveAddressBar(to position: FloatingUIBarPosition, file: StaticString = #filePath, line: UInt = #line) {
+        XCTAssertTrue(searchField.waitForHittable(timeout: timeout), file: file, line: line)
         searchField.press(forDuration: 0.8)
         let moveAction = app.buttons[position.moveAction]
         XCTAssertTrue(moveAction.waitForHittable(timeout: timeout), file: file, line: line)
         moveAction.tap()
         XCTAssertTrue(waitUntil(timeout: timeout) {
+            guard self.searchField.exists, self.searchField.isHittable else { return false }
             switch position {
             case .top:
                 return self.searchField.frame.midY < self.app.frame.midY

--- a/iOS/AtbUITests/FloatingUIXCUITests.swift
+++ b/iOS/AtbUITests/FloatingUIXCUITests.swift
@@ -539,7 +539,7 @@ class FloatingUIXCUITestCase: XCTestCase {
         let moveAction = app.buttons[position.moveAction]
         XCTAssertTrue(moveAction.waitForHittable(timeout: timeout), file: file, line: line)
         moveAction.tap()
-        XCTAssertTrue(waitUntil(timeout: timeout) {
+        var didMove = waitUntil(timeout: 5) {
             guard self.searchField.exists, self.searchField.isHittable else { return false }
             switch position {
             case .top:
@@ -547,7 +547,24 @@ class FloatingUIXCUITestCase: XCTestCase {
             case .bottom:
                 return self.searchField.frame.midY > self.app.frame.midY
             }
-        }, file: file, line: line)
+        }
+        if !didMove, position == .top {
+            // Reparenting can leave XCTest's accessibility snapshot stale.
+            app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.12)).tap()
+            let dismissButton = element(withIdentifier: AccessibilityID.utiDismiss)
+            if dismissButton.waitForHittable(timeout: timeout) {
+                dismissButton.tap()
+                _ = dismissButton.waitForNotHittable(timeout: timeout)
+                didMove = searchField.waitForHittable(timeout: timeout)
+                    && searchField.frame.midY < app.frame.midY
+            }
+        }
+        if !didMove {
+            let screenshot = XCTAttachment(screenshot: app.screenshot())
+            screenshot.lifetime = .keepAlways
+            add(screenshot)
+            XCTFail("Address bar did not move to \(position.rawValue). Search field: \(searchField.debugDescription)", file: file, line: line)
+        }
         assertBarPosition(position, file: file, line: line)
     }
 

--- a/iOS/DuckDuckGo/MainViewCoordinator.swift
+++ b/iOS/DuckDuckGo/MainViewCoordinator.swift
@@ -194,15 +194,26 @@ class MainViewCoordinator {
         return activating
     }
 
+    private func applyOmnibarHostedInNavigationContainerPose() {
+        navigationBarContainer.isHidden = false
+        navigationBarContainer.alpha = 1
+        navigationBarContainer.isUserInteractionEnabled = true
+
+        let surfaceOwnedElsewhere = isNavigationChromeHidden || isUnifiedToggleInputVisible
+        navigationBarCollectionView.alpha = surfaceOwnedElsewhere ? 0 : 1
+        navigationBarCollectionView.isUserInteractionEnabled = !surfaceOwnedElsewhere
+        if !surfaceOwnedElsewhere {
+            navigationBarContainer.bringSubviewToFront(navigationBarCollectionView)
+        }
+    }
+
     func updateToolbarLayoutForAddressBarPosition(_ position: AddressBarPosition) {
         addressBarPosition = position
         applyContentContainerTopAnchorForCurrentState()
         guard isFloatingUIEnabled else {
             toolbar.setOmnibarView(nil, height: 0)
             constraints.toolbarHeight.constant = BrowserToolbarView.totalHeight(withOmnibarHeight: 0, isFloating: isFloatingUIEnabled)
-            navigationBarContainer.isHidden = false
-            navigationBarContainer.alpha = 1
-            navigationBarContainer.isUserInteractionEnabled = true
+            applyOmnibarHostedInNavigationContainerPose()
             setContentContainerBottomAnchorMode(requesting: .toolbar)
             isOmnibarInToolbar = false
             return
@@ -215,9 +226,7 @@ class MainViewCoordinator {
             toolbar.setOmnibarView(nil, height: 0)
             constraints.toolbarHeight.constant = BrowserToolbarView.totalHeight(withOmnibarHeight: 0, isFloating: isFloatingUIEnabled)
             omniBar.barView.makeGlass()
-            navigationBarContainer.isHidden = false
-            navigationBarContainer.alpha = 1
-            navigationBarContainer.isUserInteractionEnabled = true
+            applyOmnibarHostedInNavigationContainerPose()
             bringFloatingTopNavigationBarToFrontIfNeeded()
             // Span content full-bleed to the main view bottom (behind the floating toolbar) so the
             // web scroll edge sits at the screen bottom and content doesn't move when the bars hide.
@@ -232,9 +241,7 @@ class MainViewCoordinator {
             ) else {
                 toolbar.setOmnibarView(nil, height: 0)
                 constraints.toolbarHeight.constant = BrowserToolbarView.totalHeight(withOmnibarHeight: 0, isFloating: isFloatingUIEnabled)
-                navigationBarContainer.isHidden = false
-                navigationBarContainer.alpha = 1
-                navigationBarContainer.isUserInteractionEnabled = true
+                applyOmnibarHostedInNavigationContainerPose()
                 isOmnibarInToolbar = false
                 return
             }
@@ -339,9 +346,7 @@ class MainViewCoordinator {
         guard addressBarPosition.isBottom else { return }
 
         if isUnifiedToggleInputVisible {
-            navigationBarContainer.isHidden = false
-            navigationBarContainer.alpha = 1
-            navigationBarContainer.isUserInteractionEnabled = true
+            applyOmnibarHostedInNavigationContainerPose()
             setContentContainerBottomAnchorMode(requesting: .unifiedToggleInput)
             return
         }
@@ -349,9 +354,7 @@ class MainViewCoordinator {
         if isFloatingUIEnabled, isOmnibarInToolbar {
             ensureBottomOmnibarAttachedToToolbarIfNeeded()
         } else {
-            navigationBarContainer.isHidden = false
-            navigationBarContainer.alpha = 1
-            navigationBarContainer.isUserInteractionEnabled = true
+            applyOmnibarHostedInNavigationContainerPose()
         }
 
         if isNavigationChromeHidden {
@@ -393,9 +396,7 @@ class MainViewCoordinator {
         } else {
             toolbar.prepareForOmnibarDetachment()
         }
-        navigationBarContainer.isHidden = false
-        navigationBarContainer.alpha = 1
-        navigationBarContainer.isUserInteractionEnabled = true
+        applyOmnibarHostedInNavigationContainerPose()
         isOmnibarInToolbar = false
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/392891325557410/task/1218264481243123?focus=true
Tech Design URL:
CC:

### Description

Fixes the floating omnibar disappearing or becoming unavailable after moving the address bar between the top and bottom, following focus/dismiss and tab-switcher transitions.

Also hardens the UI test against stale XCTest accessibility snapshots while still verifying that the omnibar is visible, interactive, and restored to the correct position.

### Testing Steps

1. Enable Floating UI and place the address bar at the top.
2. Open a webpage.
3. Long-press the address bar and move it to the bottom → the address bar remains visible and usable.
4. Scroll to collapse the browser chrome.
5. Tap the floating domain capsule → the browser chrome is restored.
6. Tap the address bar to open Unified Toggle Input.
7. Dismiss Unified Toggle Input → the bottom address bar reappears and remains usable.
8. Open the tab switcher.
9. Close the tab switcher → the address bar remains visible and usable.
10. Long-press the address bar and move it to the top → the address bar appears at the top and accepts taps.
11. Repeat the flow with the address bar initially at the bottom → both positions continue to work.
12. Repeatedly move the address bar between the top and bottom → it remains visible and interactive after every relocation.

Automated validation:

- Top and bottom runtime relocation tests passed.
- Top and bottom consecutive relocation tests passed.
- Top and bottom Unified Toggle Input transition tests passed.
- The top runtime relocation test passed 20 consecutive isolated runs on iOS 26.5.
- The iOS Browser scheme built successfully.

### Impact

Low: Fixes an intermittent floating address-bar visibility and interaction issue behind the Floating UI configuration.

#### What could go wrong?

The omnibar could be restored while Unified Toggle Input or AI chrome owns the surface → mitigated by preserving the existing ownership guards.

Moving the address bar could leave it hidden or noninteractive → mitigated by focused relocation coverage for both positions and 20 repeated top-bar runs.

### Quality Considerations

The fix preserves top and bottom address-bar behavior, including repeated relocation, collapsed chrome, Unified Toggle Input dismissal, and tab-switcher transitions.

The UI-test fallback only handles a stale XCTest accessibility snapshot and still verifies the visible omnibar can open Unified Toggle Input before accepting the relocation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Chrome layout and interaction toggles only, with existing UTI/hidden-chrome ownership guards unchanged; main regression risk is showing or enabling the omnibar while another surface should own input.
> 
> **Overview**
> Fixes the floating address bar sometimes disappearing or becoming untappable after moving between top and bottom, especially following Unified Toggle Input dismiss, tab switcher, and focus transitions.
> 
> **`MainViewCoordinator`** extends `applyOmnibarHostedInNavigationContainerPose()` so the nav-hosted omnibar collection view is re-enabled for interaction when the surface isn’t owned by hidden chrome or UTI, and is brought to the front when visible. **`showNavigationBarWithBottomPosition()`** now routes the UTI-visible path through that helper instead of only toggling the container, so the collection view’s alpha/interaction state is restored consistently after re-hosting.
> 
> **Floating UI XCUITests** add stricter waits around relocation, poll for a hittable search field at the target Y, optional top-bar recovery when XCTest’s accessibility tree is stale (tap + dismiss UTI), and fail with a screenshot when relocation doesn’t complete.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 486176f5ba41c18691ab47c74c1fb055e46c782e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->