### PR TITLE
Remove feature flag: promptBar

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -507,9 +507,6 @@ public enum AIChatSubfeature: String, Equatable, PrivacySubfeature {
     /// Replaces Duck.ai's web-based chat sidebar with native UI.
     case nativeSidebar
 
-    /// macOS only. System-wide Duck.ai entry point: global keyboard shortcut and menu bar icon.
-    case promptBar
-
     /// Supports Duck.ai edit prompt from the native input field.
     case nativePromptEditing
 

--- a/macOS/DuckDuckGo/Application/AppDelegate.swift
+++ b/macOS/DuckDuckGo/Application/AppDelegate.swift
@@ -1674,8 +1674,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// The settings toggles only cover users who touch a setting; this sizes the enabled base.
     @MainActor
     private func fireDailyPromptBarStatePixel() {
-        guard featureFlagger.isFeatureOn(.promptBar) else { return }
-
         PixelKit.fire(PromptBarPixel.state(shortcutEnabled: promptBarPreferences.isKeyboardShortcutEnabled,
                                            menuBarIconEnabled: promptBarPreferences.isMenuBarIconVisible),
                       frequency: .daily)
@@ -2509,11 +2507,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// Must run before `setUpPromptBarMenuBarVisibility()`, which hands the icon's click to the coordinator.
     @MainActor
     private func setUpPromptBar() {
-        guard featureFlagger.isFeatureOn(.promptBar) else {
-            promptBarCoordinator = nil
-            return
-        }
-
         let promptSubmitter = PromptBarPromptSubmitter(aiChatTabOpener: aiChatTabOpener,
                                                        windowControllersManager: windowControllersManager)
         let content = PromptBarContentFactory.makeContent(promptSubmitter: promptSubmitter,
@@ -2522,7 +2515,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                                                           duckAiNativeStorageHandler: duckAiNativeStorageHandler,
                                                           preferences: aiChatPreferencesPersistor)
         let coordinator = PromptBarCoordinator(
-            featureFlagger: featureFlagger,
             preferences: promptBarPreferences,
             shortcutRegistrar: CarbonGlobalShortcutRegistrar(),
             presenter: PromptBarPresenter(content: content)
@@ -2533,13 +2525,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     @MainActor
     private func setUpPromptBarMenuBarVisibility() {
-        guard featureFlagger.isFeatureOn(.promptBar) else {
-            promptBarMenuBarController?.hide()
-            promptBarMenuBarController = nil
-            promptBarMenuBarCancellable = nil
-            return
-        }
-
         if promptBarMenuBarController == nil {
             promptBarMenuBarController = PromptBarMenuBarController()
         }

--- a/macOS/DuckDuckGo/Preferences/Model/AIChatPreferences.swift
+++ b/macOS/DuckDuckGo/Preferences/Model/AIChatPreferences.swift
@@ -168,10 +168,6 @@ final class AIChatPreferences: ObservableObject {
         return !showShortcutInAddressBar || !openAIChatInSidebar
     }
 
-    var shouldShowPromptBarPreferences: Bool {
-        featureFlagger.isFeatureOn(.promptBar)
-    }
-
     // Native SERP AI settings (Search Assist / Hide AI Images), backed by the shared SERP settings store.
 
     var searchAssistFrequencyBinding: Binding<SearchAssistFrequency> {

--- a/macOS/DuckDuckGo/Preferences/View/PreferencesAIChat.swift
+++ b/macOS/DuckDuckGo/Preferences/View/PreferencesAIChat.swift
@@ -194,9 +194,7 @@ extension Preferences {
                         .padding(.leading, 19)
                     }
 
-                    if model.shouldShowPromptBarPreferences {
-                        PromptBarPreferencesView(preferences: model.promptBarPreferences)
-                    }
+                    PromptBarPreferencesView(preferences: model.promptBarPreferences)
                 }
                                       .visibility(model.shouldShowAIFeatures ? .visible : .gone)
 

--- a/macOS/DuckDuckGo/PromptBar/Controller/PromptBarCoordinator.swift
+++ b/macOS/DuckDuckGo/PromptBar/Controller/PromptBarCoordinator.swift
@@ -18,33 +18,26 @@
 
 import AppKit
 import Combine
-import FeatureFlags_macOS
-import PrivacyConfig
 
 /// Owns the Prompt Bar's entry points: the global shortcut and the menu bar icon click.
 @MainActor
 final class PromptBarCoordinator {
 
-    private let featureFlagger: FeatureFlagger
     private let preferences: PromptBarPreferences
     private let shortcutRegistrar: GlobalShortcutRegistering
     private let presenter: PromptBarPresenting
 
     private var shortcutCancellable: AnyCancellable?
 
-    init(featureFlagger: FeatureFlagger,
-         preferences: PromptBarPreferences,
+    init(preferences: PromptBarPreferences,
          shortcutRegistrar: GlobalShortcutRegistering,
          presenter: PromptBarPresenting) {
-        self.featureFlagger = featureFlagger
         self.preferences = preferences
         self.shortcutRegistrar = shortcutRegistrar
         self.presenter = presenter
     }
 
     func start() {
-        guard featureFlagger.isFeatureOn(.promptBar) else { return }
-
         shortcutCancellable = preferences.effectiveKeyboardShortcutPublisher
             .sink { [weak self] shortcut in
                 self?.applyShortcut(shortcut)
@@ -53,7 +46,6 @@ final class PromptBarCoordinator {
 
     /// - Parameter source: The entry point that asked, which is what the visibility pixels report.
     func togglePromptBar(source: PromptBarPresentationSource) {
-        guard featureFlagger.isFeatureOn(.promptBar) else { return }
         presenter.toggle(source: source)
     }
 

--- a/macOS/LocalPackages/FeatureFlags-macOS/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags-macOS/Sources/FeatureFlags/FeatureFlag.swift
@@ -505,11 +505,6 @@ public enum FeatureFlag: String, CaseIterable {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1217243916693082?focus=true
     case simplifiedSyncSetupV2
 
-    /// Gates the macOS Prompt Bar: a system-wide Duck.ai entry point opened via a global
-    /// keyboard shortcut or a menu bar icon, plus its rows on the AI Features settings screen.
-    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1216850216210288?focus=true
-    case promptBar
-
     /// Gates the bookmarks "Sort by name permanently" action, which permanently reorders the target
     /// folder's direct children alphabetically and persists the new order.
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1217076881156357?focus=true
@@ -862,8 +857,6 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(source: .remoteReleasable(SyncSubfeature.canReadUnifiedDeviceList), category: .sync)
         case .simplifiedSyncSetupV2:
             Config(source: .remoteReleasable(SyncSubfeature.simplifiedSyncSetupV2), category: .sync)
-        case .promptBar:
-            Config(defaultValue: .internalOnly, source: .remoteReleasable(AIChatSubfeature.promptBar), category: .duckAI)
         case .bookmarksReorderByName:
             Config(defaultValue: .enabled, source: .remoteReleasable(MacOSBrowserConfigSubfeature.bookmarksReorderByName))
         case .aiChatUsageWarnings:

--- a/macOS/UnitTests/PromptBar/PromptBarCoordinatorTests.swift
+++ b/macOS/UnitTests/PromptBar/PromptBarCoordinatorTests.swift
@@ -17,8 +17,6 @@
 //
 
 import Carbon.HIToolbox
-import FeatureFlags_macOS
-import PrivacyConfig
 import XCTest
 @testable import DuckDuckGo_Privacy_Browser
 
@@ -84,32 +82,20 @@ final class PromptBarCoordinatorTests: XCTestCase {
 
     // Doubles are built here, not passed as defaults: defaults are evaluated nonisolated.
     private func makeCoordinator(
-        isFeatureOn: Bool = true,
         persistor: MockPromptBarPreferencesPersistor = MockPromptBarPreferencesPersistor(),
         isDuckAIAvailable: Bool = true
     ) -> (PromptBarCoordinator, PromptBarPreferences, MockGlobalShortcutRegistrar, MockPromptBarPresenter) {
         let registrar = MockGlobalShortcutRegistrar()
         let presenter = MockPromptBarPresenter()
-        let featureFlagger = MockFeatureFlagger(featuresStub: [FeatureFlag.promptBar.rawValue: isFeatureOn])
 
         let configuration = MockAIChatConfig()
         configuration.shouldDisplayAnyAIChatFeature = isDuckAIAvailable
 
         let preferences = PromptBarPreferences(persistor: persistor, aiChatMenuConfiguration: configuration)
-        let coordinator = PromptBarCoordinator(featureFlagger: featureFlagger,
-                                               preferences: preferences,
+        let coordinator = PromptBarCoordinator(preferences: preferences,
                                                shortcutRegistrar: registrar,
                                                presenter: presenter)
         return (coordinator, preferences, registrar, presenter)
-    }
-
-    func testWhenFeatureFlagIsOffThenNoShortcutIsRegistered() {
-        let (coordinator, _, registrar, _) = makeCoordinator(isFeatureOn: false, persistor: .optedIn)
-
-        coordinator.start()
-
-        XCTAssertEqual(registrar.registerCallCount, 0)
-        XCTAssertNil(registrar.registeredShortcut)
     }
 
     func testWhenPreferencesAreAtTheirDefaultsThenNoShortcutIsRegistered() {
@@ -209,13 +195,5 @@ final class PromptBarCoordinatorTests: XCTestCase {
         await Task { @MainActor in }.value
 
         XCTAssertEqual(presenter.toggleSources, [.keyboardShortcut])
-    }
-
-    func testWhenFeatureFlagIsOffThenTogglingDoesNothing() {
-        let (coordinator, _, _, presenter) = makeCoordinator(isFeatureOn: false)
-
-        coordinator.togglePromptBar(source: .keyboardShortcut)
-
-        XCTAssertEqual(presenter.toggleCallCount, 0)
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211834678943996/task/1216850216210288
Tech Design URL:
CC:

### Description
Feature flag `promptBar` approved, removing conditional code. The macOS Prompt Bar (global shortcut + menu bar icon entry point to Duck.ai, plus its AI Features settings row) is now always active — removed the `FeatureFlag.promptBar` / `AIChatSubfeature.promptBar` cases and the `isFeatureOn(.promptBar)` guards in `AppDelegate`, `AIChatPreferences`, and `PromptBarCoordinator`.

### Testing Steps
1. Launch the app → Prompt Bar menu bar icon and global keyboard shortcut work with no flag override needed.
2. Open Preferences → AI Chat → the Prompt Bar preferences section (shortcut/menu bar icon toggles) is always visible.
3. Run the macOS unit test suite → `PromptBarCoordinatorTests` passes (flag-off test cases removed since the behavior they covered no longer exists).

### Impact
Low: removes a temporary rollout flag for an already-shipping feature; no behavior change for users who had the flag enabled (the default population).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hur3rG5RGnJuAewLYFjJoR)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> This only deletes a temporary kill switch for an already-shipped feature; behavior should match users who already had the flag enabled, with no auth or data-path changes.
> 
> **Overview**
> Removes the **`promptBar`** rollout flag so the macOS **Prompt Bar** (global Duck.ai shortcut, menu bar icon, and related settings) is always wired up instead of gated on privacy config / `FeatureFlag.promptBar`.
> 
> **Privacy config & flags:** Deletes `AIChatSubfeature.promptBar` and the macOS `FeatureFlag.promptBar` case plus its remote config mapping.
> 
> **Runtime:** `AppDelegate` always starts `PromptBarCoordinator` and menu bar visibility and always fires the daily Prompt Bar state pixel. `PromptBarCoordinator` no longer takes a `FeatureFlagger` or early-returns when the flag is off.
> 
> **Settings UI:** Drops `shouldShowPromptBarPreferences`; **Preferences → AI Chat** always embeds `PromptBarPreferencesView` when the AI shortcuts section is shown.
> 
> **Tests:** Removes `PromptBarCoordinatorTests` cases that asserted no-op behavior when the flag was disabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc90b2024d6df5504f8d1a300bac2c2c3615e215. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->