### PR TITLE
iOS Remove launch time metrics feature flag

### DIFF
--- a/iOS/DuckDuckGo/AppLifecycle/AppStates/Launching.swift
+++ b/iOS/DuckDuckGo/AppLifecycle/AppStates/Launching.swift
@@ -193,7 +193,7 @@ struct Launching: LaunchingHandling {
                                     freemiumPIRDebugSettings: freemiumPIRDebugSettings)
         let configurationService = RemoteConfigurationService()
         let crashCollectionService = CrashCollectionService(featureFlagger: featureFlagger)
-        let launchTimeMetricsService = LaunchTimeMetricsService(featureFlagger: featureFlagger)
+        let launchTimeMetricsService = LaunchTimeMetricsService()
         let statisticsService = StatisticsService()
 
         let productSurfaceTelemetry = PixelProductSurfaceTelemetry(featureFlagger: featureFlagger, pixelFiring: PixelKit.shared)

--- a/iOS/DuckDuckGo/AppServices/LaunchTimeMetrics/LaunchTimeMetricsService.swift
+++ b/iOS/DuckDuckGo/AppServices/LaunchTimeMetrics/LaunchTimeMetricsService.swift
@@ -21,24 +21,15 @@ import Foundation
 import MetricKit
 import Core
 import Persistence
-import PrivacyConfig
-import FeatureFlags_iOS
 
-/// Owns the MetricKit launch-time subscriber. When enabled, registers it with
-/// `MXMetricManager` and drains any already-available past payloads on start and
-/// on every foreground.
+/// Owns the MetricKit launch-time subscriber. Registers it with `MXMetricManager`
+/// and drains any already-available past payloads on start and on every foreground.
 @available(iOSApplicationExtension, unavailable)
 final class LaunchTimeMetricsService {
 
-    private let subscriber: LaunchTimeMetricsSubscriber?
+    private let subscriber: LaunchTimeMetricsSubscriber
 
-    init(featureFlagger: FeatureFlagger,
-         store: KeyValueStoring = UserDefaults.standard) {
-        guard featureFlagger.isFeatureOn(.launchTimeMetrics) else {
-            self.subscriber = nil
-            return
-        }
-
+    init(store: KeyValueStoring = UserDefaults.standard) {
         let subscriber = LaunchTimeMetricsSubscriber(store: store)
         self.subscriber = subscriber
         MXMetricManager.shared.add(subscriber)
@@ -49,12 +40,10 @@ final class LaunchTimeMetricsService {
     /// to pick up payloads delivered while the app was inactive. The subscriber does the work
     /// off the main thread, and its dedup marker makes repeated calls safe
     func resume() {
-        subscriber?.processPastPayloads()
+        subscriber.processPastPayloads()
     }
 
     deinit {
-        if let subscriber {
-            MXMetricManager.shared.remove(subscriber)
-        }
+        MXMetricManager.shared.remove(subscriber)
     }
 }

--- a/iOS/LocalPackages/FeatureFlags-iOS/Sources/FeatureFlags/FeatureFlag.swift
+++ b/iOS/LocalPackages/FeatureFlags-iOS/Sources/FeatureFlags/FeatureFlag.swift
@@ -372,10 +372,6 @@ public enum FeatureFlag: String {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1213037858764805
     case crashCollectionLimitCallStackTreeDepth
 
-    /// Enables sending MetricKit launch-time telemetry pixels.
-    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1216663565461118?focus=true
-    case launchTimeMetrics
-
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1217109908046478?focus=true
     case tabTerminationTelemetry
 
@@ -825,8 +821,6 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(source: .remoteReleasable(iOSBrowserConfigSubfeature.genericBackgroundTask))
         case .crashCollectionLimitCallStackTreeDepth:
             Config(defaultValue: .enabled, source: .remoteReleasable(iOSBrowserConfigSubfeature.crashCollectionLimitCallStackTreeDepth), supportsLocalOverriding: false)
-        case .launchTimeMetrics:
-            Config(defaultValue: .enabled, source: .remoteReleasable(iOSBrowserConfigSubfeature.launchTimeMetrics), supportsLocalOverriding: true)
         case .tabTerminationTelemetry:
             Config(defaultValue: .enabled, source: .remoteReleasable(iOSBrowserConfigSubfeature.tabTerminationTelemetry), supportsLocalOverriding: true)
         case .tabTerminationErrorPage:

--- a/iOS/LocalPackages/FeatureFlags-iOS/Sources/FeatureFlags/iOSBrowserConfigSubfeature.swift
+++ b/iOS/LocalPackages/FeatureFlags-iOS/Sources/FeatureFlags/iOSBrowserConfigSubfeature.swift
@@ -55,10 +55,6 @@ public enum iOSBrowserConfigSubfeature: String, PrivacySubfeature {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1213037858764805
     case crashCollectionLimitCallStackTreeDepth
 
-    /// Enables sending MetricKit launch-time telemetry pixels.
-    /// https://app.asana.com/1/137249556945/project/1208671677432066/task/1214963974721156
-    case launchTimeMetrics
-
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1217109908046478?focus=true
     case tabTerminationTelemetry
 


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ External contributors: file an issue before opening a PR.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1211834678943996/task/1216663565461118?focus=true
Tech Design URL:
CC:

### Description
<!-- What changed and why, in plain English. No class names, method names, or implementation details — the diff shows those. Keep it brief. -->
As title. Behavior should default to on

### Testing Steps
<!-- One action per step. Note expected outcome inline where relevant, e.g. "3. Tap Save → settings screen dismisses". Assume the reviewer is unfamiliar with this part of the app. -->
1. Run on a real device, and use Xcode to trigger metric kit test data. Check the pixels are still sent
2.

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Before submitting: identify realistic failure scenarios and check a mitigation exists in this diff (test, flag, guard). Only keep this section if the risk is non-obvious to a reviewer. Otherwise delete it. One line per scenario: "X could happen → mitigated by Y." -->

### Quality Considerations
<!-- Edge cases, performance, privacy/security impact — omit if not applicable -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Telemetry rollout change only; removes a kill switch but behavior matches the former default-on flag, with no user-facing or security impact.
> 
> **Overview**
> **Launch-time MetricKit telemetry is always on** — the `launchTimeMetrics` remote/local feature flag and its privacy-config subfeature are removed.
> 
> `LaunchTimeMetricsService` no longer accepts a `FeatureFlagger` or optional subscriber: it **always** registers `LaunchTimeMetricsSubscriber` with `MXMetricManager` at init and processes past payloads on start and via `resume()`. App launch wiring in `Launching` is updated to use the parameterless initializer, matching the prior default-enabled flag behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2ba8fa7ee9a812737fce435fe2112d642b76373. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->