### PR TITLE
iOS: Show the Duck.ai menu on empty tabs

### DIFF
--- a/iOS/DuckDuckGo/AIChat/ContextualMode/DuckAIAddressBarEntry.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/DuckAIAddressBarEntry.swift
@@ -21,7 +21,7 @@ import Foundation
 
 /// What the address-bar Duck.ai button does for the current tab and session.
 enum DuckAIAddressBarEntry: Equatable {
-    /// Offer New Chat and All Chats, plus Ask About Page on web tabs.
+    /// Offer New Chat and Chats, plus Ask About Page on web tabs.
     case menu
     /// Open the contextual sheet, restoring any chat already in progress.
     case contextualSheet
@@ -35,7 +35,7 @@ enum DuckAIAddressBarEntry: Equatable {
     ///
     /// - Parameter hasChatToReopen: A conversation this tab can go back to, whether it is still live
     ///   or was persisted by an earlier launch. Reopen this tab's conversation directly rather than
-    ///   requiring the user to find it in All Chats.
+    ///   requiring the user to find it in Chats.
     static func resolve(isContextualModeAvailable: Bool,
                         isFloatingInputAvailable: Bool,
                         isHomeTab: Bool,

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/DuckAIAddressBarEntry.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/DuckAIAddressBarEntry.swift
@@ -21,7 +21,7 @@ import Foundation
 
 /// What the address-bar Duck.ai button does for the current tab and session.
 enum DuckAIAddressBarEntry: Equatable {
-    /// Offer New Chat, Ask About Page, and Recent Chats when available.
+    /// Offer New Chat and All Chats, plus Ask About Page on web tabs.
     case menu
     /// Open the contextual sheet, restoring any chat already in progress.
     case contextualSheet
@@ -30,18 +30,22 @@ enum DuckAIAddressBarEntry: Equatable {
     /// Open Duck.ai the way the button did before contextual mode.
     case legacyDuckAI
 
-    /// The menu is only offered where the New Chat versus Ask About Page choice is meaningful: a web
-    /// page with no chat to return to and nothing already open.
+    /// Home tabs offer the menu when chat history is available. Web tabs retain contextual
+    /// restoration and require floating input for the Ask About Page action.
     ///
     /// - Parameter hasChatToReopen: A conversation this tab can go back to, whether it is still live
     ///   or was persisted by an earlier launch. Reopen this tab's conversation directly rather than
-    ///   requiring the user to find it in Recent Chats.
+    ///   requiring the user to find it in All Chats.
     static func resolve(isContextualModeAvailable: Bool,
                         isFloatingInputAvailable: Bool,
                         isHomeTab: Bool,
+                        isChatHistoryAvailable: Bool,
                         hasChatToReopen: Bool,
                         isContextualSurfacePresented: Bool) -> DuckAIAddressBarEntry {
-        guard isContextualModeAvailable, !isHomeTab else { return .legacyDuckAI }
+        if isHomeTab {
+            return isChatHistoryAvailable ? .menu : .legacyDuckAI
+        }
+        guard isContextualModeAvailable else { return .legacyDuckAI }
         guard !isContextualSurfacePresented else { return .dismissContextualSurface }
         guard isFloatingInputAvailable, !hasChatToReopen else { return .contextualSheet }
         return .menu

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/DuckAIAddressBarMenuFactory.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/DuckAIAddressBarMenuFactory.swift
@@ -25,27 +25,33 @@ import UIKit
 /// Builds the address-bar Duck.ai menu for new chats, page questions, and chat history.
 enum DuckAIAddressBarMenuFactory {
 
-    /// Groups New Chat and Ask About Page above a separator, with All Chats below.
+    static func isChatHistoryAvailable(featureFlagger: FeatureFlagger, userInterfaceIdiom: UIUserInterfaceIdiom) -> Bool {
+        userInterfaceIdiom != .pad
+            && featureFlagger.isFeatureOn(.aiChatNativeChatHistory)
+            && featureFlagger.isFeatureOn(.aiChatAddressBarRecentChats)
+    }
+
+    /// Groups New Chat and, on web tabs, Ask About Page above a separator, with All Chats below.
     static func makeActions(featureFlagger: FeatureFlagger,
                             userInterfaceIdiom: UIUserInterfaceIdiom,
+                            isHomeTab: Bool,
                             onNewChat: @escaping () -> Void,
                             onAskAboutPage: @escaping () -> Void,
                             onRecentChats: @escaping () -> Void) -> [UIMenuElement] {
-        var groups: [UIMenuElement] = [
-            UIMenu(title: "", options: .displayInline, children: [
-                UIAction(title: UserText.duckAiAddressBarMenuNewChat,
-                         image: DesignSystemImages.Glyphs.Size16.compose) { _ in
-                    onNewChat()
-                },
-                UIAction(title: UserText.aiChatAttachmentOptionAskAboutPage,
-                         image: DesignSystemImages.Glyphs.Size16.chevronCircleDown) { _ in
-                    onAskAboutPage()
-                }
-            ])
+        var chatActions: [UIMenuElement] = [
+            UIAction(title: UserText.duckAiAddressBarMenuNewChat,
+                     image: DesignSystemImages.Glyphs.Size16.compose) { _ in
+                onNewChat()
+            }
         ]
-        if userInterfaceIdiom != .pad,
-           featureFlagger.isFeatureOn(.aiChatNativeChatHistory),
-           featureFlagger.isFeatureOn(.aiChatAddressBarRecentChats) {
+        if !isHomeTab {
+            chatActions.append(UIAction(title: UserText.aiChatAttachmentOptionAskAboutPage,
+                                        image: DesignSystemImages.Glyphs.Size16.chevronCircleDown) { _ in
+                onAskAboutPage()
+            })
+        }
+        var groups: [UIMenuElement] = [UIMenu(title: "", options: .displayInline, children: chatActions)]
+        if isChatHistoryAvailable(featureFlagger: featureFlagger, userInterfaceIdiom: userInterfaceIdiom) {
             groups.append(UIMenu(title: "", options: .displayInline, children: [
                 UIAction(title: UserText.duckAiAddressBarMenuAllChats,
                          image: DesignSystemImages.Glyphs.Size16.chats) { _ in

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/DuckAIAddressBarMenuFactory.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/DuckAIAddressBarMenuFactory.swift
@@ -31,7 +31,7 @@ enum DuckAIAddressBarMenuFactory {
             && featureFlagger.isFeatureOn(.aiChatAddressBarRecentChats)
     }
 
-    /// Groups New Chat and, on web tabs, Ask About Page above a separator, with All Chats below.
+    /// Groups New Chat and, on web tabs, Ask About Page above a separator, with Chats below.
     static func makeActions(featureFlagger: FeatureFlagger,
                             userInterfaceIdiom: UIUserInterfaceIdiom,
                             isHomeTab: Bool,
@@ -53,7 +53,7 @@ enum DuckAIAddressBarMenuFactory {
         var groups: [UIMenuElement] = [UIMenu(title: "", options: .displayInline, children: chatActions)]
         if isChatHistoryAvailable(featureFlagger: featureFlagger, userInterfaceIdiom: userInterfaceIdiom) {
             groups.append(UIMenu(title: "", options: .displayInline, children: [
-                UIAction(title: UserText.duckAiAddressBarMenuAllChats,
+                UIAction(title: UserText.duckAiAddressBarMenuChats,
                          image: DesignSystemImages.Glyphs.Size16.chats) { _ in
                     onRecentChats()
                 }

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/DuckAIAddressBarMenuFactory.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/DuckAIAddressBarMenuFactory.swift
@@ -53,7 +53,7 @@ enum DuckAIAddressBarMenuFactory {
         var groups: [UIMenuElement] = [UIMenu(title: "", options: .displayInline, children: chatActions)]
         if isChatHistoryAvailable(featureFlagger: featureFlagger, userInterfaceIdiom: userInterfaceIdiom) {
             groups.append(UIMenu(title: "", options: .displayInline, children: [
-                UIAction(title: UserText.duckAiAddressBarMenuChats,
+                UIAction(title: UserText.actionChats,
                          image: DesignSystemImages.Glyphs.Size16.chats) { _ in
                     onRecentChats()
                 }

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/MainViewController+DuckAIAddressBarMenu.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/MainViewController+DuckAIAddressBarMenu.swift
@@ -27,7 +27,11 @@ extension MainViewController {
         DuckAIAddressBarEntry.resolve(
             isContextualModeAvailable: aiChatContextualModeFeature.isAvailable,
             isFloatingInputAvailable: aiChatContextualFloatingInputFeature.isAvailable,
-            isHomeTab: currentTab?.tabModel.isHomeTab ?? true,
+            isHomeTab: tabManager.currentTabsModel.currentTab?.isHomeTab ?? true,
+            isChatHistoryAvailable: DuckAIAddressBarMenuFactory.isChatHistoryAvailable(
+                featureFlagger: featureFlagger,
+                userInterfaceIdiom: UIDevice.current.userInterfaceIdiom
+            ),
             hasChatToReopen: currentTab?.hasContextualChatToReopen ?? false,
             isContextualSurfacePresented: isContextualSurfacePresented
         )
@@ -44,7 +48,7 @@ extension MainViewController {
     var hasContextualSession: Bool {
         DuckAIAddressBarEntry.showsContextualGlyph(
             isContextualModeAvailable: aiChatContextualModeFeature.isAvailable,
-            isHomeTab: currentTab?.tabModel.isHomeTab ?? true,
+            isHomeTab: tabManager.currentTabsModel.currentTab?.isHomeTab ?? true,
             hasChatToReopen: currentTab?.hasContextualChatToReopen ?? false,
             isContextualSurfacePresented: isContextualSurfacePresented
         )
@@ -73,6 +77,7 @@ extension MainViewController {
         // Deferred so the shown pixel records an actual display rather than the menu being attached.
         button?.menu = UIMenu(title: UserText.duckAiFeatureName, children: [
             UIDeferredMenuElement.uncached { [weak self] completion in
+                self?.recordNewTabPageSessionAction { $0.tapDuckaiButton() }
                 self?.duckAIAddressBarPixelHandler.fireAddressBarMenuShown()
                 completion(self?.duckAIAddressBarMenuChildren() ?? [])
             }
@@ -129,6 +134,7 @@ extension MainViewController {
         DuckAIAddressBarMenuFactory.makeActions(
             featureFlagger: featureFlagger,
             userInterfaceIdiom: UIDevice.current.userInterfaceIdiom,
+            isHomeTab: tabManager.currentTabsModel.currentTab?.isHomeTab ?? true,
             onNewChat: { [weak self] in
                 self?.duckAIAddressBarPixelHandler.fireAddressBarMenuNewChatSelected()
                 self?.openFreshDuckAIChatFromAddressBarMenu()

--- a/iOS/DuckDuckGo/AIChat/ContextualMode/MainViewController+DuckAIAddressBarMenu.swift
+++ b/iOS/DuckDuckGo/AIChat/ContextualMode/MainViewController+DuckAIAddressBarMenu.swift
@@ -152,6 +152,7 @@ extension MainViewController {
 
     private func openRecentChatsFromAddressBarMenu() {
         omniBar.endEditing()
+        recordNewTabPageSessionDeparture()
         openAIChatHistory(source: .addressBar)
     }
 

--- a/iOS/DuckDuckGo/UserText.swift
+++ b/iOS/DuckDuckGo/UserText.swift
@@ -2272,7 +2272,7 @@ public struct UserText {
     public static let aiChatAttachmentOptionTakePhoto = NSLocalizedString("aichat.attachment.option.take.photo", value: "Take Photo", comment: "Top-level attachment menu option to take a photo using the device camera for attaching to an AI chat message")
     public static let aiChatAttachmentOptionAskAboutPage = NSLocalizedString("aichat.attachment.option.ask.about.page", value: "Ask About Page", comment: "Top-level attachment menu option to attach the current page content to an AI chat message")
     public static let duckAiAddressBarMenuNewChat = NSLocalizedString("duckai.address.bar.menu.new.chat", value: "New Chat", comment: "Address bar Duck.ai menu option that opens a fresh chat with no page context")
-    public static let duckAiAddressBarMenuAllChats = NSLocalizedString("duckai.address.bar.menu.all.chats", value: "All Chats", comment: "Address bar Duck.ai menu option that opens the full chat history")
+    public static let duckAiAddressBarMenuChats = NSLocalizedString("duckai.address.bar.menu.chats", value: "Chats", comment: "Address bar Duck.ai menu option that opens the full chat history")
     public static func aiChatAttachmentFileTooLarge(maxFileSizeMB: Int) -> String {
         let message = NSLocalizedString("aichat.attachment.file.too.large", value: "This file is too large. The maximum file size is %d MB.", comment: "Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Parameter is the backend-provided size limit in megabytes.")
         return message.format(arguments: maxFileSizeMB)

--- a/iOS/DuckDuckGo/UserText.swift
+++ b/iOS/DuckDuckGo/UserText.swift
@@ -2272,7 +2272,6 @@ public struct UserText {
     public static let aiChatAttachmentOptionTakePhoto = NSLocalizedString("aichat.attachment.option.take.photo", value: "Take Photo", comment: "Top-level attachment menu option to take a photo using the device camera for attaching to an AI chat message")
     public static let aiChatAttachmentOptionAskAboutPage = NSLocalizedString("aichat.attachment.option.ask.about.page", value: "Ask About Page", comment: "Top-level attachment menu option to attach the current page content to an AI chat message")
     public static let duckAiAddressBarMenuNewChat = NSLocalizedString("duckai.address.bar.menu.new.chat", value: "New Chat", comment: "Address bar Duck.ai menu option that opens a fresh chat with no page context")
-    public static let duckAiAddressBarMenuChats = NSLocalizedString("duckai.address.bar.menu.chats", value: "Chats", comment: "Address bar Duck.ai menu option that opens the full chat history")
     public static func aiChatAttachmentFileTooLarge(maxFileSizeMB: Int) -> String {
         let message = NSLocalizedString("aichat.attachment.file.too.large", value: "This file is too large. The maximum file size is %d MB.", comment: "Error message displayed when the user tries to attach a file that exceeds the maximum allowed size. Parameter is the backend-provided size limit in megabytes.")
         return message.format(arguments: maxFileSizeMB)

--- a/iOS/DuckDuckGo/en.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/en.lproj/Localizable.strings
@@ -1867,9 +1867,6 @@
 /* Message explaining to the user that Duck Player is not available */
 "duck-player.video-contingency-message" = "Duck Player's functionality has been affected by recent changes to YouTube. We’re working to fix these issues and appreciate your understanding.";
 
-/* Address bar Duck.ai menu option that opens the full chat history */
-"duckai.address.bar.menu.chats" = "Chats";
-
 /* Address bar Duck.ai menu option that opens a fresh chat with no page context */
 "duckai.address.bar.menu.new.chat" = "New Chat";
 

--- a/iOS/DuckDuckGo/en.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/en.lproj/Localizable.strings
@@ -1868,7 +1868,7 @@
 "duck-player.video-contingency-message" = "Duck Player's functionality has been affected by recent changes to YouTube. We’re working to fix these issues and appreciate your understanding.";
 
 /* Address bar Duck.ai menu option that opens the full chat history */
-"duckai.address.bar.menu.all.chats" = "All Chats";
+"duckai.address.bar.menu.chats" = "Chats";
 
 /* Address bar Duck.ai menu option that opens a fresh chat with no page context */
 "duckai.address.bar.menu.new.chat" = "New Chat";

--- a/iOS/DuckDuckGoTests/AIChat/DuckAIAddressBarEntryTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/DuckAIAddressBarEntryTests.swift
@@ -25,12 +25,14 @@ final class DuckAIAddressBarEntryTests: XCTestCase {
     private func resolve(isContextualModeAvailable: Bool = true,
                          isFloatingInputAvailable: Bool = true,
                          isHomeTab: Bool = false,
+                         isChatHistoryAvailable: Bool = true,
                          hasChatToReopen: Bool = false,
                          isContextualSurfacePresented: Bool = false) -> DuckAIAddressBarEntry {
         DuckAIAddressBarEntry.resolve(
             isContextualModeAvailable: isContextualModeAvailable,
             isFloatingInputAvailable: isFloatingInputAvailable,
             isHomeTab: isHomeTab,
+            isChatHistoryAvailable: isChatHistoryAvailable,
             hasChatToReopen: hasChatToReopen,
             isContextualSurfacePresented: isContextualSurfacePresented
         )
@@ -65,8 +67,22 @@ final class DuckAIAddressBarEntryTests: XCTestCase {
 
     // MARK: - Legacy
 
-    func testHomeTabOpensDuckAiDirectly() {
-        XCTAssertEqual(resolve(isHomeTab: true), .legacyDuckAI)
+    func testHomeTabOffersMenuWithAndWithoutContextualOrFloatingInput() {
+        for contextualMode in [false, true] {
+            for floatingInput in [false, true] {
+                XCTAssertEqual(resolve(isContextualModeAvailable: contextualMode,
+                                       isFloatingInputAvailable: floatingInput,
+                                       isHomeTab: true), .menu)
+            }
+        }
+    }
+
+    func testHomeTabWithoutHistoryOpensDuckAiDirectly() {
+        XCTAssertEqual(resolve(isHomeTab: true, isChatHistoryAvailable: false), .legacyDuckAI)
+    }
+
+    func testWebPageMenuDoesNotRequireHistory() {
+        XCTAssertEqual(resolve(isChatHistoryAvailable: false), .menu)
     }
 
     func testWithoutContextualModeOpensDuckAiDirectly() {
@@ -74,11 +90,11 @@ final class DuckAIAddressBarEntryTests: XCTestCase {
     }
 
     func testHomeTabWinsOverAnActiveChat() {
-        XCTAssertEqual(resolve(isHomeTab: true, hasChatToReopen: true), .legacyDuckAI)
+        XCTAssertEqual(resolve(isHomeTab: true, hasChatToReopen: true), .menu)
     }
 
     func testHomeTabWinsOverAPresentedSurface() {
-        XCTAssertEqual(resolve(isHomeTab: true, isContextualSurfacePresented: true), .legacyDuckAI)
+        XCTAssertEqual(resolve(isHomeTab: true, isContextualSurfacePresented: true), .menu)
     }
 
     // MARK: - Contextual glyph
@@ -117,8 +133,7 @@ final class DuckAIAddressBarEntryTests: XCTestCase {
         XCTAssertFalse(showsGlyph(isContextualModeAvailable: false, hasChatToReopen: true))
     }
 
-    /// Matches `resolve`, which sends the home tab to `.legacyDuckAI`: the glyph must not promise a
-    /// contextual session the tap will not open.
+    /// Home-tab actions never restore a contextual session.
     func testHomeTabNeverShowsTheGlyph() {
         XCTAssertFalse(showsGlyph(isHomeTab: true, hasChatToReopen: true))
         XCTAssertFalse(showsGlyph(isHomeTab: true, isContextualSurfacePresented: true))

--- a/iOS/DuckDuckGoTests/AIChat/DuckAIAddressBarMenuFactoryTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/DuckAIAddressBarMenuFactoryTests.swift
@@ -62,7 +62,7 @@ final class DuckAIAddressBarMenuFactoryTests: XCTestCase {
         XCTAssertEqual(newChatGroup.children.compactMap { ($0 as? UIAction)?.title },
                        [UserText.duckAiAddressBarMenuNewChat, UserText.aiChatAttachmentOptionAskAboutPage])
         XCTAssertEqual(historyGroup.children.compactMap { ($0 as? UIAction)?.title },
-                       [UserText.duckAiAddressBarMenuChats])
+                       [UserText.actionChats])
     }
 
     func testHomeTabOffersNewChatAndChatsWithoutAskAboutPage() throws {
@@ -72,7 +72,7 @@ final class DuckAIAddressBarMenuFactoryTests: XCTestCase {
         XCTAssertEqual(try XCTUnwrap(groups.first).children.compactMap { ($0 as? UIAction)?.title },
                        [UserText.duckAiAddressBarMenuNewChat])
         XCTAssertEqual(try XCTUnwrap(groups.last).children.compactMap { ($0 as? UIAction)?.title },
-                       [UserText.duckAiAddressBarMenuChats])
+                       [UserText.actionChats])
     }
 
     func testHomeTabActionsInvokeOnlyNewChatAndHistoryHandlers() throws {
@@ -94,7 +94,7 @@ final class DuckAIAddressBarMenuFactoryTests: XCTestCase {
         let titles = flattenedActions(makeActions()).map(\.title)
         XCTAssertEqual(titles, [UserText.duckAiAddressBarMenuNewChat,
                                UserText.aiChatAttachmentOptionAskAboutPage,
-                               UserText.duckAiAddressBarMenuChats])
+                               UserText.actionChats])
     }
 
     func testRecentChatsGroupIsOmittedWhenFlagIsDisabled() {
@@ -126,7 +126,7 @@ final class DuckAIAddressBarMenuFactoryTests: XCTestCase {
                 featureFlagger: MockFeatureFlagger(enabledFeatureFlags: testCase.flags),
                 userInterfaceIdiom: testCase.idiom))
             let expectedTitles = [UserText.duckAiAddressBarMenuNewChat, UserText.aiChatAttachmentOptionAskAboutPage]
-                + (testCase.showsRecentChats ? [UserText.duckAiAddressBarMenuChats] : [])
+                + (testCase.showsRecentChats ? [UserText.actionChats] : [])
             XCTAssertEqual(actions.map(\.title), expectedTitles, "Flags: \(testCase.flags), device: \(testCase.idiom)")
         }
     }

--- a/iOS/DuckDuckGoTests/AIChat/DuckAIAddressBarMenuFactoryTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/DuckAIAddressBarMenuFactoryTests.swift
@@ -28,12 +28,14 @@ final class DuckAIAddressBarMenuFactoryTests: XCTestCase {
     private func makeActions(featureFlagger: MockFeatureFlagger = MockFeatureFlagger(
                                 enabledFeatureFlags: [.aiChatNativeChatHistory, .aiChatAddressBarRecentChats]),
                              userInterfaceIdiom: UIUserInterfaceIdiom = .phone,
+                             isHomeTab: Bool = false,
                              onNewChat: @escaping () -> Void = {},
                              onAskAboutPage: @escaping () -> Void = {},
                              onRecentChats: @escaping () -> Void = {}) -> [UIMenuElement] {
         DuckAIAddressBarMenuFactory.makeActions(
             featureFlagger: featureFlagger,
             userInterfaceIdiom: userInterfaceIdiom,
+            isHomeTab: isHomeTab,
             onNewChat: onNewChat,
             onAskAboutPage: onAskAboutPage,
             onRecentChats: onRecentChats
@@ -61,6 +63,31 @@ final class DuckAIAddressBarMenuFactoryTests: XCTestCase {
                        [UserText.duckAiAddressBarMenuNewChat, UserText.aiChatAttachmentOptionAskAboutPage])
         XCTAssertEqual(historyGroup.children.compactMap { ($0 as? UIAction)?.title },
                        [UserText.duckAiAddressBarMenuAllChats])
+    }
+
+    func testHomeTabOffersNewChatAndAllChatsWithoutAskAboutPage() throws {
+        let groups = makeActions(isHomeTab: true).compactMap { $0 as? UIMenu }
+        XCTAssertEqual(groups.count, 2)
+        XCTAssertTrue(groups.allSatisfy { $0.options.contains(.displayInline) })
+        XCTAssertEqual(try XCTUnwrap(groups.first).children.compactMap { ($0 as? UIAction)?.title },
+                       [UserText.duckAiAddressBarMenuNewChat])
+        XCTAssertEqual(try XCTUnwrap(groups.last).children.compactMap { ($0 as? UIAction)?.title },
+                       [UserText.duckAiAddressBarMenuAllChats])
+    }
+
+    func testHomeTabActionsInvokeOnlyNewChatAndHistoryHandlers() throws {
+        guard #available(iOS 16.0, *) else {
+            throw XCTSkip("UIAction.performWithSender requires iOS 16")
+        }
+        var selected: [String] = []
+        let actions = flattenedActions(makeActions(isHomeTab: true,
+                                                  onNewChat: { selected.append("new") },
+                                                  onAskAboutPage: { selected.append("page") },
+                                                  onRecentChats: { selected.append("history") }))
+        for action in actions {
+            action.performWithSender(nil, target: nil)
+        }
+        XCTAssertEqual(selected, ["new", "history"])
     }
 
     func testRecentChatsFollowsNewChatAndAskAboutPage() {
@@ -92,6 +119,9 @@ final class DuckAIAddressBarMenuFactoryTests: XCTestCase {
         ]
 
         for testCase in cases {
+            XCTAssertEqual(DuckAIAddressBarMenuFactory.isChatHistoryAvailable(
+                featureFlagger: MockFeatureFlagger(enabledFeatureFlags: testCase.flags),
+                userInterfaceIdiom: testCase.idiom), testCase.showsRecentChats)
             let actions = flattenedActions(makeActions(
                 featureFlagger: MockFeatureFlagger(enabledFeatureFlags: testCase.flags),
                 userInterfaceIdiom: testCase.idiom))

--- a/iOS/DuckDuckGoTests/AIChat/DuckAIAddressBarMenuFactoryTests.swift
+++ b/iOS/DuckDuckGoTests/AIChat/DuckAIAddressBarMenuFactoryTests.swift
@@ -62,17 +62,17 @@ final class DuckAIAddressBarMenuFactoryTests: XCTestCase {
         XCTAssertEqual(newChatGroup.children.compactMap { ($0 as? UIAction)?.title },
                        [UserText.duckAiAddressBarMenuNewChat, UserText.aiChatAttachmentOptionAskAboutPage])
         XCTAssertEqual(historyGroup.children.compactMap { ($0 as? UIAction)?.title },
-                       [UserText.duckAiAddressBarMenuAllChats])
+                       [UserText.duckAiAddressBarMenuChats])
     }
 
-    func testHomeTabOffersNewChatAndAllChatsWithoutAskAboutPage() throws {
+    func testHomeTabOffersNewChatAndChatsWithoutAskAboutPage() throws {
         let groups = makeActions(isHomeTab: true).compactMap { $0 as? UIMenu }
         XCTAssertEqual(groups.count, 2)
         XCTAssertTrue(groups.allSatisfy { $0.options.contains(.displayInline) })
         XCTAssertEqual(try XCTUnwrap(groups.first).children.compactMap { ($0 as? UIAction)?.title },
                        [UserText.duckAiAddressBarMenuNewChat])
         XCTAssertEqual(try XCTUnwrap(groups.last).children.compactMap { ($0 as? UIAction)?.title },
-                       [UserText.duckAiAddressBarMenuAllChats])
+                       [UserText.duckAiAddressBarMenuChats])
     }
 
     func testHomeTabActionsInvokeOnlyNewChatAndHistoryHandlers() throws {
@@ -94,7 +94,7 @@ final class DuckAIAddressBarMenuFactoryTests: XCTestCase {
         let titles = flattenedActions(makeActions()).map(\.title)
         XCTAssertEqual(titles, [UserText.duckAiAddressBarMenuNewChat,
                                UserText.aiChatAttachmentOptionAskAboutPage,
-                               UserText.duckAiAddressBarMenuAllChats])
+                               UserText.duckAiAddressBarMenuChats])
     }
 
     func testRecentChatsGroupIsOmittedWhenFlagIsDisabled() {
@@ -126,7 +126,7 @@ final class DuckAIAddressBarMenuFactoryTests: XCTestCase {
                 featureFlagger: MockFeatureFlagger(enabledFeatureFlags: testCase.flags),
                 userInterfaceIdiom: testCase.idiom))
             let expectedTitles = [UserText.duckAiAddressBarMenuNewChat, UserText.aiChatAttachmentOptionAskAboutPage]
-                + (testCase.showsRecentChats ? [UserText.duckAiAddressBarMenuAllChats] : [])
+                + (testCase.showsRecentChats ? [UserText.duckAiAddressBarMenuChats] : [])
             XCTAssertEqual(actions.map(\.title), expectedTitles, "Flags: \(testCase.flags), device: \(testCase.idiom)")
         }
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206488453854252/task/1218334529171054

### Description
On an empty tab, tapping Duck.ai now offers New Chat and All Chats instead of opening Duck.ai immediately. Ask About Page appears only on web tabs. The new-tab menu works with floating and non-floating input; devices or configurations without native history keep the direct entry.

### Testing Steps
Manual verification pending:
1. On iPhone with native history and the address-bar history flag enabled, open a new tab and tap Duck.ai → New Chat and All Chats appear, with no Ask About Page.
2. Select New Chat → a fresh full Duck.ai chat opens without page context or an automatically submitted prompt.
3. Open All Chats from normal and Fire new tabs → each shows its own history; an empty history still opens the list. Dismiss → return to the new tab.
4. Repeat with floating/non-floating input, top/bottom address bar, and light/dark appearance.
5. On a web tab, verify the existing menu, Ask About Page, and direct restoration/dismissal of contextual chats remain unchanged.
6. Disable either history flag, or use iPad → the empty-tab button still opens Duck.ai directly.

### Impact
Low: changes the empty-tab Duck.ai entry menu; reuses existing navigation and history storage.

### Quality Considerations
Added resolver and menu tests for home-tab eligibility, omitted page actions, and handler wiring. Reads home-tab state from the tab model, including when no view controller exists. Preserves new-tab tap instrumentation and existing translations/pixels.

`git diff --check` passed. Build/run and tests could not execute because Beekeeper rejected this session's missing build identity. Installed SwiftLint exited successfully with unsupported-rule and unchanged-header warnings; no runtime UI verification performed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UX-only changes to the address-bar entry path, gated by existing feature flags and covered by updated unit tests; no auth or data-model changes.
> 
> **Overview**
> **Empty (home) tabs** can show the address-bar Duck.ai **menu** instead of jumping straight into chat when native chat history is enabled (both history flags on, non-iPad). The menu offers **New Chat** and **Chats** only—**Ask About Page** stays on web tabs.
> 
> `DuckAIAddressBarEntry.resolve` now branches home tabs on `isChatHistoryAvailable`; web-tab contextual restore/dismiss behavior is unchanged. Menu construction takes `isHomeTab`, centralizes history eligibility in `DuckAIAddressBarMenuFactory.isChatHistoryAvailable`, and uses the shared **Chats** label instead of the removed **All Chats** string.
> 
> Home-tab detection reads `tabManager.currentTabsModel.currentTab?.isHomeTab`. Opening the menu records a new-tab-page Duck.ai tap; choosing **Chats** records session departure before history opens.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 080723cf2a13eccba947e8d8f1ef9b437d62bbe7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->