### PR TITLE
Add Duck.ai browser tools bridge: session, discovery, and invocation

### DIFF
--- a/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatScriptUserValues.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatScriptUserValues.swift
@@ -147,6 +147,10 @@ public struct AIChatNativeConfigValues: Codable {
     public let installAge: Int
     /// Native-owned attachment caps read by the sidebar; nil (omitted) means no caps.
     public let attachmentLimits: AIChatNativeAttachmentLimits?
+    /// `true` when native exposes the browser tools bridge, so Duck.ai may open an MCP session
+    /// and discover tools. The front end must not open a session when this is false — it also
+    /// serves as version-skew protection against builds that predate the bridge.
+    public let supportsBrowserTools: Bool
 
     public static var defaultValues: AIChatNativeConfigValues {
 #if os(iOS)
@@ -220,7 +224,8 @@ public struct AIChatNativeConfigValues: Codable {
                 supportsNativeDictationPermissionHandler: Bool = false,
                 installType: AIChatInstallType = .new,
                 installAge: Int = 0,
-                attachmentLimits: AIChatNativeAttachmentLimits? = nil) {
+                attachmentLimits: AIChatNativeAttachmentLimits? = nil,
+                supportsBrowserTools: Bool = false) {
         self.isAIChatHandoffEnabled = isAIChatHandoffEnabled
         self.platform = Platform.name
         self.supportsClosingAIChat = supportsClosingAIChat
@@ -249,6 +254,7 @@ public struct AIChatNativeConfigValues: Codable {
         self.installType = installType
         self.installAge = installAge
         self.attachmentLimits = attachmentLimits
+        self.supportsBrowserTools = supportsBrowserTools
     }
 
     /// Buckets the days between the install date and `now` into the values expected by the

--- a/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatUserScriptMessages.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/AIChatUserScriptMessages.swift
@@ -117,5 +117,21 @@ public enum AIChatUserScriptMessages: String, CaseIterable {
 
     /// Posted by the Customize Responses card placement when the user dismisses it.
     case customizeResponsesModalClosed
+
+    // MARK: - Browser tools
+
+    /// MCP `initialize` — negotiates protocol version and capabilities for browser tools.
+    /// Opens the session that `toolsList` and `toolsCall` require.
+    case initialize
+
+    /// MCP `notifications/initialized` — the FE is ready for tools traffic. Sent without an
+    /// envelope `id`, so it is answered only when the FE asks for a reply.
+    case notificationsInitialized = "notifications/initialized"
+
+    /// MCP `tools/list` — the browser tools this FE may discover, after remote-config gating.
+    case toolsList = "tools/list"
+
+    /// MCP `tools/call` — invoke a registered browser tool.
+    case toolsCall = "tools/call"
 }
 // swiftlint:enable inclusive_language

--- a/SharedPackages/AIChat/Sources/AIChat/Shared/BrowserTools/AIChatMCPSession.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/BrowserTools/AIChatMCPSession.swift
@@ -45,10 +45,8 @@ public struct AIChatMCPSession: Equatable, Sendable {
     }
 }
 
-/// Sessions keyed by Duck.ai owner tab, so a sidebar and the tab it is docked to share one.
-///
-/// Ownership sits here rather than on the sidebar's view model so `initialize` can succeed even
-/// when it races the sidebar being presented.
+/// Sessions keyed by Duck.ai owner tab, so a sidebar and its host tab share one. Kept here rather
+/// than on the sidebar's view model so `initialize` can win a race with the sidebar appearing.
 @MainActor
 public final class AIChatMCPSessionStore {
 

--- a/SharedPackages/AIChat/Sources/AIChat/Shared/BrowserTools/AIChatMCPSession.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/BrowserTools/AIChatMCPSession.swift
@@ -68,10 +68,8 @@ public final class AIChatMCPSessionStore {
         sessions[ownerTabID] = session
     }
 
-    /// Creates the session if it is missing: a front end may confirm readiness after an
-    /// `initialize` that timed out on its side, and refusing here would strand it with no way
-    /// to list tools. Such a session simply has no elicitation capability, so Ask tools report
-    /// `elicitation_unsupported` rather than prompting into the void.
+    /// Creates the session if missing, so a front end whose `initialize` timed out on its side can
+    /// still recover. It just has no elicitation capability.
     public func markInitialized(forOwnerTabID ownerTabID: String) {
         var session = sessions[ownerTabID] ?? AIChatMCPSession()
         session.markInitialized()

--- a/SharedPackages/AIChat/Sources/AIChat/Shared/BrowserTools/AIChatMCPSession.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/BrowserTools/AIChatMCPSession.swift
@@ -1,0 +1,89 @@
+//
+//  AIChatMCPSession.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+/// Per-owner-tab MCP session state, established by `initialize` and completed by
+/// `notifications/initialized`.
+public struct AIChatMCPSession: Equatable, Sendable {
+
+    /// Tools traffic is refused with `not_initialized` until the FE confirms it is ready.
+    public private(set) var isInitialized = false
+
+    /// What the client declared. Recorded for diagnostics; native always answers with its own.
+    public private(set) var protocolVersion: String?
+
+    public private(set) var supportsElicitationForm = false
+
+    public init() {}
+
+    /// Re-initializing clears readiness — a client that hands over a fresh handshake has to
+    /// complete it again before tools traffic resumes.
+    public mutating func applyInitialize(protocolVersion: String?, supportsElicitationForm: Bool) {
+        self.protocolVersion = protocolVersion
+        self.supportsElicitationForm = supportsElicitationForm
+        self.isInitialized = false
+    }
+
+    public mutating func markInitialized() {
+        isInitialized = true
+    }
+}
+
+/// Sessions keyed by Duck.ai owner tab, so a sidebar and the tab it is docked to share one.
+///
+/// Ownership sits here rather than on the sidebar's view model so `initialize` can succeed even
+/// when it races the sidebar being presented.
+@MainActor
+public final class AIChatMCPSessionStore {
+
+    private var sessions: [String: AIChatMCPSession] = [:]
+
+    public init() {}
+
+    public func session(forOwnerTabID ownerTabID: String) -> AIChatMCPSession? {
+        sessions[ownerTabID]
+    }
+
+    public func applyInitialize(forOwnerTabID ownerTabID: String,
+                                protocolVersion: String?,
+                                supportsElicitationForm: Bool) {
+        var session = sessions[ownerTabID] ?? AIChatMCPSession()
+        session.applyInitialize(protocolVersion: protocolVersion, supportsElicitationForm: supportsElicitationForm)
+        sessions[ownerTabID] = session
+    }
+
+    /// Creates the session if it is missing: a front end may confirm readiness after an
+    /// `initialize` that timed out on its side, and refusing here would strand it with no way
+    /// to list tools. Such a session simply has no elicitation capability, so Ask tools report
+    /// `elicitation_unsupported` rather than prompting into the void.
+    public func markInitialized(forOwnerTabID ownerTabID: String) {
+        var session = sessions[ownerTabID] ?? AIChatMCPSession()
+        session.markInitialized()
+        sessions[ownerTabID] = session
+    }
+
+    public func removeSession(forOwnerTabID ownerTabID: String) {
+        sessions.removeValue(forKey: ownerTabID)
+    }
+
+    /// Drops every session — used when data is burned.
+    public func removeAllSessions() {
+        sessions.removeAll()
+    }
+}

--- a/SharedPackages/AIChat/Sources/AIChat/Shared/BrowserTools/BrowserTool.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/BrowserTools/BrowserTool.swift
@@ -46,11 +46,8 @@ public protocol BrowserTool: AnyObject {
     /// MCP hints; omitted for untrusted page tools.
     var annotations: MCPToolAnnotations? { get }
 
-    /// Runs the tool.
-    ///
-    /// Callers go through the invoker so gating and consent run first. A tool still re-checks
-    /// anything it owns — notably the Fire boundary — so calling it directly cannot bypass a
-    /// refusal it is responsible for.
+    /// Runs the tool. Callers go through the invoker so gating runs first, but a tool still
+    /// re-checks the Fire boundary so a direct call cannot bypass it.
     func execute(arguments: JSONValue?, context: BrowserToolCallContext) async -> BrowserToolResult
 }
 
@@ -58,11 +55,8 @@ public extension BrowserTool {
     var outputSchema: JSONValue? { nil }
     var annotations: MCPToolAnnotations? { nil }
 
-    /// This tool's `tools/list` descriptor.
-    ///
-    /// DEBUG builds also advertise the permission mode and current decision so the debug harness
-    /// can show them; release builds keep the wire MCP-clean.
-    /// - Parameter permissionState: the effective stored decision, when the caller knows it.
+    /// This tool's `tools/list` descriptor. DEBUG builds also advertise the permission mode and
+    /// current decision; release builds keep the wire MCP-clean.
     func descriptor(permissionState: String? = nil) -> BrowserToolDescriptor {
 #if DEBUG
         let permissionDefault: String? = permissionMode.rawValue
@@ -96,6 +90,10 @@ public struct BrowserToolCallContext: Equatable, Sendable {
     /// docked to share one session and one scope.
     public let ownerTabID: String
 
+    /// Opaque handle for the window the chat belongs to, minted by the platform. Tools scope to
+    /// this rather than to `ownerTabID`, which a shared tab can make ambiguous.
+    public let ownerWindowToken: String?
+
     /// True in a Fire window. Every tool refuses with `unavailable` — never a Fire-specific
     /// token, so the front end cannot infer that the user is browsing privately.
     public let isBurner: Bool
@@ -104,8 +102,12 @@ public struct BrowserToolCallContext: Equatable, Sendable {
     /// because there would be no way to obtain consent.
     public let supportsElicitationForm: Bool
 
-    public init(ownerTabID: String, isBurner: Bool, supportsElicitationForm: Bool) {
+    public init(ownerTabID: String,
+                ownerWindowToken: String? = nil,
+                isBurner: Bool,
+                supportsElicitationForm: Bool) {
         self.ownerTabID = ownerTabID
+        self.ownerWindowToken = ownerWindowToken
         self.isBurner = isBurner
         self.supportsElicitationForm = supportsElicitationForm
     }

--- a/SharedPackages/AIChat/Sources/AIChat/Shared/BrowserTools/BrowserTool.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/BrowserTools/BrowserTool.swift
@@ -18,10 +18,8 @@
 
 import Foundation
 
-/// A discoverable, invokable browser capability exposed to Duck.ai over the MCP-shaped contract.
-///
-/// Adding a tool is: conform to this protocol, add its sub-feature gate, and register it. Nothing
-/// in the bridge, session or permission layers needs to change.
+/// A browser capability Duck.ai can discover and invoke. Adding one is: conform, add a
+/// sub-feature gate, register — the bridge, session and permission layers stay untouched.
 @MainActor
 public protocol BrowserTool: AnyObject {
 

--- a/SharedPackages/AIChat/Sources/AIChat/Shared/BrowserTools/BrowserTool.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/BrowserTools/BrowserTool.swift
@@ -1,0 +1,129 @@
+//
+//  BrowserTool.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+/// A discoverable, invokable browser capability exposed to Duck.ai over the MCP-shaped contract.
+///
+/// Adding a tool is: conform to this protocol, add its sub-feature gate, and register it. Nothing
+/// in the bridge, session or permission layers needs to change.
+@MainActor
+public protocol BrowserTool: AnyObject {
+
+    /// Stable id used in `tools/list` and `tools/call`.
+    var name: String { get }
+
+    /// Short human-readable label. English, not localized — Duck.ai's backend owns the
+    /// model-facing catalog, so these strings only describe the native↔FE contract.
+    var title: String { get }
+
+    /// What the capability does, for the native↔FE contract.
+    var description: String { get }
+
+    /// `auto` never prompts; `ask` is subject to a stored Always/Never decision.
+    var permissionMode: BrowserToolPermissionMode { get }
+
+    var inputSchema: JSONValue { get }
+
+    /// Emitted only when the result shape is known.
+    var outputSchema: JSONValue? { get }
+
+    /// MCP hints; omitted for untrusted page tools.
+    var annotations: MCPToolAnnotations? { get }
+
+    /// Runs the tool.
+    ///
+    /// Callers go through the invoker so gating and consent run first. A tool still re-checks
+    /// anything it owns — notably the Fire boundary — so calling it directly cannot bypass a
+    /// refusal it is responsible for.
+    func execute(arguments: JSONValue?, context: BrowserToolCallContext) async -> BrowserToolResult
+}
+
+public extension BrowserTool {
+    var outputSchema: JSONValue? { nil }
+    var annotations: MCPToolAnnotations? { nil }
+
+    /// This tool's `tools/list` descriptor.
+    ///
+    /// DEBUG builds also advertise the permission mode and current decision so the debug harness
+    /// can show them; release builds keep the wire MCP-clean.
+    /// - Parameter permissionState: the effective stored decision, when the caller knows it.
+    func descriptor(permissionState: String? = nil) -> BrowserToolDescriptor {
+#if DEBUG
+        let permissionDefault: String? = permissionMode.rawValue
+        let permissionCurrent: String? = permissionState
+#else
+        let permissionDefault: String? = nil
+        let permissionCurrent: String? = nil
+#endif
+        return BrowserToolDescriptor(name: name,
+                                     title: title,
+                                     description: description,
+                                     inputSchema: inputSchema,
+                                     outputSchema: outputSchema,
+                                     annotations: annotations,
+                                     permissionDefault: permissionDefault,
+                                     permissionCurrent: permissionCurrent)
+    }
+}
+
+/// A tool's declared default. Distinct from the *stored* decision, which only Ask tools have.
+public enum BrowserToolPermissionMode: String, Equatable, Sendable {
+    case auto
+    case ask
+}
+
+/// Where a call came from. Platform-neutral: a tool that needs a window resolves it from
+/// `ownerTabID` through its own injected dependencies.
+public struct BrowserToolCallContext: Equatable, Sendable {
+
+    /// The Duck.ai owner tab. A sidebar resolves to its host tab, so a sidebar and the tab it is
+    /// docked to share one session and one scope.
+    public let ownerTabID: String
+
+    /// True in a Fire window. Every tool refuses with `unavailable` — never a Fire-specific
+    /// token, so the front end cannot infer that the user is browsing privately.
+    public let isBurner: Bool
+
+    /// From the `initialize` handshake. Ask tools fail with `elicitation_unsupported` when false,
+    /// because there would be no way to obtain consent.
+    public let supportsElicitationForm: Bool
+
+    public init(ownerTabID: String, isBurner: Bool, supportsElicitationForm: Bool) {
+        self.ownerTabID = ownerTabID
+        self.isBurner = isBurner
+        self.supportsElicitationForm = supportsElicitationForm
+    }
+}
+
+/// Outcome of an invocation, before it is mapped onto the MCP `CallToolResult` envelope.
+public enum BrowserToolResult: Equatable, Sendable {
+    case success(JSONValue)
+    case failure(BrowserToolFailure)
+}
+
+/// Remote-config state for the tool catalog: the parent kill switch plus the per-tool gates.
+@MainActor
+public protocol BrowserToolsConfiguration: AnyObject {
+
+    /// The parent feature. When false there are no tools at all, and every call is `unavailable`.
+    var isEnabled: Bool { get }
+
+    /// The tool's own sub-feature, already combined with the parent.
+    func isToolEnabled(named name: String) -> Bool
+}

--- a/SharedPackages/AIChat/Sources/AIChat/Shared/BrowserTools/BrowserToolCatalog.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/BrowserTools/BrowserToolCatalog.swift
@@ -18,10 +18,8 @@
 
 import Foundation
 
-/// The browser tools Duck.ai may discover and invoke, after remote-config gating.
-///
-/// A tool whose sub-feature is off is absent from `tools/list` *and* unresolvable by name, so
-/// calling it anyway reports `unavailable` rather than running.
+/// Tools Duck.ai may discover and invoke, after remote-config gating. A disabled tool is absent
+/// from `tools/list` *and* unresolvable by name, so calling it anyway reports `unavailable`.
 @MainActor
 public final class BrowserToolCatalog {
 

--- a/SharedPackages/AIChat/Sources/AIChat/Shared/BrowserTools/BrowserToolCatalog.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/BrowserTools/BrowserToolCatalog.swift
@@ -1,0 +1,53 @@
+//
+//  BrowserToolCatalog.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+/// The browser tools Duck.ai may discover and invoke, after remote-config gating.
+///
+/// A tool whose sub-feature is off is absent from `tools/list` *and* unresolvable by name, so
+/// calling it anyway reports `unavailable` rather than running.
+@MainActor
+public final class BrowserToolCatalog {
+
+    private let orderedTools: [any BrowserTool]
+    private let toolsByName: [String: any BrowserTool]
+    private let configuration: BrowserToolsConfiguration
+
+    /// - Parameter tools: registration order is the order the front end sees, so it stays stable
+    ///   across launches rather than following dictionary ordering.
+    public init(tools: [any BrowserTool], configuration: BrowserToolsConfiguration) {
+        self.orderedTools = tools
+        self.configuration = configuration
+        self.toolsByName = Dictionary(tools.map { ($0.name, $0) }, uniquingKeysWith: { first, _ in first })
+        assert(tools.count == toolsByName.count, "Browser tool names must be unique")
+    }
+
+    /// Enabled tools, in registration order. Empty when the parent feature is off.
+    public var enabledTools: [any BrowserTool] {
+        guard configuration.isEnabled else { return [] }
+        return orderedTools.filter { configuration.isToolEnabled(named: $0.name) }
+    }
+
+    /// Resolves a tool for invocation. `nil` covers an unknown name and a disabled sub-feature
+    /// alike — both are `unavailable` to the caller.
+    public func tool(named name: String) -> (any BrowserTool)? {
+        guard configuration.isEnabled, let tool = toolsByName[name] else { return nil }
+        return configuration.isToolEnabled(named: name) ? tool : nil
+    }
+}

--- a/SharedPackages/AIChat/Sources/AIChat/Shared/BrowserTools/BrowserToolInvoker.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/BrowserTools/BrowserToolInvoker.swift
@@ -18,10 +18,8 @@
 
 import Foundation
 
-/// The single entry point for running a browser tool.
-///
-/// Everything that can refuse a call lives here and runs in a fixed order, so a tool's `execute`
-/// only has to worry about its own arguments.
+/// The single entry point for running a tool. Every reason a call can be refused lives here, in a
+/// fixed order, so a tool's `execute` only handles its own arguments.
 @MainActor
 public final class BrowserToolInvoker {
 

--- a/SharedPackages/AIChat/Sources/AIChat/Shared/BrowserTools/BrowserToolInvoker.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/BrowserTools/BrowserToolInvoker.swift
@@ -42,15 +42,12 @@ public final class BrowserToolInvoker {
         // the capability is not available here, not which of the two it was.
         guard let tool = catalog.tool(named: name) else { return .failure(.unavailable) }
 
-        // The Fire boundary is checked before any consent evaluation, and reported as plain
-        // `unavailable` rather than a Fire-specific token — so the front end cannot infer that the
-        // user is browsing privately. Once consent exists (PR 2) this ordering also stops a call
-        // that can never succeed in this window from persisting an Always/Never decision.
+        // Reported as plain `unavailable`, never a Fire-specific token, so the front end cannot
+        // infer the user is browsing privately. Checked before consent so a call that can never
+        // succeed here cannot persist a decision.
         guard !context.isBurner else { return .failure(.unavailable) }
 
-        // Consent lands in PR 2. Until then every tool behaves as `auto`, which is why only `auto`
-        // tools are registered in the catalog so far.
-        assert(tool.permissionMode == .auto, "An ask-mode tool must not be registered before consent exists")
+        assert(tool.permissionMode == .auto, "Ask-mode tools need consent, which does not exist yet")
 
         return await tool.execute(arguments: arguments, context: context)
     }

--- a/SharedPackages/AIChat/Sources/AIChat/Shared/BrowserTools/BrowserToolInvoker.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/BrowserTools/BrowserToolInvoker.swift
@@ -1,0 +1,57 @@
+//
+//  BrowserToolInvoker.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+/// The single entry point for running a browser tool.
+///
+/// Everything that can refuse a call lives here and runs in a fixed order, so a tool's `execute`
+/// only has to worry about its own arguments.
+@MainActor
+public final class BrowserToolInvoker {
+
+    private let catalog: BrowserToolCatalog
+    private let configuration: BrowserToolsConfiguration
+
+    public init(catalog: BrowserToolCatalog, configuration: BrowserToolsConfiguration) {
+        self.catalog = catalog
+        self.configuration = configuration
+    }
+
+    public func invoke(toolNamed name: String,
+                       arguments: JSONValue?,
+                       context: BrowserToolCallContext) async -> BrowserToolResult {
+        guard configuration.isEnabled else { return .failure(.unavailable) }
+
+        // Covers an unknown name and a disabled sub-feature alike: the front end learns only that
+        // the capability is not available here, not which of the two it was.
+        guard let tool = catalog.tool(named: name) else { return .failure(.unavailable) }
+
+        // The Fire boundary is checked before any consent evaluation, and reported as plain
+        // `unavailable` rather than a Fire-specific token — so the front end cannot infer that the
+        // user is browsing privately. Once consent exists (PR 2) this ordering also stops a call
+        // that can never succeed in this window from persisting an Always/Never decision.
+        guard !context.isBurner else { return .failure(.unavailable) }
+
+        // Consent lands in PR 2. Until then every tool behaves as `auto`, which is why only `auto`
+        // tools are registered in the catalog so far.
+        assert(tool.permissionMode == .auto, "An ask-mode tool must not be registered before consent exists")
+
+        return await tool.execute(arguments: arguments, context: context)
+    }
+}

--- a/SharedPackages/AIChat/Sources/AIChat/Shared/BrowserTools/BrowserToolInvoker.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/BrowserTools/BrowserToolInvoker.swift
@@ -42,9 +42,8 @@ public final class BrowserToolInvoker {
         // the capability is not available here, not which of the two it was.
         guard let tool = catalog.tool(named: name) else { return .failure(.unavailable) }
 
-        // Reported as plain `unavailable`, never a Fire-specific token, so the front end cannot
-        // infer the user is browsing privately. Checked before consent so a call that can never
-        // succeed here cannot persist a decision.
+        // Reported as plain `unavailable`, never a Fire-specific token. Checked before consent so a
+        // call that can never succeed here cannot persist a decision.
         guard !context.isBurner else { return .failure(.unavailable) }
 
         assert(tool.permissionMode == .auto, "Ask-mode tools need consent, which does not exist yet")

--- a/SharedPackages/AIChat/Sources/AIChat/Shared/BrowserTools/BrowserToolsWireTypes.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/BrowserTools/BrowserToolsWireTypes.swift
@@ -1,0 +1,300 @@
+//
+//  BrowserToolsWireTypes.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+/// The MCP-shaped contract Duck.ai uses to discover and invoke browser capabilities.
+///
+/// The vocabulary and payloads are MCP; the framing is the existing Duck.ai ↔ native message
+/// bridge. There is no JSON-RPC endpoint and no MCP server. These shapes match the Windows
+/// browser byte for byte so the Duck.ai front end can treat the platforms uniformly.
+public enum MCPProtocol {
+
+    /// Negotiated on `initialize`. Native always answers with its own version, never an echo.
+    public static let version = "2025-11-25"
+
+    /// How long a mid-call permission prompt may stay unanswered before the call completes
+    /// as `cancelled`.
+    public static let elicitationTimeout: TimeInterval = 120
+}
+
+// MARK: - Session
+
+/// FE → native `initialize`.
+///
+/// Deliberately tolerant: a partial or malformed payload still yields a request so native can
+/// answer, because a silent drop would hang the front end's pending promise. Anything it could
+/// not understand simply reads as "capability not supported".
+public struct MCPInitializeRequest: Decodable, Equatable {
+    public let protocolVersion: String?
+    public let capabilities: MCPClientCapabilities?
+    public let clientInfo: MCPImplementationInfo?
+
+    /// True when the FE declared `capabilities.elicitation.form` as an object. Ask-mode tools
+    /// fail with `elicitation_unsupported` when this is false.
+    public var supportsElicitationForm: Bool {
+        capabilities?.elicitation?.form != nil
+    }
+}
+
+public struct MCPClientCapabilities: Decodable, Equatable {
+    public let elicitation: MCPElicitationClientCapability?
+
+    private enum CodingKeys: String, CodingKey { case elicitation }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        // A capability we cannot parse means "unsupported", never a failed handshake.
+        let decoded: MCPElicitationClientCapability? = try? container.decodeIfPresent(MCPElicitationClientCapability.self,
+                                                                                      forKey: .elicitation)
+        elicitation = decoded
+    }
+}
+
+public struct MCPElicitationClientCapability: Decodable, Equatable {
+    /// Presence of an *object* is the signal; its contents are never read. `"form": true` does
+    /// not declare support.
+    public let form: JSONValue?
+
+    private enum CodingKeys: String, CodingKey { case form }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let decoded: JSONValue? = try? container.decodeIfPresent(JSONValue.self, forKey: .form)
+        form = decoded?.objectValue == nil ? nil : decoded
+    }
+}
+
+/// native → FE `initialize` result.
+public struct MCPInitializeResult: Encodable, Equatable {
+    public let protocolVersion: String
+    public let capabilities: MCPServerCapabilities
+    public let serverInfo: MCPImplementationInfo
+
+    public init(serverName: String, serverVersion: String?) {
+        self.protocolVersion = MCPProtocol.version
+        self.capabilities = MCPServerCapabilities(tools: MCPToolsServerCapability(listChanged: true))
+        self.serverInfo = MCPImplementationInfo(name: serverName, version: serverVersion)
+    }
+}
+
+public struct MCPServerCapabilities: Encodable, Equatable {
+    public let tools: MCPToolsServerCapability
+}
+
+public struct MCPToolsServerCapability: Encodable, Equatable {
+    public let listChanged: Bool
+}
+
+public struct MCPImplementationInfo: Codable, Equatable {
+    public let name: String
+    public let version: String?
+
+    public init(name: String, version: String? = nil) {
+        self.name = name
+        self.version = version
+    }
+}
+
+/// Reply body for messages whose MCP result is an empty object.
+public struct MCPEmptyResult: Encodable, Equatable {
+    public init() {}
+}
+
+// MARK: - Discovery
+
+/// One MCP tool descriptor, emitted verbatim in `tools/list`.
+public struct BrowserToolDescriptor: Encodable, Equatable {
+    public let name: String
+    public let title: String
+    public let description: String
+    public let inputSchema: JSONValue
+    public let outputSchema: JSONValue?
+    public let annotations: MCPToolAnnotations?
+
+    /// DEBUG harness only — the tool's declared mode (`auto`/`ask`). Absent from release builds
+    /// so the wire stays MCP-clean.
+    public let permissionDefault: String?
+
+    /// DEBUG harness only — the effective state (`allow`/`deny`/`ask`).
+    public let permissionCurrent: String?
+
+    public init(name: String,
+                title: String,
+                description: String,
+                inputSchema: JSONValue,
+                outputSchema: JSONValue? = nil,
+                annotations: MCPToolAnnotations? = nil,
+                permissionDefault: String? = nil,
+                permissionCurrent: String? = nil) {
+        self.name = name
+        self.title = title
+        self.description = description
+        self.inputSchema = inputSchema
+        self.outputSchema = outputSchema
+        self.annotations = annotations
+        self.permissionDefault = permissionDefault
+        self.permissionCurrent = permissionCurrent
+    }
+}
+
+/// MCP ToolAnnotations. All four hints are always written.
+public struct MCPToolAnnotations: Codable, Equatable, Sendable {
+    public let readOnlyHint: Bool
+    public let destructiveHint: Bool
+    public let idempotentHint: Bool
+    public let openWorldHint: Bool
+
+    public init(readOnlyHint: Bool, destructiveHint: Bool, idempotentHint: Bool, openWorldHint: Bool) {
+        self.readOnlyHint = readOnlyHint
+        self.destructiveHint = destructiveHint
+        self.idempotentHint = idempotentHint
+        self.openWorldHint = openWorldHint
+    }
+}
+
+/// Reply body for `tools/list`.
+///
+/// Note the asymmetry with `tools/call`: a listing failure is a top-level `error` token, whereas
+/// an invocation failure rides inside the MCP `CallToolResult`.
+public struct BrowserToolsListResponse: Encodable, Equatable {
+    public let tools: [BrowserToolDescriptor]
+    public let error: String?
+
+    public init(tools: [BrowserToolDescriptor]) {
+        self.tools = tools
+        self.error = nil
+    }
+
+    public init(failure: BrowserToolFailure) {
+        self.tools = []
+        self.error = failure.rawValue
+    }
+}
+
+// MARK: - Invocation
+
+/// FE → native `tools/call`.
+public struct InvokeBrowserToolRequest: Decodable, Equatable {
+    public let name: String
+    public let callId: String
+    public let arguments: JSONValue?
+}
+
+/// native → FE reply to `tools/call`.
+///
+/// `status` reports the round trip only and is therefore always `ok` — a tool that refused or
+/// failed says so through `result.isError`, never through a transport error.
+public struct InvokeBrowserToolResponse: Encodable, Equatable {
+    public let callId: String
+    public let status: String
+    public let result: MCPCallToolResult
+
+    public init(callId: String, result: MCPCallToolResult) {
+        self.callId = callId
+        self.status = "ok"
+        self.result = result
+    }
+}
+
+/// MCP CallToolResult.
+public struct MCPCallToolResult: Encodable, Equatable {
+    public let content: [MCPTextContentBlock]
+    public let isError: Bool
+    public let structuredContent: JSONValue?
+
+    /// The structured payload is also serialised into a single text block, mirroring Windows, so
+    /// a client that only reads `content` still sees the whole result.
+    public static func success(_ structuredContent: JSONValue) -> MCPCallToolResult {
+        MCPCallToolResult(content: [MCPTextContentBlock(text: structuredContent.jsonStringRepresentation)],
+                          isError: false,
+                          structuredContent: structuredContent)
+    }
+
+    /// The failure token is the text content, and `structuredContent` is omitted. Unknown tokens
+    /// are treated by the FE as a generic failure.
+    public static func failure(_ failure: BrowserToolFailure) -> MCPCallToolResult {
+        MCPCallToolResult(content: [MCPTextContentBlock(text: failure.rawValue)],
+                          isError: true,
+                          structuredContent: nil)
+    }
+}
+
+/// MCP text content block — the only block type browser tools emit.
+public struct MCPTextContentBlock: Encodable, Equatable {
+    public let type: String
+    public let text: String
+
+    public init(text: String) {
+        self.type = "text"
+        self.text = text
+    }
+}
+
+// MARK: - Failures
+
+/// Stable failure tokens the front end may branch on.
+public enum BrowserToolFailure: String, Equatable, Sendable, CaseIterable {
+
+    /// Arguments did not satisfy the tool's input schema.
+    case invalidArguments = "invalid_arguments"
+
+    /// The referenced target existed as an identifier but could not be resolved — e.g. a tab id
+    /// that names no open tab, or one in another window.
+    case notFound = "not_found"
+
+    /// The capability is not available here: the feature or the tool's sub-feature is off, the
+    /// tool is unknown, or the call crosses the Fire boundary. Deliberately indistinguishable so
+    /// the front end learns nothing about Fire windows.
+    case unavailable
+
+    /// The user refused, now or by a stored decision.
+    case denied
+
+    /// The permission prompt was dismissed, timed out, or could not be delivered.
+    case cancelled
+
+    /// An Ask-mode tool was called but the session never declared `elicitation.form`.
+    case elicitationUnsupported = "elicitation_unsupported"
+
+    /// The permission prompt was accepted with a choice native does not recognise.
+    case invalidPermissionChoice = "invalid_permission_choice"
+
+    /// Tools traffic arrived before the MCP handshake completed.
+    case notInitialized = "not_initialized"
+
+    /// The `tools/call` payload could not be read at all.
+    case invalidRequest = "invalid_request"
+}
+
+// MARK: -
+
+extension JSONValue {
+
+    /// Serialised form used for the text duplicate of a structured result. Keys are sorted so the
+    /// output is stable across runs — Swift dictionaries have no inherent ordering.
+    var jsonStringRepresentation: String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+        guard let data = try? encoder.encode(self), let string = String(data: data, encoding: .utf8) else {
+            assertionFailure("Could not serialise a JSONValue")
+            return "null"
+        }
+        return string
+    }
+}

--- a/SharedPackages/AIChat/Sources/AIChat/Shared/BrowserTools/BrowserToolsWireTypes.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/BrowserTools/BrowserToolsWireTypes.swift
@@ -235,6 +235,18 @@ public struct MCPCallToolResult: Encodable, Equatable {
     }
 }
 
+public extension BrowserToolResult {
+
+    /// Maps an invocation outcome onto the MCP envelope the front end receives. A refusal is not a
+    /// transport error, so both cases produce a well-formed result.
+    var callToolResult: MCPCallToolResult {
+        switch self {
+        case .success(let structuredContent): .success(structuredContent)
+        case .failure(let failure): .failure(failure)
+        }
+    }
+}
+
 /// MCP text content block — the only block type browser tools emit.
 public struct MCPTextContentBlock: Encodable, Equatable {
     public let type: String

--- a/SharedPackages/AIChat/Sources/AIChat/Shared/BrowserTools/BrowserToolsWireTypes.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/BrowserTools/BrowserToolsWireTypes.swift
@@ -18,11 +18,8 @@
 
 import Foundation
 
-/// The MCP-shaped contract Duck.ai uses to discover and invoke browser capabilities.
-///
-/// The vocabulary and payloads are MCP; the framing is the existing Duck.ai ↔ native message
-/// bridge. There is no JSON-RPC endpoint and no MCP server. These shapes match the Windows
-/// browser byte for byte so the Duck.ai front end can treat the platforms uniformly.
+/// MCP vocabulary and payloads over the existing Duck.ai ↔ native bridge — no JSON-RPC endpoint,
+/// no MCP server. Shapes match the Windows browser so one front end drives both platforms.
 public enum MCPProtocol {
 
     /// Negotiated on `initialize`. Native always answers with its own version, never an echo.
@@ -35,11 +32,8 @@ public enum MCPProtocol {
 
 // MARK: - Session
 
-/// FE → native `initialize`.
-///
-/// Deliberately tolerant: a partial or malformed payload still yields a request so native can
-/// answer, because a silent drop would hang the front end's pending promise. Anything it could
-/// not understand simply reads as "capability not supported".
+/// Tolerant by design: a malformed payload still yields a request so native can answer, because
+/// the bridge has no timeout and silence would hang the caller. What it can't read means "no".
 public struct MCPInitializeRequest: Decodable, Equatable {
     public let protocolVersion: String?
     public let capabilities: MCPClientCapabilities?
@@ -80,7 +74,6 @@ public struct MCPElicitationClientCapability: Decodable, Equatable {
     }
 }
 
-/// native → FE `initialize` result.
 public struct MCPInitializeResult: Encodable, Equatable {
     public let protocolVersion: String
     public let capabilities: MCPServerCapabilities
@@ -111,7 +104,6 @@ public struct MCPImplementationInfo: Codable, Equatable {
     }
 }
 
-/// Reply body for messages whose MCP result is an empty object.
 public struct MCPEmptyResult: Encodable, Equatable {
     public init() {}
 }
@@ -168,10 +160,8 @@ public struct MCPToolAnnotations: Codable, Equatable, Sendable {
     }
 }
 
-/// Reply body for `tools/list`.
-///
-/// Note the asymmetry with `tools/call`: a listing failure is a top-level `error` token, whereas
-/// an invocation failure rides inside the MCP `CallToolResult`.
+/// Reply body for `tools/list`. Note the asymmetry with `tools/call`: a listing failure is a
+/// top-level `error` token, an invocation failure rides inside the MCP result.
 public struct BrowserToolsListResponse: Encodable, Equatable {
     public let tools: [BrowserToolDescriptor]
     public let error: String?
@@ -189,17 +179,14 @@ public struct BrowserToolsListResponse: Encodable, Equatable {
 
 // MARK: - Invocation
 
-/// FE → native `tools/call`.
 public struct InvokeBrowserToolRequest: Decodable, Equatable {
     public let name: String
     public let callId: String
     public let arguments: JSONValue?
 }
 
-/// native → FE reply to `tools/call`.
-///
-/// `status` reports the round trip only and is therefore always `ok` — a tool that refused or
-/// failed says so through `result.isError`, never through a transport error.
+/// `status` reports the round trip only, so it is always `ok` — a tool that refused says so
+/// through `result.isError`, never through a transport error.
 public struct InvokeBrowserToolResponse: Encodable, Equatable {
     public let callId: String
     public let status: String
@@ -212,7 +199,6 @@ public struct InvokeBrowserToolResponse: Encodable, Equatable {
     }
 }
 
-/// MCP CallToolResult.
 public struct MCPCallToolResult: Encodable, Equatable {
     public let content: [MCPTextContentBlock]
     public let isError: Bool
@@ -270,9 +256,7 @@ public enum BrowserToolFailure: String, Equatable, Sendable, CaseIterable {
     /// that names no open tab, or one in another window.
     case notFound = "not_found"
 
-    /// The capability is not available here: the feature or the tool's sub-feature is off, the
-    /// tool is unknown, or the call crosses the Fire boundary. Deliberately indistinguishable so
-    /// the front end learns nothing about Fire windows.
+    /// Feature or sub-feature off, tool unknown, or a Fire window — deliberately indistinguishable.
     case unavailable
 
     /// The user refused, now or by a stored decision.

--- a/SharedPackages/AIChat/Sources/AIChat/Shared/BrowserTools/JSONValue.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/BrowserTools/JSONValue.swift
@@ -1,0 +1,186 @@
+//
+//  JSONValue.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+
+/// A concrete JSON value, used where the MCP wire carries free-form JSON: tool input/output
+/// schemas, tool arguments, and structured tool results.
+///
+/// Tools declare their schemas with Swift literals rather than parsing JSON strings, so a
+/// malformed schema is a compile error instead of a runtime surprise:
+///
+/// ```swift
+/// static let inputSchema: JSONValue = [
+///     "type": "object",
+///     "properties": ["limit": ["type": "integer", "minimum": 1, "maximum": 50]]
+/// ]
+/// ```
+public enum JSONValue: Codable, Equatable, Sendable {
+    case null
+    case bool(Bool)
+    case int(Int)
+    case double(Double)
+    case string(String)
+    case array([JSONValue])
+    case object([String: JSONValue])
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+
+        if container.decodeNil() {
+            self = .null
+        } else if let value = try? container.decode(Bool.self) {
+            self = .bool(value)
+        } else if let value = try? container.decode(Int.self) {
+            self = .int(value)
+        } else if let value = try? container.decode(Double.self) {
+            self = .double(value)
+        } else if let value = try? container.decode(String.self) {
+            self = .string(value)
+        } else if let value = try? container.decode([JSONValue].self) {
+            self = .array(value)
+        } else if let value = try? container.decode([String: JSONValue].self) {
+            self = .object(value)
+        } else {
+            throw DecodingError.dataCorruptedError(in: container, debugDescription: "Unsupported JSON value")
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+
+        switch self {
+        case .null: try container.encodeNil()
+        case .bool(let value): try container.encode(value)
+        case .int(let value): try container.encode(value)
+        case .double(let value): try container.encode(value)
+        case .string(let value): try container.encode(value)
+        case .array(let value): try container.encode(value)
+        case .object(let value): try container.encode(value)
+        }
+    }
+}
+
+// MARK: - Reading
+
+public extension JSONValue {
+
+    var objectValue: [String: JSONValue]? {
+        guard case .object(let value) = self else { return nil }
+        return value
+    }
+
+    var arrayValue: [JSONValue]? {
+        guard case .array(let value) = self else { return nil }
+        return value
+    }
+
+    var stringValue: String? {
+        guard case .string(let value) = self else { return nil }
+        return value
+    }
+
+    var boolValue: Bool? {
+        guard case .bool(let value) = self else { return nil }
+        return value
+    }
+
+    /// Integers only — a JSON `1.5` is not silently truncated, so a tool can reject it as an
+    /// invalid argument rather than acting on a rounded value.
+    var intValue: Int? {
+        guard case .int(let value) = self else { return nil }
+        return value
+    }
+
+    subscript(key: String) -> JSONValue? {
+        objectValue?[key]
+    }
+}
+
+// MARK: - Literals
+
+// Deliberately not `ExpressibleByNilLiteral`: it would make `nil` mean JSON null, so an
+// ordinary `optionalValue ?? nil` would quietly produce `.null` instead of staying absent.
+// Write `.null` where a JSON null is actually intended.
+
+extension JSONValue: ExpressibleByBooleanLiteral {
+    public init(booleanLiteral value: Bool) { self = .bool(value) }
+}
+
+extension JSONValue: ExpressibleByIntegerLiteral {
+    public init(integerLiteral value: Int) { self = .int(value) }
+}
+
+extension JSONValue: ExpressibleByFloatLiteral {
+    public init(floatLiteral value: Double) { self = .double(value) }
+}
+
+extension JSONValue: ExpressibleByStringLiteral {
+    public init(stringLiteral value: String) { self = .string(value) }
+}
+
+extension JSONValue: ExpressibleByArrayLiteral {
+    public init(arrayLiteral elements: JSONValue...) { self = .array(elements) }
+}
+
+extension JSONValue: ExpressibleByDictionaryLiteral {
+    public init(dictionaryLiteral elements: (String, JSONValue)...) {
+        self = .object(Dictionary(elements, uniquingKeysWith: { _, last in last }))
+    }
+}
+
+// MARK: - Bridging
+
+public extension JSONValue {
+
+    /// Builds a value from the `[String: Any]` the user-script bridge hands to a message handler.
+    /// Returns `nil` for anything JSON cannot represent.
+    init?(bridgeValue: Any) {
+        switch bridgeValue {
+        case is NSNull:
+            self = .null
+        case let value as String:
+            self = .string(value)
+        case let number as NSNumber:
+            // Bool, Int and Double all bridge to NSNumber, and only the CFTypeID separates a
+            // boolean from a numeric 0/1. JS has no integer type, so a whole double becomes an
+            // Int here — that is what lets a tool validate `limit: 50` as an integer argument.
+            if CFGetTypeID(number) == CFBooleanGetTypeID() {
+                self = .bool(number.boolValue)
+            } else if let int = Int(exactly: number.doubleValue) {
+                self = .int(int)
+            } else {
+                self = .double(number.doubleValue)
+            }
+        case let value as [Any]:
+            self = .array(value.compactMap { JSONValue(bridgeValue: $0) })
+        case let value as [String: Any]:
+            self = .object(value.compactMapValues { JSONValue(bridgeValue: $0) })
+        default:
+            return nil
+        }
+    }
+
+    /// Parses a JSON document. Used by tests and golden-JSON comparisons; tools use literals.
+    init(jsonString: String) throws {
+        guard let data = jsonString.data(using: .utf8) else {
+            throw DecodingError.dataCorrupted(.init(codingPath: [], debugDescription: "Not UTF-8"))
+        }
+        self = try JSONDecoder().decode(JSONValue.self, from: data)
+    }
+}

--- a/SharedPackages/AIChat/Sources/AIChat/Shared/BrowserTools/JSONValue.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/BrowserTools/JSONValue.swift
@@ -18,18 +18,8 @@
 
 import Foundation
 
-/// A concrete JSON value, used where the MCP wire carries free-form JSON: tool input/output
-/// schemas, tool arguments, and structured tool results.
-///
-/// Tools declare their schemas with Swift literals rather than parsing JSON strings, so a
-/// malformed schema is a compile error instead of a runtime surprise:
-///
-/// ```swift
-/// static let inputSchema: JSONValue = [
-///     "type": "object",
-///     "properties": ["limit": ["type": "integer", "minimum": 1, "maximum": 50]]
-/// ]
-/// ```
+/// Free-form JSON on the MCP wire: schemas, tool arguments, structured results. Tools declare
+/// schemas as Swift literals, so a malformed one is a compile error rather than a runtime surprise.
 public enum JSONValue: Codable, Equatable, Sendable {
     case null
     case bool(Bool)
@@ -114,9 +104,8 @@ public extension JSONValue {
 
 // MARK: - Literals
 
-// Deliberately not `ExpressibleByNilLiteral`: it would make `nil` mean JSON null, so an
-// ordinary `optionalValue ?? nil` would quietly produce `.null` instead of staying absent.
-// Write `.null` where a JSON null is actually intended.
+// Deliberately not `ExpressibleByNilLiteral`: it would make `optionalValue ?? nil` quietly
+// produce `.null` instead of staying absent. Write `.null` where a JSON null is intended.
 
 extension JSONValue: ExpressibleByBooleanLiteral {
     public init(booleanLiteral value: Bool) { self = .bool(value) }
@@ -157,9 +146,8 @@ public extension JSONValue {
         case let value as String:
             self = .string(value)
         case let number as NSNumber:
-            // Bool, Int and Double all bridge to NSNumber, and only the CFTypeID separates a
-            // boolean from a numeric 0/1. JS has no integer type, so a whole double becomes an
-            // Int here — that is what lets a tool validate `limit: 50` as an integer argument.
+            // Only the CFTypeID separates a bool from a numeric 0/1. JS has no integer type, so a
+            // whole double becomes an Int — which is what lets a tool validate `limit: 50`.
             if CFGetTypeID(number) == CFBooleanGetTypeID() {
                 self = .bool(number.boolValue)
             } else if let int = Int(exactly: number.doubleValue) {

--- a/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/ContentScopeScript/ContentScopePrivacyConfigurationJSONGenerator.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/ContentScopeScript/ContentScopePrivacyConfigurationJSONGenerator.swift
@@ -31,12 +31,16 @@ public struct ContentScopePrivacyConfigurationJSONGenerator: CustomisedPrivacyCo
     let privacyConfigurationManager: PrivacyConfigurationManaging
     let excludedFeatures: [String]
 
+    /// Features every caller keeps out of the injected configuration. Exposed so a caller that
+    /// needs to exclude more can extend this rather than restate it and drift.
+    public static let defaultExcludedFeatures = [
+        PrivacyConfigurationData.CodingKeys.trackerAllowlist.rawValue,
+        PrivacyFeature.autoconsent.rawValue
+    ]
+
     public init(featureFlagger: FeatureFlagger,
                 privacyConfigurationManager: PrivacyConfigurationManaging,
-                excludedFeatures: [String] = [
-                    PrivacyConfigurationData.CodingKeys.trackerAllowlist.rawValue,
-                    PrivacyFeature.autoconsent.rawValue
-                ]) {
+                excludedFeatures: [String] = Self.defaultExcludedFeatures) {
         self.featureFlagger = featureFlagger
         self.privacyConfigurationManager = privacyConfigurationManager
         self.excludedFeatures = excludedFeatures

--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -522,11 +522,8 @@ public enum AIChatSubfeature: String, Equatable, PrivacySubfeature {
     case usageWarnings
 }
 
-/// Native browser capabilities Duck.ai can discover and invoke over the MCP-shaped contract.
-///
-/// The parent feature is the kill switch: with it off there are no tools at all. Each tool then
-/// has its own gate, so one can be withdrawn without touching the rest — a disabled tool is
-/// absent from `tools/list` and reports `unavailable` if called anyway.
+/// Native capabilities Duck.ai can discover and invoke. The parent is the kill switch; each tool
+/// also has its own gate, so one can be withdrawn without touching the rest.
 public enum AIChatBrowserToolsSubfeature: String, Equatable, PrivacySubfeature {
     public var parent: PrivacyFeature {
         .aiChatBrowserTools

--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -89,6 +89,7 @@ public enum PrivacyFeature: String {
     case promoQueue
     case adBlockingExtension
     case eventHub
+    case aiChatBrowserTools
 }
 
 /// An abstraction to be implemented by any "subfeature" of a given `PrivacyConfiguration` feature.
@@ -519,6 +520,38 @@ public enum AIChatSubfeature: String, Equatable, PrivacySubfeature {
     /// Warns users as they approach their daily/weekly Duck.ai limits, using the usage snapshot the
     /// web app writes into the reserved `usageLimits` native-storage entry.
     case usageWarnings
+}
+
+/// Native browser capabilities Duck.ai can discover and invoke over the MCP-shaped contract.
+///
+/// The parent feature is the kill switch: with it off there are no tools at all. Each tool then
+/// has its own gate, so one can be withdrawn without touching the rest — a disabled tool is
+/// absent from `tools/list` and reports `unavailable` if called anyway.
+public enum AIChatBrowserToolsSubfeature: String, Equatable, PrivacySubfeature {
+    public var parent: PrivacyFeature {
+        .aiChatBrowserTools
+    }
+
+    /// Kill switch for the whole browser-tools bridge.
+    case featureEnabled
+
+    /// Lists the open tabs of the owner tab's window (title and URL only).
+    case listOpenTabs
+
+    /// Searches local browsing history.
+    case searchHistory
+
+    /// Switches to an open tab in the owner tab's window.
+    case switchToTab
+
+    /// Reads the text content of an open tab.
+    case readTabContent
+
+    /// Finds text on a page and reports match counts and snippets.
+    case findInPage
+
+    /// Paints previously-found matches on a page.
+    case highlightInPage
 }
 
 public enum HtmlNewTabPageSubfeature: String, Equatable, PrivacySubfeature {

--- a/SharedPackages/BrowserServicesKit/Sources/UserScript/UserScriptMessagingSchema.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/UserScript/UserScriptMessagingSchema.swift
@@ -148,10 +148,8 @@ public struct SubscriptionEvent {
             return nil
         }
 
-        // Subscription names are not always valid JS identifiers — MCP-style names such as
-        // `elicitation/create` are legal — so the handler is looked up by string key. Dot notation
-        // parses `a/b` as a division and throws at runtime, and `push` evaluates this without a
-        // completion handler, so that failure would be silent.
+        // Looked up by string key because a name like `elicitation/create` is legal here: dot
+        // notation would parse `a/b` as division and throw, silently, since nothing checks it.
         let name = jsStringLiteral(res.subscriptionName)
         let warnStatement = debug ? "console.warn(\"missing \" + \(name), \(json))" : ""
 

--- a/SharedPackages/BrowserServicesKit/Sources/UserScript/UserScriptMessagingSchema.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/UserScript/UserScriptMessagingSchema.swift
@@ -148,17 +148,33 @@ public struct SubscriptionEvent {
             return nil
         }
 
-        let warnStatement = debug ? "console.warn(\"missing '\(res.subscriptionName)'\", \(json))" : ""
+        // Subscription names are not always valid JS identifiers — MCP-style names such as
+        // `elicitation/create` are legal — so the handler is looked up by string key. Dot notation
+        // parses `a/b` as a division and throws at runtime, and `push` evaluates this without a
+        // completion handler, so that failure would be silent.
+        let name = jsStringLiteral(res.subscriptionName)
+        let warnStatement = debug ? "console.warn(\"missing \" + \(name), \(json))" : ""
 
         return """
            (() => {
-              if (!('\(res.subscriptionName)' in (navigator?.duckduckgo?.messageHandlers ?? {}))) {
+              if (!(\(name) in (navigator?.duckduckgo?.messageHandlers ?? {}))) {
                  \(warnStatement)
               } else {
-                  navigator?.duckduckgo?.messageHandlers?.\(res.subscriptionName)?.(\(json));
+                  navigator?.duckduckgo?.messageHandlers?.[\(name)]?.(\(json));
               }
            })();
            """
+    }
+
+    /// Renders `value` as a JS string literal, escaped so any character is safe to embed.
+    private static func jsStringLiteral(_ value: String) -> String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .withoutEscapingSlashes
+        guard let data = try? encoder.encode(value), let literal = String(data: data, encoding: .utf8) else {
+            assertionFailure("Could not encode subscription name as a JS string literal")
+            return "\"\""
+        }
+        return literal
     }
 }
 

--- a/SharedPackages/BrowserServicesKit/Tests/UserScriptTests/UserScriptMessagingTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/UserScriptTests/UserScriptMessagingTests.swift
@@ -19,6 +19,7 @@
 import Foundation
 import XCTest
 import WebKit
+import JavaScriptCore
 import BrowserServicesKitTestsUtils
 @testable import UserScript
 
@@ -303,5 +304,94 @@ struct TestDelegate: Subfeature {
     func responseExample(params: Any, original: WKScriptMessage) async throws -> Encodable? {
         let person = Person(name: "Kittie")
         return person
+    }
+}
+
+/// `SubscriptionEvent.toJS` has to cope with subscription names that are not valid JS
+/// identifiers — MCP uses names like `elicitation/create` and `notifications/tools/list_changed`.
+/// These tests execute the generated JS rather than asserting on its shape, because the failure
+/// mode being guarded against is a runtime `ReferenceError`, not a malformed string.
+final class SubscriptionEventToJSTests: XCTestCase {
+
+    func testWhenSubscriptionNameIsAPlainIdentifierThenTheHandlerIsCalled() throws {
+        let result = try evaluate(subscriptionName: "submitAIChatPageContext")
+
+        XCTAssertTrue(result.handlerWasCalled)
+        XCTAssertNil(result.exception)
+    }
+
+    func testWhenSubscriptionNameContainsSlashesThenTheHandlerIsStillCalled() throws {
+        for name in ["elicitation/create", "notifications/tools/list_changed"] {
+            let result = try evaluate(subscriptionName: name)
+
+            XCTAssertTrue(result.handlerWasCalled, "expected \(name) to reach its handler")
+            XCTAssertNil(result.exception, "expected \(name) to evaluate without throwing")
+        }
+    }
+
+    func testWhenSubscriptionNameContainsQuotesOrBackslashesThenItIsEscaped() throws {
+        let result = try evaluate(subscriptionName: #"od"d\name"#)
+
+        XCTAssertTrue(result.handlerWasCalled)
+        XCTAssertNil(result.exception)
+    }
+
+    func testWhenHandlerIsNotSubscribedThenNothingIsCalledAndNothingThrows() throws {
+        let result = try evaluate(subscriptionName: "elicitation/create", subscribe: false)
+
+        XCTAssertFalse(result.handlerWasCalled)
+        XCTAssertNil(result.exception)
+    }
+
+    /// The handler receives the whole `SubscriptionEvent`, not just its `params` — so a
+    /// correlation id carried at `params.id` is read by the page as `envelope.params.id`.
+    func testWhenEventIsPushedThenTheHandlerReceivesTheWholeEnvelope() throws {
+        let result = try evaluate(subscriptionName: "elicitation/create")
+
+        XCTAssertEqual(result.receivedEnvelope?["subscriptionName"] as? String, "elicitation/create")
+        XCTAssertEqual(result.receivedEnvelope?["featureName"] as? String, "aiChat")
+        XCTAssertEqual(result.receivedEnvelope?["context"] as? String, "contentScopeScripts")
+        let params = result.receivedEnvelope?["params"] as? [String: Any]
+        XCTAssertEqual(params?["mode"] as? String, "form")
+    }
+
+    // MARK: -
+
+    private struct EvaluationResult {
+        let handlerWasCalled: Bool
+        let receivedEnvelope: [String: Any]?
+        let exception: String?
+    }
+
+    /// Builds a stub `navigator.duckduckgo.messageHandlers`, evaluates the generated JS against it,
+    /// and reports whether the subscription's handler was reached.
+    private func evaluate(subscriptionName: String, subscribe: Bool = true) throws -> EvaluationResult {
+        let context = try XCTUnwrap(JSContext())
+        var exception: String?
+        context.exceptionHandler = { _, value in exception = value?.toString() }
+
+        context.evaluateScript("var handlerWasCalled = false; var receivedEnvelope = null;")
+        context.evaluateScript("var navigator = { duckduckgo: { messageHandlers: {} } };")
+        if subscribe {
+            context.setObject(subscriptionName, forKeyedSubscript: "handlerName" as NSString)
+            context.evaluateScript("""
+                navigator.duckduckgo.messageHandlers[handlerName] = function (event) {
+                    handlerWasCalled = true;
+                    receivedEnvelope = event;
+                };
+                """)
+        }
+
+        let js = try XCTUnwrap(SubscriptionEvent.toJS(context: "contentScopeScripts",
+                                                      featureName: "aiChat",
+                                                      subscriptionName: subscriptionName,
+                                                      params: ["mode": "form"]))
+        context.evaluateScript(js)
+
+        return EvaluationResult(
+            handlerWasCalled: context.objectForKeyedSubscript("handlerWasCalled")?.toBool() ?? false,
+            receivedEnvelope: context.objectForKeyedSubscript("receivedEnvelope")?.toDictionary() as? [String: Any],
+            exception: exception
+        )
     }
 }

--- a/SharedPackages/BrowserServicesKit/Tests/UserScriptTests/UserScriptMessagingTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/UserScriptTests/UserScriptMessagingTests.swift
@@ -307,10 +307,8 @@ struct TestDelegate: Subfeature {
     }
 }
 
-/// `SubscriptionEvent.toJS` has to cope with subscription names that are not valid JS
-/// identifiers — MCP uses names like `elicitation/create` and `notifications/tools/list_changed`.
-/// These tests execute the generated JS rather than asserting on its shape, because the failure
-/// mode being guarded against is a runtime `ReferenceError`, not a malformed string.
+/// Subscription names are not always valid JS identifiers. These execute the generated JS rather
+/// than asserting on its shape, because the failure guarded against is a runtime `ReferenceError`.
 final class SubscriptionEventToJSTests: XCTestCase {
 
     func testWhenSubscriptionNameIsAPlainIdentifierThenTheHandlerIsCalled() throws {

--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
@@ -1314,6 +1314,8 @@
 		AB1E70020000000000000002 /* AIChatMCPSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1E70020000000000000001 /* AIChatMCPSessionTests.swift */; };
 		AB1E70020000000000000003 /* AIChatMCPSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1E70020000000000000001 /* AIChatMCPSessionTests.swift */; };
 		AB1E70020000000000000005 /* BrowserToolCatalogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1E70020000000000000004 /* BrowserToolCatalogTests.swift */; };
+		AB1E70040000000000000002 /* BrowserToolInvokerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1E70040000000000000001 /* BrowserToolInvokerTests.swift */; };
+		AB1E70040000000000000003 /* BrowserToolInvokerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1E70040000000000000001 /* BrowserToolInvokerTests.swift */; };
 		AB1E70020000000000000006 /* BrowserToolCatalogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1E70020000000000000004 /* BrowserToolCatalogTests.swift */; };
 		AB1E70020000000000000008 /* BrowserToolsWireFormatTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1E70020000000000000007 /* BrowserToolsWireFormatTests.swift */; };
 		AB1E70020000000000000009 /* BrowserToolsWireFormatTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1E70020000000000000007 /* BrowserToolsWireFormatTests.swift */; };
@@ -4378,6 +4380,10 @@
 		D1A7B0010000000000000003 /* NewTabPageOmnibarTabsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A7B0010000000000000001 /* NewTabPageOmnibarTabsProvider.swift */; };
 		D1A7B0010000000000000012 /* AIChatTabPickerSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A7B0010000000000000011 /* AIChatTabPickerSource.swift */; };
 		AB1E70010000000000000003 /* AIChatBrowserToolsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1E70010000000000000002 /* AIChatBrowserToolsService.swift */; };
+		AB1E70030000000000000002 /* SwitchToTabBrowserTool.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1E70030000000000000001 /* SwitchToTabBrowserTool.swift */; };
+		AB1E70050000000000000002 /* BrowserToolsDebugPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1E70050000000000000001 /* BrowserToolsDebugPanel.swift */; };
+		AB1E70050000000000000003 /* BrowserToolsDebugPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1E70050000000000000001 /* BrowserToolsDebugPanel.swift */; };
+		AB1E70030000000000000003 /* SwitchToTabBrowserTool.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1E70030000000000000001 /* SwitchToTabBrowserTool.swift */; };
 		AB1E70010000000000000004 /* AIChatBrowserToolsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1E70010000000000000002 /* AIChatBrowserToolsService.swift */; };
 		D1A7B0010000000000000013 /* AIChatTabPickerSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A7B0010000000000000011 /* AIChatTabPickerSource.swift */; };
 		D1A7B0010000000000000022 /* AIChatTabPickerSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A7B0010000000000000021 /* AIChatTabPickerSourceTests.swift */; };
@@ -5537,6 +5543,7 @@
 		37AA017E2E2164A500844427 /* AIChatUserScriptHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatUserScriptHandlerTests.swift; sourceTree = "<group>"; };
 		AB1E70020000000000000001 /* AIChatMCPSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatMCPSessionTests.swift; sourceTree = "<group>"; };
 		AB1E70020000000000000004 /* BrowserToolCatalogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserToolCatalogTests.swift; sourceTree = "<group>"; };
+		AB1E70040000000000000001 /* BrowserToolInvokerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserToolInvokerTests.swift; sourceTree = "<group>"; };
 		AB1E70020000000000000007 /* BrowserToolsWireFormatTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserToolsWireFormatTests.swift; sourceTree = "<group>"; };
 		37ABFE7B2DED901000DE39F2 /* SettingsPixel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsPixel.swift; sourceTree = "<group>"; };
 		37ADC3ED2DF031830001CA03 /* MoreOptionsMenuPixel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoreOptionsMenuPixel.swift; sourceTree = "<group>"; };
@@ -7257,6 +7264,8 @@
 		D1A7B0010000000000000001 /* NewTabPageOmnibarTabsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTabPageOmnibarTabsProvider.swift; sourceTree = "<group>"; };
 		D1A7B0010000000000000011 /* AIChatTabPickerSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatTabPickerSource.swift; sourceTree = "<group>"; };
 		AB1E70010000000000000002 /* AIChatBrowserToolsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatBrowserToolsService.swift; sourceTree = "<group>"; };
+		AB1E70030000000000000001 /* SwitchToTabBrowserTool.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwitchToTabBrowserTool.swift; sourceTree = "<group>"; };
+		AB1E70050000000000000001 /* BrowserToolsDebugPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserToolsDebugPanel.swift; sourceTree = "<group>"; };
 		D1A7B0010000000000000021 /* AIChatTabPickerSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatTabPickerSourceTests.swift; sourceTree = "<group>"; };
 		D1A7B0010000000000000041 /* AIChatSelectionActionPageContextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatSelectionActionPageContextTests.swift; sourceTree = "<group>"; };
 		D1D1D1D100000000000000E0 /* MouseEventInterceptingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MouseEventInterceptingView.swift; sourceTree = "<group>"; };
@@ -8396,6 +8405,7 @@
 			children = (
 				AB1E70020000000000000001 /* AIChatMCPSessionTests.swift */,
 				AB1E70020000000000000004 /* BrowserToolCatalogTests.swift */,
+				AB1E70040000000000000001 /* BrowserToolInvokerTests.swift */,
 				AB1E70020000000000000007 /* BrowserToolsWireFormatTests.swift */,
 			);
 			path = BrowserTools;
@@ -8405,6 +8415,8 @@
 			isa = PBXGroup;
 			children = (
 				AB1E70010000000000000002 /* AIChatBrowserToolsService.swift */,
+				AB1E70030000000000000001 /* SwitchToTabBrowserTool.swift */,
+				AB1E70050000000000000001 /* BrowserToolsDebugPanel.swift */,
 			);
 			path = BrowserTools;
 			sourceTree = "<group>";
@@ -16231,6 +16243,8 @@
 				31FBF22F2CDD068000626C17 /* AIChatUserScriptHandling.swift in Sources */,
 				D1A7B0010000000000000012 /* AIChatTabPickerSource.swift in Sources */,
 				AB1E70010000000000000003 /* AIChatBrowserToolsService.swift in Sources */,
+				AB1E70030000000000000002 /* SwitchToTabBrowserTool.swift in Sources */,
+				AB1E70050000000000000002 /* BrowserToolsDebugPanel.swift in Sources */,
 				84CE00162DAE41F100852AA2 /* ResizablePreviewView.swift in Sources */,
 				96B6A494304EC0B5009BF9EC /* WebsitePermissionCategory.swift in Sources */,
 				1D1A334A2A6FEB170080ACED /* BurnerMode.swift in Sources */,
@@ -17398,6 +17412,7 @@
 				37AA01802E2164A700844427 /* AIChatUserScriptHandlerTests.swift in Sources */,
 				AB1E70020000000000000003 /* AIChatMCPSessionTests.swift in Sources */,
 				AB1E70020000000000000006 /* BrowserToolCatalogTests.swift in Sources */,
+				AB1E70040000000000000003 /* BrowserToolInvokerTests.swift in Sources */,
 				AB1E70020000000000000009 /* BrowserToolsWireFormatTests.swift in Sources */,
 				D1A7B0010000000000000022 /* AIChatTabPickerSourceTests.swift in Sources */,
 				D1A7B0010000000000000042 /* AIChatSelectionActionPageContextTests.swift in Sources */,
@@ -18260,6 +18275,8 @@
 				31FBF22E2CDD068000626C17 /* AIChatUserScriptHandling.swift in Sources */,
 				D1A7B0010000000000000013 /* AIChatTabPickerSource.swift in Sources */,
 				AB1E70010000000000000004 /* AIChatBrowserToolsService.swift in Sources */,
+				AB1E70030000000000000003 /* SwitchToTabBrowserTool.swift in Sources */,
+				AB1E70050000000000000003 /* BrowserToolsDebugPanel.swift in Sources */,
 				C1D3C5682E747BBE0086A2BD /* CreditCardsCleanupErrorHandling.swift in Sources */,
 				C1D3C5692E747BBE0086A2BD /* SyncCreditCardsAdapter.swift in Sources */,
 				4B9292A426670D2A00AD2C21 /* PasteboardWriting.swift in Sources */,
@@ -19799,6 +19816,7 @@
 				37AA017F2E2164A700844427 /* AIChatUserScriptHandlerTests.swift in Sources */,
 				AB1E70020000000000000002 /* AIChatMCPSessionTests.swift in Sources */,
 				AB1E70020000000000000005 /* BrowserToolCatalogTests.swift in Sources */,
+				AB1E70040000000000000002 /* BrowserToolInvokerTests.swift in Sources */,
 				AB1E70020000000000000008 /* BrowserToolsWireFormatTests.swift in Sources */,
 				D1A7B0010000000000000023 /* AIChatTabPickerSourceTests.swift in Sources */,
 				D1A7B0010000000000000043 /* AIChatSelectionActionPageContextTests.swift in Sources */,

--- a/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
+++ b/macOS/DuckDuckGo-macOS.xcodeproj/project.pbxproj
@@ -1311,6 +1311,12 @@
 		37AA017C2E2100DA00844427 /* CrashPixelAppIdentifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37AA017B2E2100D500844427 /* CrashPixelAppIdentifierTests.swift */; };
 		37AA017D2E2100DA00844427 /* CrashPixelAppIdentifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37AA017B2E2100D500844427 /* CrashPixelAppIdentifierTests.swift */; };
 		37AA017F2E2164A700844427 /* AIChatUserScriptHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37AA017E2E2164A500844427 /* AIChatUserScriptHandlerTests.swift */; };
+		AB1E70020000000000000002 /* AIChatMCPSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1E70020000000000000001 /* AIChatMCPSessionTests.swift */; };
+		AB1E70020000000000000003 /* AIChatMCPSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1E70020000000000000001 /* AIChatMCPSessionTests.swift */; };
+		AB1E70020000000000000005 /* BrowserToolCatalogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1E70020000000000000004 /* BrowserToolCatalogTests.swift */; };
+		AB1E70020000000000000006 /* BrowserToolCatalogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1E70020000000000000004 /* BrowserToolCatalogTests.swift */; };
+		AB1E70020000000000000008 /* BrowserToolsWireFormatTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1E70020000000000000007 /* BrowserToolsWireFormatTests.swift */; };
+		AB1E70020000000000000009 /* BrowserToolsWireFormatTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1E70020000000000000007 /* BrowserToolsWireFormatTests.swift */; };
 		37AA01802E2164A700844427 /* AIChatUserScriptHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37AA017E2E2164A500844427 /* AIChatUserScriptHandlerTests.swift */; };
 		37ABFE7C2DED901200DE39F2 /* SettingsPixel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37ABFE7B2DED901000DE39F2 /* SettingsPixel.swift */; };
 		37ABFE7D2DED901200DE39F2 /* SettingsPixel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37ABFE7B2DED901000DE39F2 /* SettingsPixel.swift */; };
@@ -4371,6 +4377,8 @@
 		D1A7B0010000000000000002 /* NewTabPageOmnibarTabsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A7B0010000000000000001 /* NewTabPageOmnibarTabsProvider.swift */; };
 		D1A7B0010000000000000003 /* NewTabPageOmnibarTabsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A7B0010000000000000001 /* NewTabPageOmnibarTabsProvider.swift */; };
 		D1A7B0010000000000000012 /* AIChatTabPickerSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A7B0010000000000000011 /* AIChatTabPickerSource.swift */; };
+		AB1E70010000000000000003 /* AIChatBrowserToolsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1E70010000000000000002 /* AIChatBrowserToolsService.swift */; };
+		AB1E70010000000000000004 /* AIChatBrowserToolsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1E70010000000000000002 /* AIChatBrowserToolsService.swift */; };
 		D1A7B0010000000000000013 /* AIChatTabPickerSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A7B0010000000000000011 /* AIChatTabPickerSource.swift */; };
 		D1A7B0010000000000000022 /* AIChatTabPickerSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A7B0010000000000000021 /* AIChatTabPickerSourceTests.swift */; };
 		D1A7B0010000000000000023 /* AIChatTabPickerSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A7B0010000000000000021 /* AIChatTabPickerSourceTests.swift */; };
@@ -5527,6 +5535,9 @@
 		37AA01722E1FE88900844427 /* CrashPixelAppIdentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashPixelAppIdentifier.swift; sourceTree = "<group>"; };
 		37AA017B2E2100D500844427 /* CrashPixelAppIdentifierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashPixelAppIdentifierTests.swift; sourceTree = "<group>"; };
 		37AA017E2E2164A500844427 /* AIChatUserScriptHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatUserScriptHandlerTests.swift; sourceTree = "<group>"; };
+		AB1E70020000000000000001 /* AIChatMCPSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatMCPSessionTests.swift; sourceTree = "<group>"; };
+		AB1E70020000000000000004 /* BrowserToolCatalogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserToolCatalogTests.swift; sourceTree = "<group>"; };
+		AB1E70020000000000000007 /* BrowserToolsWireFormatTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserToolsWireFormatTests.swift; sourceTree = "<group>"; };
 		37ABFE7B2DED901000DE39F2 /* SettingsPixel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsPixel.swift; sourceTree = "<group>"; };
 		37ADC3ED2DF031830001CA03 /* MoreOptionsMenuPixel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoreOptionsMenuPixel.swift; sourceTree = "<group>"; };
 		37ADC4002DF040000001CA03 /* WebViewZoomPixel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewZoomPixel.swift; sourceTree = "<group>"; };
@@ -7245,6 +7256,7 @@
 		D09265BA0D784C47B9644675 /* RebrandedContextualOnboardingDialogs+Fire.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RebrandedContextualOnboardingDialogs+Fire.swift"; sourceTree = "<group>"; };
 		D1A7B0010000000000000001 /* NewTabPageOmnibarTabsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewTabPageOmnibarTabsProvider.swift; sourceTree = "<group>"; };
 		D1A7B0010000000000000011 /* AIChatTabPickerSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatTabPickerSource.swift; sourceTree = "<group>"; };
+		AB1E70010000000000000002 /* AIChatBrowserToolsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatBrowserToolsService.swift; sourceTree = "<group>"; };
 		D1A7B0010000000000000021 /* AIChatTabPickerSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatTabPickerSourceTests.swift; sourceTree = "<group>"; };
 		D1A7B0010000000000000041 /* AIChatSelectionActionPageContextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIChatSelectionActionPageContextTests.swift; sourceTree = "<group>"; };
 		D1D1D1D100000000000000E0 /* MouseEventInterceptingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MouseEventInterceptingView.swift; sourceTree = "<group>"; };
@@ -8256,6 +8268,7 @@
 				1E4EDA262DE9ED1C0019B6E8 /* Sidebar */,
 				4773D76F5C4F4B31900F6E7A /* FloatingWindow */,
 				31CF74542CDC1771004ACCE5 /* UserScript */,
+				AB1E70010000000000000001 /* BrowserTools */,
 				1D5C23272F150A580055046E /* Suggestions */,
 				319FCFF42CC83003004F9288 /* AIChatDebugMenu.swift */,
 				C150EB212F0D817100A98C97 /* AIChatFeatureFlagProvider.swift */,
@@ -8378,6 +8391,24 @@
 			path = DBP;
 			sourceTree = "<group>";
 		};
+		AB1E70020000000000000010 /* BrowserTools */ = {
+			isa = PBXGroup;
+			children = (
+				AB1E70020000000000000001 /* AIChatMCPSessionTests.swift */,
+				AB1E70020000000000000004 /* BrowserToolCatalogTests.swift */,
+				AB1E70020000000000000007 /* BrowserToolsWireFormatTests.swift */,
+			);
+			path = BrowserTools;
+			sourceTree = "<group>";
+		};
+		AB1E70010000000000000001 /* BrowserTools */ = {
+			isa = PBXGroup;
+			children = (
+				AB1E70010000000000000002 /* AIChatBrowserToolsService.swift */,
+			);
+			path = BrowserTools;
+			sourceTree = "<group>";
+		};
 		31CF74542CDC1771004ACCE5 /* UserScript */ = {
 			isa = PBXGroup;
 			children = (
@@ -8425,6 +8456,7 @@
 				BBC277A02FBF000300756A85 /* DuckAiVoiceChatLegacyConsentCleanupTests.swift */,
 				BBF17D1F2F7B4D33004AFCF4 /* AIChatMenuTests.swift */,
 				37AA017E2E2164A500844427 /* AIChatUserScriptHandlerTests.swift */,
+				AB1E70020000000000000010 /* BrowserTools */,
 				D1A7B0010000000000000021 /* AIChatTabPickerSourceTests.swift */,
 				D1A7B0010000000000000041 /* AIChatSelectionActionPageContextTests.swift */,
 				3135647D2D9EBB9900BF4B5D /* AIChatAddressBarPromptExtractorTests.swift */,
@@ -16198,6 +16230,7 @@
 				31CF74562CDC177D004ACCE5 /* AIChatUserScript.swift in Sources */,
 				31FBF22F2CDD068000626C17 /* AIChatUserScriptHandling.swift in Sources */,
 				D1A7B0010000000000000012 /* AIChatTabPickerSource.swift in Sources */,
+				AB1E70010000000000000003 /* AIChatBrowserToolsService.swift in Sources */,
 				84CE00162DAE41F100852AA2 /* ResizablePreviewView.swift in Sources */,
 				96B6A494304EC0B5009BF9EC /* WebsitePermissionCategory.swift in Sources */,
 				1D1A334A2A6FEB170080ACED /* BurnerMode.swift in Sources */,
@@ -17363,6 +17396,9 @@
 				C17CA7B32B9B5317008EC3C1 /* MockAutofillPopoverPresenter.swift in Sources */,
 				BBDF565D2EA8E22100AA2DFF /* WinBackOfferPromptPresenterTests.swift in Sources */,
 				37AA01802E2164A700844427 /* AIChatUserScriptHandlerTests.swift in Sources */,
+				AB1E70020000000000000003 /* AIChatMCPSessionTests.swift in Sources */,
+				AB1E70020000000000000006 /* BrowserToolCatalogTests.swift in Sources */,
+				AB1E70020000000000000009 /* BrowserToolsWireFormatTests.swift in Sources */,
 				D1A7B0010000000000000022 /* AIChatTabPickerSourceTests.swift in Sources */,
 				D1A7B0010000000000000042 /* AIChatSelectionActionPageContextTests.swift in Sources */,
 				B6619F042B17123200CD9186 /* DataImportViewModelTests.swift in Sources */,
@@ -18223,6 +18259,7 @@
 				37445F992A1566420029F789 /* SyncDataProviders.swift in Sources */,
 				31FBF22E2CDD068000626C17 /* AIChatUserScriptHandling.swift in Sources */,
 				D1A7B0010000000000000013 /* AIChatTabPickerSource.swift in Sources */,
+				AB1E70010000000000000004 /* AIChatBrowserToolsService.swift in Sources */,
 				C1D3C5682E747BBE0086A2BD /* CreditCardsCleanupErrorHandling.swift in Sources */,
 				C1D3C5692E747BBE0086A2BD /* SyncCreditCardsAdapter.swift in Sources */,
 				4B9292A426670D2A00AD2C21 /* PasteboardWriting.swift in Sources */,
@@ -19760,6 +19797,9 @@
 				FEE12B412E520E4D00AD9807 /* PromoHistoryRecordTests.swift in Sources */,
 				56504F102E0D9A8C00333A1E /* MockSubscriptionTabsShowing.swift in Sources */,
 				37AA017F2E2164A700844427 /* AIChatUserScriptHandlerTests.swift in Sources */,
+				AB1E70020000000000000002 /* AIChatMCPSessionTests.swift in Sources */,
+				AB1E70020000000000000005 /* BrowserToolCatalogTests.swift in Sources */,
+				AB1E70020000000000000008 /* BrowserToolsWireFormatTests.swift in Sources */,
 				D1A7B0010000000000000023 /* AIChatTabPickerSourceTests.swift in Sources */,
 				D1A7B0010000000000000043 /* AIChatSelectionActionPageContextTests.swift in Sources */,
 				AAE39D1B24F44885008EF28B /* TabCollectionViewModelDelegateMock.swift in Sources */,

--- a/macOS/DuckDuckGo/AIChat/AIChatDebugMenu.swift
+++ b/macOS/DuckDuckGo/AIChat/AIChatDebugMenu.swift
@@ -60,8 +60,33 @@ final class AIChatDebugMenu: NSMenu {
             NSMenuItem.separator()
 
             storageServerMenuItem
+
+#if DEBUG
+            NSMenuItem.separator()
+
+            NSMenuItem(title: "Browser Tools Panel…", action: #selector(openBrowserToolsPanel))
+                .targetting(self)
+#endif
         }
     }
+
+#if DEBUG
+
+    // MARK: - Browser Tools
+
+    private var browserToolsPanel: BrowserToolsDebugPanel?
+
+    /// Stands in for the Duck.ai front end, which cannot drive the browser tools bridge yet.
+    @MainActor
+    @objc func openBrowserToolsPanel() {
+        let panel = browserToolsPanel
+            ?? BrowserToolsDebugPanel(windowControllersManager: NSApp.delegateTyped.windowControllersManager)
+        browserToolsPanel = panel
+        panel.showWindow(nil)
+        panel.window?.makeKeyAndOrderFront(nil)
+    }
+
+#endif
 
     // MARK: - Duck.ai Usage Warnings
 

--- a/macOS/DuckDuckGo/AIChat/BrowserTools/AIChatBrowserToolsService.swift
+++ b/macOS/DuckDuckGo/AIChat/BrowserTools/AIChatBrowserToolsService.swift
@@ -36,6 +36,7 @@ final class AIChatBrowserToolsService {
 
     let sessions = AIChatMCPSessionStore()
     let catalog: BrowserToolCatalog
+    let invoker: BrowserToolInvoker
 
     private let configuration: AIChatBrowserToolsConfiguration
 
@@ -43,10 +44,23 @@ final class AIChatBrowserToolsService {
     /// when this is false, which also protects against version skew.
     var isEnabled: Bool { configuration.isEnabled }
 
-    init(featureFlagger: FeatureFlagger, tools: [any BrowserTool] = []) {
+    /// - Parameter tools: overridable so tests can register their own catalog.
+    init(featureFlagger: FeatureFlagger,
+         windowControllersManager: WindowControllersManagerProtocol,
+         tools: [any BrowserTool]? = nil) {
         let configuration = AIChatBrowserToolsConfiguration(featureFlagger: featureFlagger)
+        let catalog = BrowserToolCatalog(tools: tools ?? Self.defaultTools(windowControllersManager: windowControllersManager),
+                                         configuration: configuration)
         self.configuration = configuration
-        self.catalog = BrowserToolCatalog(tools: tools, configuration: configuration)
+        self.catalog = catalog
+        self.invoker = BrowserToolInvoker(catalog: catalog, configuration: configuration)
+    }
+
+    /// Registration order is the order the front end sees in `tools/list`.
+    private static func defaultTools(windowControllersManager: WindowControllersManagerProtocol) -> [any BrowserTool] {
+        [
+            SwitchToTabBrowserTool(windowControllersManager: windowControllersManager)
+        ]
     }
 }
 

--- a/macOS/DuckDuckGo/AIChat/BrowserTools/AIChatBrowserToolsService.swift
+++ b/macOS/DuckDuckGo/AIChat/BrowserTools/AIChatBrowserToolsService.swift
@@ -1,0 +1,88 @@
+//
+//  AIChatBrowserToolsService.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import AIChat
+import FeatureFlags_macOS
+import Foundation
+import PrivacyConfig
+
+/// App-wide owner of the Duck.ai browser tools bridge: the MCP sessions, the tool catalog, and
+/// the remote-config gating behind them.
+///
+/// One instance per app rather than per web view, because a session belongs to the Duck.ai *owner
+/// tab* — a sidebar and the tab it is docked to share one — while each web view gets its own
+/// `AIChatUserScript`.
+@MainActor
+final class AIChatBrowserToolsService {
+
+    /// Identifies this browser in the MCP `initialize` result. The Windows browser reports
+    /// `windows-browser`.
+    static let serverName = "macos-browser"
+
+    let sessions = AIChatMCPSessionStore()
+    let catalog: BrowserToolCatalog
+
+    private let configuration: AIChatBrowserToolsConfiguration
+
+    /// Reported to the front end as `supportsBrowserTools`. The front end must not open a session
+    /// when this is false, which also protects against version skew.
+    var isEnabled: Bool { configuration.isEnabled }
+
+    init(featureFlagger: FeatureFlagger, tools: [any BrowserTool] = []) {
+        let configuration = AIChatBrowserToolsConfiguration(featureFlagger: featureFlagger)
+        self.configuration = configuration
+        self.catalog = BrowserToolCatalog(tools: tools, configuration: configuration)
+    }
+}
+
+/// Maps the browser-tools remote-config sub-features onto macOS feature flags.
+///
+/// A tool's `name` is its sub-feature's raw value, so the two cannot drift apart: adding a
+/// sub-feature is a compile error here until it is mapped.
+@MainActor
+final class AIChatBrowserToolsConfiguration: BrowserToolsConfiguration {
+
+    private let featureFlagger: FeatureFlagger
+
+    init(featureFlagger: FeatureFlagger) {
+        self.featureFlagger = featureFlagger
+    }
+
+    var isEnabled: Bool {
+        featureFlagger.isFeatureOn(.aiChatBrowserTools)
+    }
+
+    func isToolEnabled(named name: String) -> Bool {
+        guard isEnabled,
+              let subfeature = AIChatBrowserToolsSubfeature(rawValue: name),
+              let flag = Self.featureFlag(for: subfeature) else { return false }
+        return featureFlagger.isFeatureOn(flag)
+    }
+
+    private static func featureFlag(for subfeature: AIChatBrowserToolsSubfeature) -> FeatureFlag? {
+        switch subfeature {
+        case .featureEnabled: nil // The parent gate, not a tool.
+        case .listOpenTabs: .aiChatBrowserToolListOpenTabs
+        case .searchHistory: .aiChatBrowserToolSearchHistory
+        case .switchToTab: .aiChatBrowserToolSwitchToTab
+        case .readTabContent: .aiChatBrowserToolReadTabContent
+        case .findInPage: .aiChatBrowserToolFindInPage
+        case .highlightInPage: .aiChatBrowserToolHighlightInPage
+        }
+    }
+}

--- a/macOS/DuckDuckGo/AIChat/BrowserTools/AIChatBrowserToolsService.swift
+++ b/macOS/DuckDuckGo/AIChat/BrowserTools/AIChatBrowserToolsService.swift
@@ -21,12 +21,8 @@ import FeatureFlags_macOS
 import Foundation
 import PrivacyConfig
 
-/// App-wide owner of the Duck.ai browser tools bridge: the MCP sessions, the tool catalog, and
-/// the remote-config gating behind them.
-///
-/// One instance per app rather than per web view, because a session belongs to the Duck.ai *owner
-/// tab* — a sidebar and the tab it is docked to share one — while each web view gets its own
-/// `AIChatUserScript`.
+/// Owns the MCP sessions, the tool catalog and their gating. App-wide rather than per web view,
+/// because a session belongs to the owner tab while each web view gets its own user script.
 @MainActor
 final class AIChatBrowserToolsService {
 
@@ -64,10 +60,8 @@ final class AIChatBrowserToolsService {
     }
 }
 
-/// Maps the browser-tools remote-config sub-features onto macOS feature flags.
-///
-/// A tool's `name` is its sub-feature's raw value, so the two cannot drift apart: adding a
-/// sub-feature is a compile error here until it is mapped.
+/// Maps browser-tools sub-features onto macOS feature flags. A tool's `name` is its sub-feature's
+/// raw value, so adding a sub-feature is a compile error here until it is mapped.
 @MainActor
 final class AIChatBrowserToolsConfiguration: BrowserToolsConfiguration {
 

--- a/macOS/DuckDuckGo/AIChat/BrowserTools/BrowserToolsDebugPanel.swift
+++ b/macOS/DuckDuckGo/AIChat/BrowserTools/BrowserToolsDebugPanel.swift
@@ -109,6 +109,22 @@ final class BrowserToolsDebugPanel: NSWindowController {
         ])
     }
 
+    /// `listOpenTabs` is not part of this change, so there is otherwise no way to discover a tabId
+    /// to hand to `switchToTab`. This reads the window directly rather than going through a tool.
+    @objc private func listWindowTabs() {
+        guard let collection = windowControllersManager.lastKeyMainWindowController?
+            .mainViewController.tabCollectionViewModel else {
+            appendToLog("→ no window")
+            return
+        }
+        let tabs = (collection.pinnedTabsCollection?.tabs ?? []) + collection.tabCollection.tabs
+        appendToLog("→ tabs in this window (panel only, not a tool)")
+        for tab in tabs {
+            appendToLog("   \(tab.uuid)  \(tab.title ?? "")  \(tab.url?.absoluteString ?? "")")
+        }
+        appendToLog("")
+    }
+
     @objc private func refreshTarget() {
         guard let tab = selectedTab else {
             targetLabel.stringValue = "No tab selected — open a tab to act as the Duck.ai owner tab."
@@ -188,6 +204,7 @@ final class BrowserToolsDebugPanel: NSWindowController {
             makeButton("initialize", #selector(initializeSession)),
             makeButton("notifications/initialized", #selector(notifyInitialized)),
             makeButton("tools/list", #selector(listTools)),
+            makeButton("Show tab IDs", #selector(listWindowTabs)),
             makeButton("Refresh target", #selector(refreshTarget))
         ])
         buttons.orientation = .horizontal

--- a/macOS/DuckDuckGo/AIChat/BrowserTools/BrowserToolsDebugPanel.swift
+++ b/macOS/DuckDuckGo/AIChat/BrowserTools/BrowserToolsDebugPanel.swift
@@ -97,6 +97,10 @@ final class BrowserToolsDebugPanel: NSWindowController {
 
     @objc private func callTool() {
         let name = toolNameField.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !name.contains(where: \.isWhitespace), !name.contains("{") else {
+            appendToLog("→ '\(name)' is not a tool name — arguments JSON belongs in the arguments field\n")
+            return
+        }
         guard let argumentsData = argumentsField.stringValue.data(using: .utf8),
               let arguments = try? JSONSerialization.jsonObject(with: argumentsData) else {
             appendToLog("→ arguments are not valid JSON; nothing sent")
@@ -120,7 +124,8 @@ final class BrowserToolsDebugPanel: NSWindowController {
         let tabs = (collection.pinnedTabsCollection?.tabs ?? []) + collection.tabCollection.tabs
         appendToLog("→ tabs in this window (panel only, not a tool)")
         for tab in tabs {
-            appendToLog("   \(tab.uuid)  \(tab.title ?? "")  \(tab.url?.absoluteString ?? "")")
+            appendToLog("   \(tab.title ?? tab.url?.absoluteString ?? "")")
+            appendToLog("      {\"tabId\": \"\(tab.uuid)\"}")
         }
         appendToLog("")
     }
@@ -211,17 +216,20 @@ final class BrowserToolsDebugPanel: NSWindowController {
         buttons.spacing = 8
 
         toolNameField.placeholderString = "tool name"
-        argumentsField.placeholderString = "arguments JSON"
+        argumentsField.placeholderString = "{\"tabId\": \"…\"}"
         let call = NSStackView(views: [
-            NSTextField(labelWithString: "tools/call"),
+            NSTextField(labelWithString: "tools/call  name:"),
             toolNameField,
+            NSTextField(labelWithString: "arguments:"),
             argumentsField,
             makeButton("Call", #selector(callTool))
         ])
         call.orientation = .horizontal
         call.spacing = 8
-        toolNameField.setContentHuggingPriority(.defaultLow, for: .horizontal)
-        argumentsField.setContentHuggingPriority(.init(1), for: .horizontal)
+        NSLayoutConstraint.activate([
+            toolNameField.widthAnchor.constraint(equalToConstant: 130),
+            argumentsField.widthAnchor.constraint(greaterThanOrEqualToConstant: 280)
+        ])
 
         logView.isEditable = false
         logView.font = .monospacedSystemFont(ofSize: 11, weight: .regular)

--- a/macOS/DuckDuckGo/AIChat/BrowserTools/BrowserToolsDebugPanel.swift
+++ b/macOS/DuckDuckGo/AIChat/BrowserTools/BrowserToolsDebugPanel.swift
@@ -23,12 +23,8 @@ import AppKit
 import UserScript
 import WebKit
 
-/// DEBUG-only panel for exercising the Duck.ai browser tools bridge by hand.
-///
-/// A web page cannot do this on macOS: the message handlers live in an isolated content world page
-/// scripts cannot reach, and content-scope-scripts grants the `aiChat` page-world bridge only to
-/// duckduckgo.com / duck.co / duck.ai. So the panel stands in for the front end from inside the
-/// app, driving the same dispatch and handlers a page message would.
+/// DEBUG-only stand-in for the Duck.ai front end, driving the same dispatch and handlers a page
+/// message would. A page cannot do this yet — the `aiChat` bridge is granted only to duck.ai.
 @MainActor
 final class BrowserToolsDebugPanel: NSWindowController {
 
@@ -123,9 +119,8 @@ final class BrowserToolsDebugPanel: NSWindowController {
         appendToLog("")
     }
 
-    /// Sessions are keyed per owner tab, and the owner tab is re-read on every click — so selecting
-    /// a different tab between the handshake and a call silently moves you to a tab that has no
-    /// session. Showing the state makes that visible instead of surfacing it as `not_initialized`.
+    /// The owner tab is re-read on every click, so switching tabs mid-handshake lands you on one
+    /// with no session. Showing the state beats discovering it as `not_initialized` on a call.
     @objc private func refreshTarget() {
         guard let tab = selectedTab else {
             targetLabel.stringValue = "No tab selected — open a tab to act as the Duck.ai owner tab."
@@ -150,9 +145,8 @@ final class BrowserToolsDebugPanel: NSWindowController {
             return
         }
 
-        // Check the method really is wired into the production dispatch switch — the same lookup a
-        // page message performs. Its closure takes a concrete `WKScriptMessage`, which only WebKit
-        // can create, so the typed handler behind it is invoked directly below.
+        // Same lookup a page message performs. Its closure needs a concrete `WKScriptMessage`,
+        // which only WebKit can make, so the typed handler behind it is invoked directly below.
         guard userScript.handler(forMethodNamed: method) != nil else {
             appendToLog("→ \(method): not wired into the dispatch switch")
             return

--- a/macOS/DuckDuckGo/AIChat/BrowserTools/BrowserToolsDebugPanel.swift
+++ b/macOS/DuckDuckGo/AIChat/BrowserTools/BrowserToolsDebugPanel.swift
@@ -1,0 +1,253 @@
+//
+//  BrowserToolsDebugPanel.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#if DEBUG
+
+import AIChat
+import AppKit
+import UserScript
+import WebKit
+
+/// DEBUG-only panel for exercising the Duck.ai browser tools bridge by hand.
+///
+/// Duck.ai's own front end cannot drive this yet, and unlike Windows we cannot stand up a web
+/// harness to do it: WebView2 hands page scripts a raw native channel (`chrome.webview`), whereas
+/// on macOS the message handlers live in an isolated content world that page JavaScript cannot
+/// reach, and content-scope-scripts only grants the `aiChat` page-world bridge to
+/// duckduckgo.com / duck.co / duck.ai.
+///
+/// So this panel takes the front end's place from *inside* the app: it builds a real
+/// `AIChatUserScript`, resolves handlers through the same dispatch switch a page message would, and
+/// feeds them synthetic messages carrying a real web view. Everything below the JavaScript hop —
+/// dispatch, owner-tab resolution, session state, catalog gating, the invoker and the MCP
+/// envelopes — runs exactly as it does in production.
+@MainActor
+final class BrowserToolsDebugPanel: NSWindowController {
+
+    private let userScript: AIChatUserScript
+    private let chatHandler: AIChatUserScriptHandler
+    private let windowControllersManager: WindowControllersManagerProtocol
+
+    private let targetLabel = NSTextField(labelWithString: "")
+    private let toolNameField = NSTextField(string: "switchToTab")
+    private let argumentsField = NSTextField(string: "{}")
+    private let logView = NSTextView()
+
+    init(windowControllersManager: WindowControllersManagerProtocol) {
+        self.windowControllersManager = windowControllersManager
+        let chatHandler = AIChatUserScriptHandler(
+            storage: DefaultAIChatPreferencesStorage(),
+            windowControllersManager: windowControllersManager,
+            pixelFiring: nil,
+            statisticsLoader: nil,
+            syncServiceProvider: { nil },
+            syncErrorHandler: NSApp.delegateTyped.syncErrorHandler,
+            featureFlagger: NSApp.delegateTyped.featureFlagger
+        )
+        self.chatHandler = chatHandler
+        self.userScript = AIChatUserScript(handler: chatHandler, urlSettings: UserDefaults.standard.keyedStoring())
+
+        let window = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 720, height: 520),
+                              styleMask: [.titled, .closable, .resizable],
+                              backing: .buffered,
+                              defer: false)
+        window.title = "Duck.ai Browser Tools"
+        super.init(window: window)
+        window.contentView = makeContentView()
+        window.center()
+        refreshTarget()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Actions
+
+    @objc private func initializeSession() {
+        run("initialize", params: [
+            "protocolVersion": "2025-11-25",
+            "capabilities": ["elicitation": ["form": [:] as [String: Any]]],
+            "clientInfo": ["name": "browser-tools-debug-panel", "version": "1"]
+        ])
+    }
+
+    @objc private func notifyInitialized() {
+        run("notifications/initialized", params: [:])
+    }
+
+    @objc private func listTools() {
+        run("tools/list", params: [:])
+    }
+
+    @objc private func callTool() {
+        let name = toolNameField.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let argumentsData = argumentsField.stringValue.data(using: .utf8),
+              let arguments = try? JSONSerialization.jsonObject(with: argumentsData) else {
+            appendToLog("→ arguments are not valid JSON; nothing sent")
+            return
+        }
+        run("tools/call", params: [
+            "name": name,
+            "callId": "panel-\(Int(Date().timeIntervalSince1970 * 1000))",
+            "arguments": arguments
+        ])
+    }
+
+    @objc private func refreshTarget() {
+        guard let tab = selectedTab else {
+            targetLabel.stringValue = "No tab selected — open a tab to act as the Duck.ai owner tab."
+            return
+        }
+        let burner = tab.burnerMode.isBurner ? "  ·  Fire Window" : ""
+        targetLabel.stringValue = "Owner tab: \(tab.uuid)\(burner)"
+    }
+
+    // MARK: -
+
+    private func run(_ method: String, params: [String: Any]) {
+        refreshTarget()
+        guard let webView = selectedTab?.webView else {
+            appendToLog("→ no selected tab; cannot resolve an owner tab")
+            return
+        }
+
+        // Check the method really is wired into the production dispatch switch — the same lookup a
+        // page message performs. Its closure takes a concrete `WKScriptMessage`, which only WebKit
+        // can create, so the typed handler behind it is invoked directly below.
+        guard userScript.handler(forMethodNamed: method) != nil else {
+            appendToLog("→ \(method): not wired into the dispatch switch")
+            return
+        }
+        guard let invoke = typedHandler(for: method) else {
+            appendToLog("→ \(method): no typed handler")
+            return
+        }
+
+        appendToLog("→ \(method) \(prettyPrinted(params))")
+        Task { @MainActor in
+            let response = await invoke(params, SyntheticUserScriptMessage(name: method, body: params, webView: webView))
+            appendToLog("← \(response.map(prettyPrinted) ?? "(no reply)")\n")
+        }
+    }
+
+    private func typedHandler(for method: String) -> ((Any, UserScriptMessage) async -> Encodable?)? {
+        switch AIChatUserScriptMessages(rawValue: method) {
+        case .initialize: chatHandler.mcpInitialize
+        case .notificationsInitialized: chatHandler.mcpNotificationsInitialized
+        case .toolsList: chatHandler.mcpToolsList
+        case .toolsCall: chatHandler.mcpToolsCall
+        default: nil
+        }
+    }
+
+    private var selectedTab: Tab? {
+        windowControllersManager.lastKeyMainWindowController?.mainViewController.tabCollectionViewModel.selectedTab
+    }
+
+    private func prettyPrinted(_ value: Any) -> String {
+        if let encodable = value as? Encodable {
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+            if let data = try? encoder.encode(encodable), let string = String(data: data, encoding: .utf8) {
+                return string
+            }
+        }
+        if JSONSerialization.isValidJSONObject(value),
+           let data = try? JSONSerialization.data(withJSONObject: value, options: [.prettyPrinted, .sortedKeys]),
+           let string = String(data: data, encoding: .utf8) {
+            return string
+        }
+        return String(describing: value)
+    }
+
+    private func appendToLog(_ text: String) {
+        logView.string += text + "\n"
+        logView.scrollToEndOfDocument(nil)
+    }
+
+    // MARK: - Layout
+
+    private func makeContentView() -> NSView {
+        let buttons = NSStackView(views: [
+            makeButton("initialize", #selector(initializeSession)),
+            makeButton("notifications/initialized", #selector(notifyInitialized)),
+            makeButton("tools/list", #selector(listTools)),
+            makeButton("Refresh target", #selector(refreshTarget))
+        ])
+        buttons.orientation = .horizontal
+        buttons.spacing = 8
+
+        toolNameField.placeholderString = "tool name"
+        argumentsField.placeholderString = "arguments JSON"
+        let call = NSStackView(views: [
+            NSTextField(labelWithString: "tools/call"),
+            toolNameField,
+            argumentsField,
+            makeButton("Call", #selector(callTool))
+        ])
+        call.orientation = .horizontal
+        call.spacing = 8
+        toolNameField.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        argumentsField.setContentHuggingPriority(.init(1), for: .horizontal)
+
+        logView.isEditable = false
+        logView.font = .monospacedSystemFont(ofSize: 11, weight: .regular)
+        let scroll = NSScrollView()
+        scroll.documentView = logView
+        scroll.hasVerticalScroller = true
+
+        targetLabel.font = .monospacedSystemFont(ofSize: 11, weight: .regular)
+        targetLabel.lineBreakMode = .byTruncatingMiddle
+
+        let stack = NSStackView(views: [targetLabel, buttons, call, scroll])
+        stack.orientation = .vertical
+        stack.alignment = .leading
+        stack.spacing = 10
+        stack.edgeInsets = NSEdgeInsets(top: 12, left: 12, bottom: 12, right: 12)
+        stack.setHuggingPriority(.defaultLow, for: .vertical)
+        scroll.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            scroll.widthAnchor.constraint(equalTo: stack.widthAnchor, constant: -24),
+            scroll.heightAnchor.constraint(greaterThanOrEqualToConstant: 320)
+        ])
+        return stack
+    }
+
+    private func makeButton(_ title: String, _ action: Selector) -> NSButton {
+        let button = NSButton(title: title, target: self, action: action)
+        button.bezelStyle = .rounded
+        return button
+    }
+}
+
+/// Stands in for the `WKScriptMessage` a real page would send. Only `messageWebView` matters to the
+/// handlers — it is how the owner tab is resolved.
+private struct SyntheticUserScriptMessage: UserScriptMessage {
+    let name: String
+    let body: Any
+    let webView: WKWebView
+
+    var messageName: String { name }
+    var messageBody: Any { body }
+    var messageHost: String { "duck.ai" }
+    var isMainFrame: Bool { true }
+    var messageWebView: WKWebView? { webView }
+}
+
+#endif

--- a/macOS/DuckDuckGo/AIChat/BrowserTools/BrowserToolsDebugPanel.swift
+++ b/macOS/DuckDuckGo/AIChat/BrowserTools/BrowserToolsDebugPanel.swift
@@ -25,17 +25,10 @@ import WebKit
 
 /// DEBUG-only panel for exercising the Duck.ai browser tools bridge by hand.
 ///
-/// Duck.ai's own front end cannot drive this yet, and unlike Windows we cannot stand up a web
-/// harness to do it: WebView2 hands page scripts a raw native channel (`chrome.webview`), whereas
-/// on macOS the message handlers live in an isolated content world that page JavaScript cannot
-/// reach, and content-scope-scripts only grants the `aiChat` page-world bridge to
-/// duckduckgo.com / duck.co / duck.ai.
-///
-/// So this panel takes the front end's place from *inside* the app: it builds a real
-/// `AIChatUserScript`, resolves handlers through the same dispatch switch a page message would, and
-/// feeds them synthetic messages carrying a real web view. Everything below the JavaScript hop —
-/// dispatch, owner-tab resolution, session state, catalog gating, the invoker and the MCP
-/// envelopes — runs exactly as it does in production.
+/// A web page cannot do this on macOS: the message handlers live in an isolated content world page
+/// scripts cannot reach, and content-scope-scripts grants the `aiChat` page-world bridge only to
+/// duckduckgo.com / duck.co / duck.ai. So the panel stands in for the front end from inside the
+/// app, driving the same dispatch and handlers a page message would.
 @MainActor
 final class BrowserToolsDebugPanel: NSWindowController {
 
@@ -113,8 +106,8 @@ final class BrowserToolsDebugPanel: NSWindowController {
         ])
     }
 
-    /// `listOpenTabs` is not part of this change, so there is otherwise no way to discover a tabId
-    /// to hand to `switchToTab`. This reads the window directly rather than going through a tool.
+    /// Reads the window directly — there is no tool for discovering a tabId to hand to
+    /// `switchToTab`.
     @objc private func listWindowTabs() {
         guard let collection = windowControllersManager.lastKeyMainWindowController?
             .mainViewController.tabCollectionViewModel else {

--- a/macOS/DuckDuckGo/AIChat/BrowserTools/BrowserToolsDebugPanel.swift
+++ b/macOS/DuckDuckGo/AIChat/BrowserTools/BrowserToolsDebugPanel.swift
@@ -130,13 +130,22 @@ final class BrowserToolsDebugPanel: NSWindowController {
         appendToLog("")
     }
 
+    /// Sessions are keyed per owner tab, and the owner tab is re-read on every click — so selecting
+    /// a different tab between the handshake and a call silently moves you to a tab that has no
+    /// session. Showing the state makes that visible instead of surfacing it as `not_initialized`.
     @objc private func refreshTarget() {
         guard let tab = selectedTab else {
             targetLabel.stringValue = "No tab selected — open a tab to act as the Duck.ai owner tab."
             return
         }
         let burner = tab.burnerMode.isBurner ? "  ·  Fire Window" : ""
-        targetLabel.stringValue = "Owner tab: \(tab.uuid)\(burner)"
+        let session = NSApp.delegateTyped.aiChatBrowserToolsService.sessions.session(forOwnerTabID: tab.uuid)
+        let state = switch session {
+        case .none: "no session — run initialize"
+        case .some(let session) where !session.isInitialized: "awaiting notifications/initialized"
+        case .some: "initialized"
+        }
+        targetLabel.stringValue = "Owner tab: \(tab.uuid)\(burner)  ·  \(state)"
     }
 
     // MARK: -
@@ -164,6 +173,7 @@ final class BrowserToolsDebugPanel: NSWindowController {
         Task { @MainActor in
             let response = await invoke(params, SyntheticUserScriptMessage(name: method, body: params, webView: webView))
             appendToLog("← \(response.map(prettyPrinted) ?? "(no reply)")\n")
+            refreshTarget()
         }
     }
 

--- a/macOS/DuckDuckGo/AIChat/BrowserTools/SwitchToTabBrowserTool.swift
+++ b/macOS/DuckDuckGo/AIChat/BrowserTools/SwitchToTabBrowserTool.swift
@@ -1,0 +1,91 @@
+//
+//  SwitchToTabBrowserTool.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import AIChat
+import Foundation
+
+/// Switches to another tab in the window the chat belongs to.
+///
+/// `auto`, so it never prompts: it exposes nothing the user cannot already see, and only moves the
+/// selection they are looking at. `readOnlyHint` is still false because it does mutate UI state.
+@MainActor
+final class SwitchToTabBrowserTool: BrowserTool {
+
+    /// Matches `AIChatBrowserToolsSubfeature.switchToTab`, which is how the catalog gates it.
+    let name = "switchToTab"
+    let title = "Switch to tab"
+    let description = "Switch to an open tab in the current window by tabId from listOpenTabs."
+    let permissionMode = BrowserToolPermissionMode.auto
+
+    let inputSchema: JSONValue = [
+        "type": "object",
+        "properties": [
+            "tabId": ["type": "string", "description": "Tab ID from listOpenTabs (GUID string)."]
+        ],
+        "required": ["tabId"]
+    ]
+
+    let outputSchema: JSONValue? = [
+        "type": "object",
+        "properties": [
+            "tabId": ["type": "string"],
+            "title": ["type": "string"],
+            "url": ["type": "string"]
+        ],
+        "required": ["tabId", "title", "url"]
+    ]
+
+    let annotations: MCPToolAnnotations? = MCPToolAnnotations(readOnlyHint: false,
+                                                              destructiveHint: false,
+                                                              idempotentHint: true,
+                                                              openWorldHint: false)
+
+    private let windowControllersManager: WindowControllersManagerProtocol
+
+    init(windowControllersManager: WindowControllersManagerProtocol) {
+        self.windowControllersManager = windowControllersManager
+    }
+
+    func execute(arguments: JSONValue?, context: BrowserToolCallContext) async -> BrowserToolResult {
+        // Belt and braces behind the invoker's own check, so calling a tool directly cannot skip it.
+        guard !context.isBurner else { return .failure(.unavailable) }
+
+        guard let targetTabID = arguments?["tabId"]?.stringValue, !targetTabID.isEmpty else {
+            return .failure(.invalidArguments)
+        }
+
+        // Scoped to the window the chat lives in, mirroring the tool's own description. A tab in
+        // another window is reported as missing rather than switched to, so a chat cannot move the
+        // user's attention to a window they were not working in.
+        guard let ownerCollection = AIChatTabPickerSource.tabCollectionViewModel(containingTabWithID: context.ownerTabID,
+                                                                                in: windowControllersManager),
+              ownerCollection.indexInAllTabs(where: { $0.uuid == targetTabID }) != nil else {
+            return .failure(.notFound)
+        }
+
+        guard let tab = windowControllersManager.focusTab(byUUID: targetTabID) else {
+            return .failure(.notFound)
+        }
+
+        return .success([
+            "tabId": .string(targetTabID),
+            "title": .string(tab.title ?? ""),
+            "url": .string(tab.content.userEditableUrl?.absoluteString ?? "")
+        ])
+    }
+}

--- a/macOS/DuckDuckGo/AIChat/BrowserTools/SwitchToTabBrowserTool.swift
+++ b/macOS/DuckDuckGo/AIChat/BrowserTools/SwitchToTabBrowserTool.swift
@@ -19,10 +19,8 @@
 import AIChat
 import Foundation
 
-/// Switches to another tab in the window the chat belongs to.
-///
-/// `auto`, so it never prompts: it exposes nothing the user cannot already see, and only moves the
-/// selection they are looking at. `readOnlyHint` is still false because it does mutate UI state.
+/// Switches to another tab in the window the chat belongs to. Never prompts — it exposes nothing
+/// the user cannot already see — but `readOnlyHint` is false because it does mutate UI state.
 @MainActor
 final class SwitchToTabBrowserTool: BrowserTool {
 
@@ -69,10 +67,8 @@ final class SwitchToTabBrowserTool: BrowserTool {
             return .failure(.invalidArguments)
         }
 
-        // Scoped to the window the chat lives in: a tab elsewhere is reported missing rather than
-        // switched to, so a chat cannot pull the user to a window they were not working in.
-        // Selection happens inside that collection rather than by id, because a shared pinned tab
-        // resolves in every window and would otherwise raise the wrong one.
+        // Selection happens inside the chat's own window rather than by id: a shared pinned tab
+        // resolves in every window, so an id lookup could raise one the user was not working in.
         guard let token = context.ownerWindowToken,
               let collection = AIChatTabPickerSource.tabCollectionViewModel(forWindowToken: token,
                                                                            in: windowControllersManager),

--- a/macOS/DuckDuckGo/AIChat/BrowserTools/SwitchToTabBrowserTool.swift
+++ b/macOS/DuckDuckGo/AIChat/BrowserTools/SwitchToTabBrowserTool.swift
@@ -69,18 +69,18 @@ final class SwitchToTabBrowserTool: BrowserTool {
             return .failure(.invalidArguments)
         }
 
-        // Scoped to the window the chat lives in, mirroring the tool's own description. A tab in
-        // another window is reported as missing rather than switched to, so a chat cannot move the
-        // user's attention to a window they were not working in.
-        guard let ownerCollection = AIChatTabPickerSource.tabCollectionViewModel(containingTabWithID: context.ownerTabID,
-                                                                                in: windowControllersManager),
-              ownerCollection.indexInAllTabs(where: { $0.uuid == targetTabID }) != nil else {
+        // Scoped to the window the chat lives in: a tab elsewhere is reported missing rather than
+        // switched to, so a chat cannot pull the user to a window they were not working in.
+        // Selection happens inside that collection rather than by id, because a shared pinned tab
+        // resolves in every window and would otherwise raise the wrong one.
+        guard let token = context.ownerWindowToken,
+              let collection = AIChatTabPickerSource.tabCollectionViewModel(forWindowToken: token,
+                                                                           in: windowControllersManager),
+              let index = collection.indexInAllTabs(where: { $0.uuid == targetTabID }),
+              let tab = collection.selectTab(at: index) else {
             return .failure(.notFound)
         }
-
-        guard let tab = windowControllersManager.focusTab(byUUID: targetTabID) else {
-            return .failure(.notFound)
-        }
+        windowControllersManager.windowController(for: collection)?.window?.makeKeyAndOrderFront(nil)
 
         return .success([
             "tabId": .string(targetTabID),

--- a/macOS/DuckDuckGo/AIChat/UserScript/AIChatMessageHandler.swift
+++ b/macOS/DuckDuckGo/AIChat/UserScript/AIChatMessageHandler.swift
@@ -150,7 +150,8 @@ extension AIChatMessageHandler {
             installAge: AIChatNativeConfigValues.installAgeBucket(installDate: installDateProvider()),
             attachmentLimits: featureFlagger.isFeatureOn(.aiChatTabAttachmentLimit)
                 ? AIChatNativeAttachmentLimits(tabs: .init(maxAttached: AIChatOmnibarController.maxTabAttachments))
-                : nil
+                : nil,
+            supportsBrowserTools: featureFlagger.isFeatureOn(.aiChatBrowserTools)
         )
     }
 

--- a/macOS/DuckDuckGo/AIChat/UserScript/AIChatTabPickerSource.swift
+++ b/macOS/DuckDuckGo/AIChat/UserScript/AIChatTabPickerSource.swift
@@ -54,11 +54,8 @@ enum AIChatTabPickerSource {
         }
     }
 
-    /// An opaque handle for the window a call is scoped to.
-    ///
-    /// A tab id is not enough: pinned tabs are shared, so the same id appears in every window and
-    /// "the window holding this tab" is ambiguous. The origin collection is resolved once from the
-    /// sending web view, then carried through the call as this token.
+    /// Opaque handle for the window a call is scoped to. A tab id is not enough — pinned tabs are
+    /// shared, so "the window holding this tab" is ambiguous; this is resolved from the web view.
     static func windowToken(forCollection collection: TabCollectionViewModel) -> String {
         String(UInt(bitPattern: ObjectIdentifier(collection).hashValue))
     }

--- a/macOS/DuckDuckGo/AIChat/UserScript/AIChatTabPickerSource.swift
+++ b/macOS/DuckDuckGo/AIChat/UserScript/AIChatTabPickerSource.swift
@@ -54,6 +54,23 @@ enum AIChatTabPickerSource {
         }
     }
 
+    /// The tab collection that owns `tabID`, or nil when no open window holds it.
+    static func tabCollectionViewModel(containingTabWithID tabID: TabIdentifier,
+                                       in windowControllersManager: WindowControllersManagerProtocol) -> TabCollectionViewModel? {
+        windowControllersManager.allTabCollectionViewModels
+            .first { $0.indexInAllTabs(where: { $0.uuid == tabID }) != nil }
+    }
+
+    /// True when the owner tab lives in a Fire Window. Browser tools refuse there entirely.
+    ///
+    /// A tab we cannot place is treated as non-burner, matching Windows: the tool it belongs to
+    /// will fail its own lookup a moment later anyway, and assuming burner would break ordinary
+    /// calls whenever a tab is briefly unresolvable.
+    static func isBurner(ownerTabID: TabIdentifier,
+                         in windowControllersManager: WindowControllersManagerProtocol) -> Bool {
+        tabCollectionViewModel(containingTabWithID: ownerTabID, in: windowControllersManager)?.isBurner ?? false
+    }
+
     /// The Duck.ai owner tab for `webView`.
     ///
     /// A sidebar or detached Duck.ai window belongs to the tab it was opened from; a Duck.ai

--- a/macOS/DuckDuckGo/AIChat/UserScript/AIChatTabPickerSource.swift
+++ b/macOS/DuckDuckGo/AIChat/UserScript/AIChatTabPickerSource.swift
@@ -54,6 +54,23 @@ enum AIChatTabPickerSource {
         }
     }
 
+    /// The Duck.ai owner tab for `webView`.
+    ///
+    /// A sidebar or detached Duck.ai window belongs to the tab it was opened from; a Duck.ai
+    /// loaded as an ordinary tab owns itself. Browser-tool sessions and scoping are keyed on this,
+    /// so a sidebar and its host tab share one session.
+    static func ownerTabID(for webView: WKWebView?,
+                           in windowControllersManager: WindowControllersManagerProtocol) -> TabIdentifier? {
+        guard let webView else { return nil }
+        if let hostTabID = hostingAIChatViewController(of: webView)?.tabID {
+            return hostTabID
+        }
+        return windowControllersManager.allTabCollectionViewModels
+            .flatMap { ($0.pinnedTabsCollection?.loadedTabs ?? []) + $0.tabCollection.loadedTabs }
+            .first { $0.webView === webView }?
+            .uuid
+    }
+
     private static func hostingAIChatViewController(of webView: WKWebView) -> AIChatViewController? {
         var responder: NSResponder? = webView
         while let current = responder {

--- a/macOS/DuckDuckGo/AIChat/UserScript/AIChatTabPickerSource.swift
+++ b/macOS/DuckDuckGo/AIChat/UserScript/AIChatTabPickerSource.swift
@@ -54,28 +54,22 @@ enum AIChatTabPickerSource {
         }
     }
 
-    /// The tab collection that owns `tabID`, or nil when no open window holds it.
-    static func tabCollectionViewModel(containingTabWithID tabID: TabIdentifier,
+    /// An opaque handle for the window a call is scoped to.
+    ///
+    /// A tab id is not enough: pinned tabs are shared, so the same id appears in every window and
+    /// "the window holding this tab" is ambiguous. The origin collection is resolved once from the
+    /// sending web view, then carried through the call as this token.
+    static func windowToken(forCollection collection: TabCollectionViewModel) -> String {
+        String(UInt(bitPattern: ObjectIdentifier(collection).hashValue))
+    }
+
+    static func tabCollectionViewModel(forWindowToken token: String,
                                        in windowControllersManager: WindowControllersManagerProtocol) -> TabCollectionViewModel? {
-        windowControllersManager.allTabCollectionViewModels
-            .first { $0.indexInAllTabs(where: { $0.uuid == tabID }) != nil }
+        windowControllersManager.allTabCollectionViewModels.first { windowToken(forCollection: $0) == token }
     }
 
-    /// True when the owner tab lives in a Fire Window. Browser tools refuse there entirely.
-    ///
-    /// A tab we cannot place is treated as non-burner, matching Windows: the tool it belongs to
-    /// will fail its own lookup a moment later anyway, and assuming burner would break ordinary
-    /// calls whenever a tab is briefly unresolvable.
-    static func isBurner(ownerTabID: TabIdentifier,
-                         in windowControllersManager: WindowControllersManagerProtocol) -> Bool {
-        tabCollectionViewModel(containingTabWithID: ownerTabID, in: windowControllersManager)?.isBurner ?? false
-    }
-
-    /// The Duck.ai owner tab for `webView`.
-    ///
-    /// A sidebar or detached Duck.ai window belongs to the tab it was opened from; a Duck.ai
-    /// loaded as an ordinary tab owns itself. Browser-tool sessions and scoping are keyed on this,
-    /// so a sidebar and its host tab share one session.
+    /// The Duck.ai owner tab for `webView` — the host tab for a sidebar or detached window, the
+    /// chat's own tab otherwise. Sessions are keyed on it, so a sidebar and its host tab share one.
     static func ownerTabID(for webView: WKWebView?,
                            in windowControllersManager: WindowControllersManagerProtocol) -> TabIdentifier? {
         guard let webView else { return nil }

--- a/macOS/DuckDuckGo/AIChat/UserScript/AIChatUserScript.swift
+++ b/macOS/DuckDuckGo/AIChat/UserScript/AIChatUserScript.swift
@@ -211,6 +211,8 @@ final class AIChatUserScript: NSObject, Subfeature {
             return handler.mcpNotificationsInitialized
         case .toolsList:
             return handler.mcpToolsList
+        case .toolsCall:
+            return handler.mcpToolsCall
 
         case .reportMetric:
             return handler.reportMetric

--- a/macOS/DuckDuckGo/AIChat/UserScript/AIChatUserScript.swift
+++ b/macOS/DuckDuckGo/AIChat/UserScript/AIChatUserScript.swift
@@ -202,6 +202,16 @@ final class AIChatUserScript: NSObject, Subfeature {
             return handler.getAIChatOpenTabs
         case .getAIChatTabContent:
             return handler.getAIChatTabContent
+
+        // Browser tools. Answered regardless of the feature flag: the catalog is empty when it is
+        // off, so `tools/list` comes back empty rather than leaving the front end waiting.
+        case .initialize:
+            return handler.mcpInitialize
+        case .notificationsInitialized:
+            return handler.mcpNotificationsInitialized
+        case .toolsList:
+            return handler.mcpToolsList
+
         case .reportMetric:
             return handler.reportMetric
         case .togglePageContextTelemetry:

--- a/macOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
+++ b/macOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
@@ -1218,8 +1218,8 @@ extension AIChatUserScriptHandler {
 
     /// MCP `tools/list`.
     ///
-    /// A listing failure is reported as a top-level `error` token, unlike `tools/call`, which
-    /// carries failures inside the MCP result envelope.
+    /// A listing failure is a top-level `error` token, unlike `tools/call`, which carries failures
+    /// inside the MCP result envelope.
     @MainActor
     func mcpToolsList(params: Any, message: UserScriptMessage) async -> Encodable? {
         guard let ownerTabID = ownerTabID(for: message),
@@ -1227,6 +1227,13 @@ extension AIChatUserScriptHandler {
               session.isInitialized else {
             return BrowserToolsListResponse(failure: .notInitialized)
         }
+
+        // A Fire window advertises nothing, exactly as a disabled feature does. Listing the tools
+        // and then refusing every call would be a pair no other state produces, telling the front
+        // end it is in a Fire window.
+        let isBurner = AIChatTabPickerSource.originTabCollectionViewModel(for: message.messageWebView,
+                                                                          in: windowControllersManager)?.isBurner ?? true
+        guard !isBurner else { return BrowserToolsListResponse(tools: []) }
 
         return BrowserToolsListResponse(tools: browserTools.catalog.enabledTools.map { $0.descriptor() })
     }
@@ -1250,9 +1257,12 @@ extension AIChatUserScriptHandler {
             return InvokeBrowserToolResponse(callId: request.callId, result: .failure(.notInitialized))
         }
 
+        let originCollection = AIChatTabPickerSource.originTabCollectionViewModel(for: message.messageWebView,
+                                                                                  in: windowControllersManager)
         let context = BrowserToolCallContext(
             ownerTabID: ownerTabID,
-            isBurner: AIChatTabPickerSource.isBurner(ownerTabID: ownerTabID, in: windowControllersManager),
+            ownerWindowToken: originCollection.map(AIChatTabPickerSource.windowToken(forCollection:)),
+            isBurner: originCollection?.isBurner ?? true,
             supportsElicitationForm: session.supportsElicitationForm
         )
 

--- a/macOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
+++ b/macOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
@@ -1228,13 +1228,10 @@ extension AIChatUserScriptHandler {
             return BrowserToolsListResponse(failure: .notInitialized)
         }
 
-        // A Fire window advertises nothing, exactly as a disabled feature does. Listing the tools
-        // and then refusing every call would be a pair no other state produces, telling the front
-        // end it is in a Fire window.
-        let isBurner = AIChatTabPickerSource.originTabCollectionViewModel(for: message.messageWebView,
-                                                                          in: windowControllersManager)?.isBurner ?? true
-        guard !isBurner else { return BrowserToolsListResponse(tools: []) }
-
+        // Deliberately no Fire check here, mirroring Windows: a Fire window is advertised the full
+        // catalogue and refused on every call. That pair is detectable — a disabled feature returns
+        // an empty list — so it is a known cross-platform gap to close together rather than one
+        // platform diverging on its own.
         return BrowserToolsListResponse(tools: browserTools.catalog.enabledTools.map { $0.descriptor() })
     }
 

--- a/macOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
+++ b/macOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
@@ -1185,11 +1185,8 @@ extension AIChatUserScriptHandler: AIChatMetricReportingHandling {
 
 extension AIChatUserScriptHandler {
 
-    /// MCP `initialize`.
-    ///
-    /// Always answers, even when the payload is unreadable: the bridge has no timeout, so a
-    /// silent drop would leave the front end's promise pending forever. An unreadable payload
-    /// simply yields a session with no elicitation capability.
+    /// Always answers, even on an unreadable payload: the bridge has no timeout, so silence would
+    /// leave the caller pending forever.
     @MainActor
     func mcpInitialize(params: Any, message: UserScriptMessage) async -> Encodable? {
         let request: MCPInitializeRequest? = DecodableHelper.decode(from: params)
@@ -1204,10 +1201,8 @@ extension AIChatUserScriptHandler {
                                    serverVersion: AppVersion.shared.versionAndBuildNumber)
     }
 
-    /// MCP `notifications/initialized`.
-    ///
-    /// The bridge decides whether this reply is delivered — a message carrying an envelope `id`
-    /// gets it, a plain notification discards it — so returning a result is correct either way.
+    /// The bridge decides whether this reply is delivered — a message with an envelope `id` gets
+    /// it, a plain notification discards it — so returning a result is correct either way.
     @MainActor
     func mcpNotificationsInitialized(params: Any, message: UserScriptMessage) async -> Encodable? {
         if let ownerTabID = ownerTabID(for: message) {
@@ -1216,8 +1211,6 @@ extension AIChatUserScriptHandler {
         return MCPEmptyResult()
     }
 
-    /// MCP `tools/list`.
-    ///
     /// A listing failure is a top-level `error` token, unlike `tools/call`, which carries failures
     /// inside the MCP result envelope.
     @MainActor
@@ -1228,18 +1221,13 @@ extension AIChatUserScriptHandler {
             return BrowserToolsListResponse(failure: .notInitialized)
         }
 
-        // Deliberately no Fire check here, mirroring Windows: a Fire window is advertised the full
-        // catalogue and refused on every call. That pair is detectable — a disabled feature returns
-        // an empty list — so it is a known cross-platform gap to close together rather than one
-        // platform diverging on its own.
+        // No Fire check, mirroring Windows: a Fire window is advertised the catalogue and refused
+        // on every call. Detectable, and a known cross-platform gap to close on both sides together.
         return BrowserToolsListResponse(tools: browserTools.catalog.enabledTools.map { $0.descriptor() })
     }
 
-    /// MCP `tools/call`.
-    ///
-    /// Every outcome is a well-formed reply carrying the request's `callId`. A tool that refused
-    /// reports it through `isError` inside the MCP result; the envelope's own status describes the
-    /// round trip only, and is always `ok`.
+    /// Every outcome is a well-formed reply carrying the request's `callId`. A refusal rides in
+    /// `isError`; the envelope status describes the round trip only, and is always `ok`.
     @MainActor
     func mcpToolsCall(params: Any, message: UserScriptMessage) async -> Encodable? {
         guard let request: InvokeBrowserToolRequest = DecodableHelper.decode(from: params), !request.name.isEmpty else {

--- a/macOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
+++ b/macOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
@@ -124,6 +124,12 @@ protocol AIChatUserScriptHandling: AnyObject {
 
     @MainActor func getAIChatOpenTabs(params: Any, message: UserScriptMessage) async -> Encodable?
     @MainActor func getAIChatTabContent(params: Any, message: UserScriptMessage) async -> Encodable?
+
+    // MARK: Browser tools
+
+    @MainActor func mcpInitialize(params: Any, message: UserScriptMessage) async -> Encodable?
+    @MainActor func mcpNotificationsInitialized(params: Any, message: UserScriptMessage) async -> Encodable?
+    @MainActor func mcpToolsList(params: Any, message: UserScriptMessage) async -> Encodable?
     func togglePageContextTelemetry(params: Any, message: UserScriptMessage) -> Encodable?
     func reportMetric(params: Any, message: UserScriptMessage) async -> Encodable?
     func storeMigrationData(params: Any, message: UserScriptMessage) -> Encodable?
@@ -192,6 +198,7 @@ final class AIChatUserScriptHandler: AIChatUserScriptHandling {
     private let freeTrialConversionService: FreeTrialConversionInstrumentationService
     private let migrationStore = AIChatMigrationStore()
     private let voiceChatFailureHandler: DuckAiVoiceChatFailureHandling
+    private let browserTools: AIChatBrowserToolsService
 
     var isFireWindowProvider: (() -> Bool)?
 
@@ -222,11 +229,13 @@ final class AIChatUserScriptHandler: AIChatUserScriptHandling {
         freeTrialConversionService: FreeTrialConversionInstrumentationService = Application.appDelegate.freeTrialConversionService,
         notificationCenter: NotificationCenter = .default,
         voiceChatFailureHandler: DuckAiVoiceChatFailureHandling? = nil,
-        conversationSourceHandler: AIChatConversationSourceHandler = Application.appDelegate.aiChatConversationSourceHandler
+        conversationSourceHandler: AIChatConversationSourceHandler = Application.appDelegate.aiChatConversationSourceHandler,
+        browserTools: AIChatBrowserToolsService = Application.appDelegate.aiChatBrowserToolsService
     ) {
         self.storage = storage
         self.messageHandling = messageHandling
         self.windowControllersManager = windowControllersManager
+        self.browserTools = browserTools
         self.pixelFiring = pixelFiring
         self.aiChatUserScriptErrorEventMapper = aiChatUserScriptErrorEventMapper ?? AIChatUserScriptErrorEventMapper(pixelFiring: pixelFiring)
         self.statisticsLoader = statisticsLoader
@@ -1169,4 +1178,62 @@ extension AIChatUserScriptHandler: AIChatMetricReportingHandling {
         freeTrialConversionService.markDuckAIActivated()
     }
 
+}
+
+// MARK: - Browser tools
+
+extension AIChatUserScriptHandler {
+
+    /// MCP `initialize`.
+    ///
+    /// Always answers, even when the payload is unreadable: the bridge has no timeout, so a
+    /// silent drop would leave the front end's promise pending forever. An unreadable payload
+    /// simply yields a session with no elicitation capability.
+    @MainActor
+    func mcpInitialize(params: Any, message: UserScriptMessage) async -> Encodable? {
+        let request: MCPInitializeRequest? = DecodableHelper.decode(from: params)
+
+        if let ownerTabID = ownerTabID(for: message) {
+            browserTools.sessions.applyInitialize(forOwnerTabID: ownerTabID,
+                                                  protocolVersion: request?.protocolVersion,
+                                                  supportsElicitationForm: request?.supportsElicitationForm ?? false)
+        }
+
+        return MCPInitializeResult(serverName: AIChatBrowserToolsService.serverName,
+                                   serverVersion: AppVersion.shared.versionAndBuildNumber)
+    }
+
+    /// MCP `notifications/initialized`.
+    ///
+    /// The bridge decides whether this reply is delivered — a message carrying an envelope `id`
+    /// gets it, a plain notification discards it — so returning a result is correct either way.
+    @MainActor
+    func mcpNotificationsInitialized(params: Any, message: UserScriptMessage) async -> Encodable? {
+        if let ownerTabID = ownerTabID(for: message) {
+            browserTools.sessions.markInitialized(forOwnerTabID: ownerTabID)
+        }
+        return MCPEmptyResult()
+    }
+
+    /// MCP `tools/list`.
+    ///
+    /// A listing failure is reported as a top-level `error` token, unlike `tools/call`, which
+    /// carries failures inside the MCP result envelope.
+    @MainActor
+    func mcpToolsList(params: Any, message: UserScriptMessage) async -> Encodable? {
+        guard let ownerTabID = ownerTabID(for: message),
+              let session = browserTools.sessions.session(forOwnerTabID: ownerTabID),
+              session.isInitialized else {
+            return BrowserToolsListResponse(failure: .notInitialized)
+        }
+
+        return BrowserToolsListResponse(tools: browserTools.catalog.enabledTools.map { $0.descriptor() })
+    }
+
+    /// The Duck.ai owner tab this message belongs to — the host tab for a sidebar or detached
+    /// window, the chat's own tab otherwise. Sessions and tool scoping are keyed on it.
+    @MainActor
+    private func ownerTabID(for message: UserScriptMessage) -> TabIdentifier? {
+        AIChatTabPickerSource.ownerTabID(for: message.messageWebView, in: windowControllersManager)
+    }
 }

--- a/macOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
+++ b/macOS/DuckDuckGo/AIChat/UserScript/AIChatUserScriptHandling.swift
@@ -130,6 +130,7 @@ protocol AIChatUserScriptHandling: AnyObject {
     @MainActor func mcpInitialize(params: Any, message: UserScriptMessage) async -> Encodable?
     @MainActor func mcpNotificationsInitialized(params: Any, message: UserScriptMessage) async -> Encodable?
     @MainActor func mcpToolsList(params: Any, message: UserScriptMessage) async -> Encodable?
+    @MainActor func mcpToolsCall(params: Any, message: UserScriptMessage) async -> Encodable?
     func togglePageContextTelemetry(params: Any, message: UserScriptMessage) -> Encodable?
     func reportMetric(params: Any, message: UserScriptMessage) async -> Encodable?
     func storeMigrationData(params: Any, message: UserScriptMessage) -> Encodable?
@@ -1228,6 +1229,41 @@ extension AIChatUserScriptHandler {
         }
 
         return BrowserToolsListResponse(tools: browserTools.catalog.enabledTools.map { $0.descriptor() })
+    }
+
+    /// MCP `tools/call`.
+    ///
+    /// Every outcome is a well-formed reply carrying the request's `callId`. A tool that refused
+    /// reports it through `isError` inside the MCP result; the envelope's own status describes the
+    /// round trip only, and is always `ok`.
+    @MainActor
+    func mcpToolsCall(params: Any, message: UserScriptMessage) async -> Encodable? {
+        guard let request: InvokeBrowserToolRequest = DecodableHelper.decode(from: params), !request.name.isEmpty else {
+            // Recover the call id even from a payload we could not read, so the front end can still
+            // match the failure to the call it made rather than being left guessing.
+            return InvokeBrowserToolResponse(callId: Self.callID(fromRawParams: params), result: .failure(.invalidRequest))
+        }
+
+        guard let ownerTabID = ownerTabID(for: message),
+              let session = browserTools.sessions.session(forOwnerTabID: ownerTabID),
+              session.isInitialized else {
+            return InvokeBrowserToolResponse(callId: request.callId, result: .failure(.notInitialized))
+        }
+
+        let context = BrowserToolCallContext(
+            ownerTabID: ownerTabID,
+            isBurner: AIChatTabPickerSource.isBurner(ownerTabID: ownerTabID, in: windowControllersManager),
+            supportsElicitationForm: session.supportsElicitationForm
+        )
+
+        let result = await browserTools.invoker.invoke(toolNamed: request.name,
+                                                       arguments: request.arguments,
+                                                       context: context)
+        return InvokeBrowserToolResponse(callId: request.callId, result: result.callToolResult)
+    }
+
+    private static func callID(fromRawParams params: Any) -> String {
+        (params as? [String: Any])?["callId"] as? String ?? ""
     }
 
     /// The Duck.ai owner tab this message belongs to — the host tab for a sidebar or detached

--- a/macOS/DuckDuckGo/Application/AppDelegate.swift
+++ b/macOS/DuckDuckGo/Application/AppDelegate.swift
@@ -263,9 +263,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     let aiChatMenuConfiguration: AIChatMenuVisibilityConfigurable
     let aiChatSessionStore: AIChatSessionStoring
 
-    /// Owns the Duck.ai browser tools bridge — MCP sessions keyed by owner tab, plus the tool
-    /// catalog. App-wide because a sidebar and its host tab share one session, while each web
-    /// view gets its own `AIChatUserScript`.
+    /// App-wide because a sidebar and its host tab share one session, while each web view gets
+    /// its own `AIChatUserScript`.
     let aiChatBrowserToolsService: AIChatBrowserToolsService
     let aiChatPreferences: AIChatPreferences
     let promptBarPreferences: PromptBarPreferences

--- a/macOS/DuckDuckGo/Application/AppDelegate.swift
+++ b/macOS/DuckDuckGo/Application/AppDelegate.swift
@@ -677,7 +677,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         )
 
         aiChatSessionStore = AIChatSessionStore(featureFlagger: featureFlagger)
-        aiChatBrowserToolsService = AIChatBrowserToolsService(featureFlagger: featureFlagger)
         aiChatMenuConfiguration = AIChatMenuConfiguration(
             storage: DefaultAIChatPreferencesStorage(),
             remoteSettings: AIChatRemoteSettings(
@@ -859,6 +858,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         pinnedTabsManagerProvider.tabsPreferences = tabsPreferences
         pinnedTabsManagerProvider.windowControllersManager = windowControllersManager
+
+        aiChatBrowserToolsService = AIChatBrowserToolsService(featureFlagger: featureFlagger,
+                                                             windowControllersManager: windowControllersManager)
 
         contentScopePreferences = ContentScopePreferences(windowControllersManager: windowControllersManager)
         webTrackingProtectionPreferences = WebTrackingProtectionPreferences(persistor: WebTrackingProtectionPreferencesUserDefaultsPersistor(), windowControllersManager: windowControllersManager)

--- a/macOS/DuckDuckGo/Application/AppDelegate.swift
+++ b/macOS/DuckDuckGo/Application/AppDelegate.swift
@@ -262,6 +262,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     let aiChatConversationSourceHandler = AIChatConversationSourceHandler()
     let aiChatMenuConfiguration: AIChatMenuVisibilityConfigurable
     let aiChatSessionStore: AIChatSessionStoring
+
+    /// Owns the Duck.ai browser tools bridge — MCP sessions keyed by owner tab, plus the tool
+    /// catalog. App-wide because a sidebar and its host tab share one session, while each web
+    /// view gets its own `AIChatUserScript`.
+    let aiChatBrowserToolsService: AIChatBrowserToolsService
     let aiChatPreferences: AIChatPreferences
     let promptBarPreferences: PromptBarPreferences
     private(set) var aiChatHistoryCleaner: AIChatHistoryCleaning!
@@ -672,6 +677,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         )
 
         aiChatSessionStore = AIChatSessionStore(featureFlagger: featureFlagger)
+        aiChatBrowserToolsService = AIChatBrowserToolsService(featureFlagger: featureFlagger)
         aiChatMenuConfiguration = AIChatMenuConfiguration(
             storage: DefaultAIChatPreferencesStorage(),
             remoteSettings: AIChatRemoteSettings(

--- a/macOS/DuckDuckGo/Tab/UserScripts/UserScripts.swift
+++ b/macOS/DuckDuckGo/Tab/UserScripts/UserScripts.swift
@@ -142,12 +142,9 @@ final class UserScripts: UserScriptsProvider, ReleaseNotesUserScriptProvider {
                                            currentCohorts: currentCohorts,
                                            themeVariant: themeVariant)
         do {
-            // `aiChatBrowserTools` is native-only: Duck.ai gates on the `supportsBrowserTools` config
-            // value and never reads this key. Windows found that injecting it broke
-            // content-scope-scripts' aiChat message-bridge setup for the sidebar web view, and
-            // content-scope-scripts is shared across platforms, so keep it out of the injected config
-            // here too. A no-op until the feature is added to the remote privacy config, which is
-            // exactly the point — it cannot then be forgotten.
+            // Native-only: Duck.ai gates on the `supportsBrowserTools` config value and never reads
+            // this key. Windows found that injecting it broke content-scope-scripts' aiChat message
+            // bridge, and content-scope-scripts is shared, so keep it out here too.
             let nativeOnlyFeatures = [PrivacyFeature.aiChatBrowserTools.rawValue]
             let configGenerator = ContentScopePrivacyConfigurationJSONGenerator(
                 featureFlagger: sourceProvider.featureFlagger,

--- a/macOS/DuckDuckGo/Tab/UserScripts/UserScripts.swift
+++ b/macOS/DuckDuckGo/Tab/UserScripts/UserScripts.swift
@@ -142,9 +142,8 @@ final class UserScripts: UserScriptsProvider, ReleaseNotesUserScriptProvider {
                                            currentCohorts: currentCohorts,
                                            themeVariant: themeVariant)
         do {
-            // Native-only: Duck.ai gates on the `supportsBrowserTools` config value and never reads
-            // this key. Windows found that injecting it broke content-scope-scripts' aiChat message
-            // bridge, and content-scope-scripts is shared, so keep it out here too.
+            // Native-only — Duck.ai gates on `supportsBrowserTools` and never reads this key.
+            // Windows found injecting it broke the aiChat message bridge, which is shared code.
             let nativeOnlyFeatures = [PrivacyFeature.aiChatBrowserTools.rawValue]
             let configGenerator = ContentScopePrivacyConfigurationJSONGenerator(
                 featureFlagger: sourceProvider.featureFlagger,

--- a/macOS/DuckDuckGo/Tab/UserScripts/UserScripts.swift
+++ b/macOS/DuckDuckGo/Tab/UserScripts/UserScripts.swift
@@ -142,8 +142,21 @@ final class UserScripts: UserScriptsProvider, ReleaseNotesUserScriptProvider {
                                            currentCohorts: currentCohorts,
                                            themeVariant: themeVariant)
         do {
-            let configGenerator = ContentScopePrivacyConfigurationJSONGenerator(featureFlagger: sourceProvider.featureFlagger, privacyConfigurationManager: sourceProvider.privacyConfigurationManager, excludedFeatures: [PrivacyFeature.autoconsent.rawValue])
-            let isolatedConfigGenerator = ContentScopePrivacyConfigurationJSONGenerator(featureFlagger: sourceProvider.featureFlagger, privacyConfigurationManager: sourceProvider.privacyConfigurationManager)
+            // `aiChatBrowserTools` is native-only: Duck.ai gates on the `supportsBrowserTools` config
+            // value and never reads this key. Windows found that injecting it broke
+            // content-scope-scripts' aiChat message-bridge setup for the sidebar web view, and
+            // content-scope-scripts is shared across platforms, so keep it out of the injected config
+            // here too. A no-op until the feature is added to the remote privacy config, which is
+            // exactly the point — it cannot then be forgotten.
+            let nativeOnlyFeatures = [PrivacyFeature.aiChatBrowserTools.rawValue]
+            let configGenerator = ContentScopePrivacyConfigurationJSONGenerator(
+                featureFlagger: sourceProvider.featureFlagger,
+                privacyConfigurationManager: sourceProvider.privacyConfigurationManager,
+                excludedFeatures: [PrivacyFeature.autoconsent.rawValue] + nativeOnlyFeatures)
+            let isolatedConfigGenerator = ContentScopePrivacyConfigurationJSONGenerator(
+                featureFlagger: sourceProvider.featureFlagger,
+                privacyConfigurationManager: sourceProvider.privacyConfigurationManager,
+                excludedFeatures: ContentScopePrivacyConfigurationJSONGenerator.defaultExcludedFeatures + nativeOnlyFeatures)
             contentScopeUserScript = try ContentScopeUserScript(sourceProvider.privacyConfigurationManager, properties: prefs, scriptContext: .contentScope(surrogateTrackerData: sourceProvider.trackerProtectionDataSource?.surrogateFilteredTrackerData), allowedNonisolatedFeatures: [PageContextUserScript.featureName, "webCompat", TrackerProtectionSubfeature.featureNameValue], privacyConfigurationJSONGenerator: configGenerator)
             contentScopeUserScriptIsolated = try ContentScopeUserScript(sourceProvider.privacyConfigurationManager, properties: prefs, scriptContext: .contentScopeIsolated, privacyConfigurationJSONGenerator: isolatedConfigGenerator)
         } catch {

--- a/macOS/LocalPackages/FeatureFlags-macOS/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags-macOS/Sources/FeatureFlags/FeatureFlag.swift
@@ -519,9 +519,8 @@ public enum FeatureFlag: String, CaseIterable {
     /// and the warnings that will be built on top of it. Internal-only while the UI is in development.
     case aiChatUsageWarnings
 
-    /// Gates the Duck.ai browser tools bridge: the MCP-shaped contract that lets Duck.ai discover
-    /// and invoke native browser capabilities with per-tool user consent. Parent kill switch — with
-    /// it off there are no tools at all. Internal-only while the front end is in development.
+    /// Parent kill switch for the Duck.ai browser tools bridge — with it off there are no tools.
+    /// Internal-only while the front end is in development.
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1218321368831117?focus=true
     case aiChatBrowserTools
 

--- a/macOS/LocalPackages/FeatureFlags-macOS/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags-macOS/Sources/FeatureFlags/FeatureFlag.swift
@@ -519,6 +519,30 @@ public enum FeatureFlag: String, CaseIterable {
     /// and the warnings that will be built on top of it. Internal-only while the UI is in development.
     case aiChatUsageWarnings
 
+    /// Gates the Duck.ai browser tools bridge: the MCP-shaped contract that lets Duck.ai discover
+    /// and invoke native browser capabilities with per-tool user consent. Parent kill switch — with
+    /// it off there are no tools at all. Internal-only while the front end is in development.
+    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1218321368831117?focus=true
+    case aiChatBrowserTools
+
+    /// Gates the `listOpenTabs` browser tool. https://app.asana.com/1/137249556945/project/1211834678943996/task/1218321368831117?focus=true
+    case aiChatBrowserToolListOpenTabs
+
+    /// Gates the `searchHistory` browser tool. https://app.asana.com/1/137249556945/project/1211834678943996/task/1218321368831117?focus=true
+    case aiChatBrowserToolSearchHistory
+
+    /// Gates the `switchToTab` browser tool. https://app.asana.com/1/137249556945/project/1211834678943996/task/1218321368831117?focus=true
+    case aiChatBrowserToolSwitchToTab
+
+    /// Gates the `readTabContent` browser tool. https://app.asana.com/1/137249556945/project/1211834678943996/task/1218321368831117?focus=true
+    case aiChatBrowserToolReadTabContent
+
+    /// Gates the `findInPage` browser tool. https://app.asana.com/1/137249556945/project/1211834678943996/task/1218321368831117?focus=true
+    case aiChatBrowserToolFindInPage
+
+    /// Gates the `highlightInPage` browser tool. https://app.asana.com/1/137249556945/project/1211834678943996/task/1218321368831117?focus=true
+    case aiChatBrowserToolHighlightInPage
+
 }
 
 extension FeatureFlag: FeatureFlagDescribing {
@@ -868,6 +892,20 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(defaultValue: .enabled, source: .remoteReleasable(MacOSBrowserConfigSubfeature.bookmarksReorderByName))
         case .aiChatUsageWarnings:
             Config(defaultValue: .internalOnly, source: .remoteReleasable(AIChatSubfeature.usageWarnings), category: .duckAI)
+        case .aiChatBrowserTools:
+            Config(defaultValue: .internalOnly, source: .remoteReleasable(AIChatBrowserToolsSubfeature.featureEnabled), category: .duckAI)
+        case .aiChatBrowserToolListOpenTabs:
+            Config(defaultValue: .internalOnly, source: .remoteReleasable(AIChatBrowserToolsSubfeature.listOpenTabs), category: .duckAI)
+        case .aiChatBrowserToolSearchHistory:
+            Config(defaultValue: .internalOnly, source: .remoteReleasable(AIChatBrowserToolsSubfeature.searchHistory), category: .duckAI)
+        case .aiChatBrowserToolSwitchToTab:
+            Config(defaultValue: .internalOnly, source: .remoteReleasable(AIChatBrowserToolsSubfeature.switchToTab), category: .duckAI)
+        case .aiChatBrowserToolReadTabContent:
+            Config(defaultValue: .internalOnly, source: .remoteReleasable(AIChatBrowserToolsSubfeature.readTabContent), category: .duckAI)
+        case .aiChatBrowserToolFindInPage:
+            Config(defaultValue: .internalOnly, source: .remoteReleasable(AIChatBrowserToolsSubfeature.findInPage), category: .duckAI)
+        case .aiChatBrowserToolHighlightInPage:
+            Config(defaultValue: .internalOnly, source: .remoteReleasable(AIChatBrowserToolsSubfeature.highlightInPage), category: .duckAI)
         }
     }
 

--- a/macOS/UnitTests/AIChat/AIChatUserScriptTests.swift
+++ b/macOS/UnitTests/AIChat/AIChatUserScriptTests.swift
@@ -143,6 +143,35 @@ final class AIChatUserScriptTests: XCTestCase {
         XCTAssertTrue(mockHandler.didGetAIChatTabContent, "getAIChatTabContent should be called")
     }
 
+    // MARK: - Browser tools
+
+    @MainActor func testWhenInitializeIsReceivedThenItRoutesToTheMCPHandler() async throws {
+        let handler = try XCTUnwrap(userScript.handler(forMethodNamed: AIChatUserScriptMessages.initialize.rawValue))
+        _ = try await handler([""], WKScriptMessage.mock())
+
+        XCTAssertTrue(mockHandler.didCallMCPInitialize)
+    }
+
+    @MainActor func testWhenInitializedNotificationIsReceivedThenItRoutesToTheMCPHandler() async throws {
+        let handler = try XCTUnwrap(userScript.handler(forMethodNamed: AIChatUserScriptMessages.notificationsInitialized.rawValue))
+        _ = try await handler([""], WKScriptMessage.mock())
+
+        XCTAssertTrue(mockHandler.didCallMCPNotificationsInitialized)
+    }
+
+    @MainActor func testWhenToolsListIsReceivedThenItRoutesToTheMCPHandler() async throws {
+        let handler = try XCTUnwrap(userScript.handler(forMethodNamed: AIChatUserScriptMessages.toolsList.rawValue))
+        _ = try await handler([""], WKScriptMessage.mock())
+
+        XCTAssertTrue(mockHandler.didCallMCPToolsList)
+    }
+
+    /// `tools/call` lands in the next change; until then it must not resolve to a handler, so the
+    /// front end gets a method-not-found error rather than silence.
+    @MainActor func testWhenToolsCallIsReceivedThenNoHandlerResolvesYet() {
+        XCTAssertNil(userScript.handler(forMethodNamed: AIChatUserScriptMessages.toolsCall.rawValue))
+    }
+
     // MARK: - Open Settings handshake
 
     @MainActor func testRequestOpenSettingsActionArmsHandshake() {
@@ -374,6 +403,25 @@ final class MockAIChatUserScriptHandler: AIChatUserScriptHandling {
 
     func getAIChatTabContent(params: Any, message: UserScriptMessage) async -> Encodable? {
         didGetAIChatTabContent = true
+        return nil
+    }
+
+    var didCallMCPInitialize = false
+    var didCallMCPNotificationsInitialized = false
+    var didCallMCPToolsList = false
+
+    func mcpInitialize(params: Any, message: UserScriptMessage) async -> Encodable? {
+        didCallMCPInitialize = true
+        return nil
+    }
+
+    func mcpNotificationsInitialized(params: Any, message: UserScriptMessage) async -> Encodable? {
+        didCallMCPNotificationsInitialized = true
+        return nil
+    }
+
+    func mcpToolsList(params: Any, message: UserScriptMessage) async -> Encodable? {
+        didCallMCPToolsList = true
         return nil
     }
 

--- a/macOS/UnitTests/AIChat/AIChatUserScriptTests.swift
+++ b/macOS/UnitTests/AIChat/AIChatUserScriptTests.swift
@@ -166,10 +166,11 @@ final class AIChatUserScriptTests: XCTestCase {
         XCTAssertTrue(mockHandler.didCallMCPToolsList)
     }
 
-    /// `tools/call` lands in the next change; until then it must not resolve to a handler, so the
-    /// front end gets a method-not-found error rather than silence.
-    @MainActor func testWhenToolsCallIsReceivedThenNoHandlerResolvesYet() {
-        XCTAssertNil(userScript.handler(forMethodNamed: AIChatUserScriptMessages.toolsCall.rawValue))
+    @MainActor func testWhenToolsCallIsReceivedThenItRoutesToTheMCPHandler() async throws {
+        let handler = try XCTUnwrap(userScript.handler(forMethodNamed: AIChatUserScriptMessages.toolsCall.rawValue))
+        _ = try await handler([""], WKScriptMessage.mock())
+
+        XCTAssertTrue(mockHandler.didCallMCPToolsCall)
     }
 
     // MARK: - Open Settings handshake
@@ -409,6 +410,7 @@ final class MockAIChatUserScriptHandler: AIChatUserScriptHandling {
     var didCallMCPInitialize = false
     var didCallMCPNotificationsInitialized = false
     var didCallMCPToolsList = false
+    var didCallMCPToolsCall = false
 
     func mcpInitialize(params: Any, message: UserScriptMessage) async -> Encodable? {
         didCallMCPInitialize = true
@@ -422,6 +424,11 @@ final class MockAIChatUserScriptHandler: AIChatUserScriptHandling {
 
     func mcpToolsList(params: Any, message: UserScriptMessage) async -> Encodable? {
         didCallMCPToolsList = true
+        return nil
+    }
+
+    func mcpToolsCall(params: Any, message: UserScriptMessage) async -> Encodable? {
+        didCallMCPToolsCall = true
         return nil
     }
 

--- a/macOS/UnitTests/AIChat/BrowserTools/AIChatMCPSessionTests.swift
+++ b/macOS/UnitTests/AIChat/BrowserTools/AIChatMCPSessionTests.swift
@@ -1,0 +1,102 @@
+//
+//  AIChatMCPSessionTests.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+@testable import AIChat
+
+@MainActor
+final class AIChatMCPSessionTests: XCTestCase {
+
+    private let ownerTabID = "owner-tab"
+
+    /// `initialize` alone is not enough — tools traffic waits for `notifications/initialized`.
+    func testWhenInitializeIsAppliedThenTheSessionIsNotYetReady() {
+        let store = AIChatMCPSessionStore()
+
+        store.applyInitialize(forOwnerTabID: ownerTabID, protocolVersion: "2025-11-25", supportsElicitationForm: true)
+
+        let session = store.session(forOwnerTabID: ownerTabID)
+        XCTAssertEqual(session?.isInitialized, false)
+        XCTAssertEqual(session?.protocolVersion, "2025-11-25")
+        XCTAssertEqual(session?.supportsElicitationForm, true)
+    }
+
+    func testWhenInitializedNotificationArrivesThenTheSessionIsReady() {
+        let store = AIChatMCPSessionStore()
+
+        store.applyInitialize(forOwnerTabID: ownerTabID, protocolVersion: "2025-11-25", supportsElicitationForm: true)
+        store.markInitialized(forOwnerTabID: ownerTabID)
+
+        XCTAssertEqual(store.session(forOwnerTabID: ownerTabID)?.isInitialized, true)
+    }
+
+    /// A front end whose `initialize` timed out on its side can still confirm readiness. Refusing
+    /// would strand it with no way to list tools; instead it gets a session with no elicitation
+    /// capability, so Ask tools report `elicitation_unsupported` rather than prompting into the void.
+    func testWhenOnlyTheInitializedNotificationArrivesThenTheSessionIsReadyWithoutElicitation() {
+        let store = AIChatMCPSessionStore()
+
+        store.markInitialized(forOwnerTabID: ownerTabID)
+
+        let session = store.session(forOwnerTabID: ownerTabID)
+        XCTAssertEqual(session?.isInitialized, true)
+        XCTAssertEqual(session?.supportsElicitationForm, false)
+    }
+
+    /// Re-handshaking must not leave the previous readiness in place.
+    func testWhenInitializeIsRepeatedThenReadinessIsCleared() {
+        let store = AIChatMCPSessionStore()
+
+        store.applyInitialize(forOwnerTabID: ownerTabID, protocolVersion: "2025-11-25", supportsElicitationForm: true)
+        store.markInitialized(forOwnerTabID: ownerTabID)
+        store.applyInitialize(forOwnerTabID: ownerTabID, protocolVersion: "2025-11-25", supportsElicitationForm: false)
+
+        let session = store.session(forOwnerTabID: ownerTabID)
+        XCTAssertEqual(session?.isInitialized, false)
+        XCTAssertEqual(session?.supportsElicitationForm, false)
+    }
+
+    func testWhenSessionsAreKeyedByOwnerTabThenTheyDoNotLeakAcrossTabs() {
+        let store = AIChatMCPSessionStore()
+
+        store.markInitialized(forOwnerTabID: "tab-a")
+
+        XCTAssertEqual(store.session(forOwnerTabID: "tab-a")?.isInitialized, true)
+        XCTAssertNil(store.session(forOwnerTabID: "tab-b"))
+    }
+
+    func testWhenSessionIsRemovedThenItIsGone() {
+        let store = AIChatMCPSessionStore()
+        store.markInitialized(forOwnerTabID: ownerTabID)
+
+        store.removeSession(forOwnerTabID: ownerTabID)
+
+        XCTAssertNil(store.session(forOwnerTabID: ownerTabID))
+    }
+
+    func testWhenAllSessionsAreRemovedThenNoneRemain() {
+        let store = AIChatMCPSessionStore()
+        store.markInitialized(forOwnerTabID: "tab-a")
+        store.markInitialized(forOwnerTabID: "tab-b")
+
+        store.removeAllSessions()
+
+        XCTAssertNil(store.session(forOwnerTabID: "tab-a"))
+        XCTAssertNil(store.session(forOwnerTabID: "tab-b"))
+    }
+}

--- a/macOS/UnitTests/AIChat/BrowserTools/AIChatMCPSessionTests.swift
+++ b/macOS/UnitTests/AIChat/BrowserTools/AIChatMCPSessionTests.swift
@@ -45,9 +45,8 @@ final class AIChatMCPSessionTests: XCTestCase {
         XCTAssertEqual(store.session(forOwnerTabID: ownerTabID)?.isInitialized, true)
     }
 
-    /// A front end whose `initialize` timed out on its side can still confirm readiness. Refusing
-    /// would strand it with no way to list tools; instead it gets a session with no elicitation
-    /// capability, so Ask tools report `elicitation_unsupported` rather than prompting into the void.
+    /// A front end whose `initialize` timed out can still confirm readiness — refusing would
+    /// strand it with no way to list tools.
     func testWhenOnlyTheInitializedNotificationArrivesThenTheSessionIsReadyWithoutElicitation() {
         let store = AIChatMCPSessionStore()
 

--- a/macOS/UnitTests/AIChat/BrowserTools/BrowserToolCatalogTests.swift
+++ b/macOS/UnitTests/AIChat/BrowserTools/BrowserToolCatalogTests.swift
@@ -1,0 +1,107 @@
+//
+//  BrowserToolCatalogTests.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+@testable import AIChat
+
+@MainActor
+final class BrowserToolCatalogTests: XCTestCase {
+
+    func testWhenParentFeatureIsDisabledThenNoToolsAreListedOrResolvable() {
+        let configuration = StubBrowserToolsConfiguration(isEnabled: false, enabledToolNames: ["alpha", "beta"])
+        let catalog = BrowserToolCatalog(tools: [StubBrowserTool(name: "alpha"), StubBrowserTool(name: "beta")],
+                                         configuration: configuration)
+
+        XCTAssertTrue(catalog.enabledTools.isEmpty)
+        XCTAssertNil(catalog.tool(named: "alpha"))
+    }
+
+    /// A tool whose sub-feature is off must disappear from discovery *and* stop resolving, so a
+    /// front end that calls it anyway is told `unavailable` rather than having it run.
+    func testWhenToolSubFeatureIsDisabledThenItIsNeitherListedNorResolvable() {
+        let configuration = StubBrowserToolsConfiguration(isEnabled: true, enabledToolNames: ["alpha"])
+        let catalog = BrowserToolCatalog(tools: [StubBrowserTool(name: "alpha"), StubBrowserTool(name: "beta")],
+                                         configuration: configuration)
+
+        XCTAssertEqual(catalog.enabledTools.map(\.name), ["alpha"])
+        XCTAssertNotNil(catalog.tool(named: "alpha"))
+        XCTAssertNil(catalog.tool(named: "beta"))
+    }
+
+    func testWhenToolIsUnknownThenItDoesNotResolve() {
+        let configuration = StubBrowserToolsConfiguration(isEnabled: true, enabledToolNames: ["alpha"])
+        let catalog = BrowserToolCatalog(tools: [StubBrowserTool(name: "alpha")], configuration: configuration)
+
+        XCTAssertNil(catalog.tool(named: "nope"))
+    }
+
+    /// Registration order is what the front end sees, so it must not follow dictionary ordering.
+    func testWhenToolsAreListedThenRegistrationOrderIsPreserved() {
+        let names = ["zulu", "alpha", "mike"]
+        let configuration = StubBrowserToolsConfiguration(isEnabled: true, enabledToolNames: Set(names))
+        let catalog = BrowserToolCatalog(tools: names.map { StubBrowserTool(name: $0) }, configuration: configuration)
+
+        XCTAssertEqual(catalog.enabledTools.map(\.name), names)
+    }
+
+    func testWhenToolIsDescribedThenTheDescriptorCarriesItsSchemaAndAnnotations() {
+        let tool = StubBrowserTool(name: "alpha")
+
+        let descriptor = tool.descriptor()
+
+        XCTAssertEqual(descriptor.name, "alpha")
+        XCTAssertEqual(descriptor.title, "Alpha")
+        XCTAssertEqual(descriptor.inputSchema, ["type": "object"])
+        XCTAssertEqual(descriptor.annotations?.readOnlyHint, true)
+    }
+}
+
+// MARK: - Stubs
+
+private final class StubBrowserToolsConfiguration: BrowserToolsConfiguration {
+    let isEnabled: Bool
+    private let enabledToolNames: Set<String>
+
+    init(isEnabled: Bool, enabledToolNames: Set<String>) {
+        self.isEnabled = isEnabled
+        self.enabledToolNames = enabledToolNames
+    }
+
+    func isToolEnabled(named name: String) -> Bool {
+        isEnabled && enabledToolNames.contains(name)
+    }
+}
+
+private final class StubBrowserTool: BrowserTool {
+    let name: String
+    var title: String { name.capitalized }
+    var description: String { "Stub tool" }
+    var permissionMode: BrowserToolPermissionMode { .auto }
+    var inputSchema: JSONValue { ["type": "object"] }
+    var annotations: MCPToolAnnotations? {
+        MCPToolAnnotations(readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false)
+    }
+
+    init(name: String) {
+        self.name = name
+    }
+
+    func execute(arguments: JSONValue?, context: BrowserToolCallContext) async -> BrowserToolResult {
+        .success(["ok": true])
+    }
+}

--- a/macOS/UnitTests/AIChat/BrowserTools/BrowserToolInvokerTests.swift
+++ b/macOS/UnitTests/AIChat/BrowserTools/BrowserToolInvokerTests.swift
@@ -1,0 +1,155 @@
+//
+//  BrowserToolInvokerTests.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+@testable import AIChat
+
+/// The invoker owns every reason a call can be refused. Consent arrives in a later change; these
+/// cover the gates that exist now.
+@MainActor
+final class BrowserToolInvokerTests: XCTestCase {
+
+    func testWhenParentFeatureIsDisabledThenCallIsUnavailableAndToolDoesNotRun() async {
+        let tool = SpyBrowserTool(name: "alpha")
+        let invoker = makeInvoker(tools: [tool], isEnabled: false, enabledToolNames: ["alpha"])
+
+        let result = await invoker.invoke(toolNamed: "alpha", arguments: nil, context: context())
+
+        XCTAssertEqual(result, .failure(.unavailable))
+        XCTAssertFalse(tool.didExecute)
+    }
+
+    func testWhenToolIsUnknownThenCallIsUnavailable() async {
+        let invoker = makeInvoker(tools: [SpyBrowserTool(name: "alpha")], enabledToolNames: ["alpha"])
+
+        let result = await invoker.invoke(toolNamed: "nope", arguments: nil, context: context())
+
+        XCTAssertEqual(result, .failure(.unavailable))
+    }
+
+    /// A disabled sub-feature is indistinguishable from an unknown tool, on purpose.
+    func testWhenToolSubFeatureIsDisabledThenCallIsUnavailableAndToolDoesNotRun() async {
+        let tool = SpyBrowserTool(name: "alpha")
+        let invoker = makeInvoker(tools: [tool], enabledToolNames: [])
+
+        let result = await invoker.invoke(toolNamed: "alpha", arguments: nil, context: context())
+
+        XCTAssertEqual(result, .failure(.unavailable))
+        XCTAssertFalse(tool.didExecute)
+    }
+
+    /// Fire is reported as plain `unavailable` — never a Fire-specific token — so the front end
+    /// cannot infer that the user is browsing privately.
+    func testWhenCallIsInAFireWindowThenItIsUnavailableAndToolDoesNotRun() async {
+        let tool = SpyBrowserTool(name: "alpha")
+        let invoker = makeInvoker(tools: [tool], enabledToolNames: ["alpha"])
+
+        let result = await invoker.invoke(toolNamed: "alpha", arguments: nil, context: context(isBurner: true))
+
+        XCTAssertEqual(result, .failure(.unavailable))
+        XCTAssertFalse(tool.didExecute)
+    }
+
+    func testWhenToolIsEnabledThenItRunsAndItsResultIsReturned() async {
+        let tool = SpyBrowserTool(name: "alpha", result: .success(["switched": true]))
+        let invoker = makeInvoker(tools: [tool], enabledToolNames: ["alpha"])
+
+        let result = await invoker.invoke(toolNamed: "alpha", arguments: ["tabId": "abc"], context: context())
+
+        XCTAssertEqual(result, .success(["switched": true]))
+        XCTAssertTrue(tool.didExecute)
+        XCTAssertEqual(tool.receivedArguments, ["tabId": "abc"])
+    }
+
+    func testWhenToolRefusesThenItsFailureIsPassedThrough() async {
+        let tool = SpyBrowserTool(name: "alpha", result: .failure(.invalidArguments))
+        let invoker = makeInvoker(tools: [tool], enabledToolNames: ["alpha"])
+
+        let result = await invoker.invoke(toolNamed: "alpha", arguments: nil, context: context())
+
+        XCTAssertEqual(result, .failure(.invalidArguments))
+    }
+
+    func testWhenCallSucceedsThenItMapsOntoTheMCPEnvelopeWithoutError() {
+        let result = BrowserToolResult.success(["ok": true]).callToolResult
+
+        XCTAssertFalse(result.isError)
+        XCTAssertEqual(result.structuredContent, ["ok": true])
+    }
+
+    func testWhenCallFailsThenTheEnvelopeCarriesTheTokenAsTextAndNoStructuredContent() {
+        let result = BrowserToolResult.failure(.notFound).callToolResult
+
+        XCTAssertTrue(result.isError)
+        XCTAssertEqual(result.content.first?.text, "not_found")
+        XCTAssertNil(result.structuredContent)
+    }
+
+    // MARK: -
+
+    private func makeInvoker(tools: [any BrowserTool],
+                             isEnabled: Bool = true,
+                             enabledToolNames: Set<String>) -> BrowserToolInvoker {
+        let configuration = StubConfiguration(isEnabled: isEnabled, enabledToolNames: enabledToolNames)
+        return BrowserToolInvoker(catalog: BrowserToolCatalog(tools: tools, configuration: configuration),
+                                  configuration: configuration)
+    }
+
+    private func context(isBurner: Bool = false) -> BrowserToolCallContext {
+        BrowserToolCallContext(ownerTabID: "owner-tab", isBurner: isBurner, supportsElicitationForm: true)
+    }
+}
+
+// MARK: - Stubs
+
+private final class StubConfiguration: BrowserToolsConfiguration {
+    let isEnabled: Bool
+    private let enabledToolNames: Set<String>
+
+    init(isEnabled: Bool, enabledToolNames: Set<String>) {
+        self.isEnabled = isEnabled
+        self.enabledToolNames = enabledToolNames
+    }
+
+    func isToolEnabled(named name: String) -> Bool {
+        isEnabled && enabledToolNames.contains(name)
+    }
+}
+
+private final class SpyBrowserTool: BrowserTool {
+    let name: String
+    var title: String { "Spy" }
+    var description: String { "Spy tool" }
+    let permissionMode = BrowserToolPermissionMode.auto
+    var inputSchema: JSONValue { ["type": "object"] }
+
+    private(set) var didExecute = false
+    private(set) var receivedArguments: JSONValue?
+    private let result: BrowserToolResult
+
+    init(name: String, result: BrowserToolResult = .success([:])) {
+        self.name = name
+        self.result = result
+    }
+
+    func execute(arguments: JSONValue?, context: BrowserToolCallContext) async -> BrowserToolResult {
+        didExecute = true
+        receivedArguments = arguments
+        return result
+    }
+}

--- a/macOS/UnitTests/AIChat/BrowserTools/BrowserToolInvokerTests.swift
+++ b/macOS/UnitTests/AIChat/BrowserTools/BrowserToolInvokerTests.swift
@@ -19,8 +19,7 @@
 import XCTest
 @testable import AIChat
 
-/// The invoker owns every reason a call can be refused. Consent arrives in a later change; these
-/// cover the gates that exist now.
+/// The invoker owns every reason a call can be refused.
 @MainActor
 final class BrowserToolInvokerTests: XCTestCase {
 
@@ -85,6 +84,22 @@ final class BrowserToolInvokerTests: XCTestCase {
         XCTAssertEqual(result, .failure(.invalidArguments))
     }
 
+    /// Tools scope to the window handle rather than to the owner tab id, because a shared pinned
+    /// tab resolves in every window and would let a call act on the wrong one.
+    func testWhenCallIsInvokedThenTheToolReceivesTheOwnerWindowHandle() async {
+        let tool = SpyBrowserTool(name: "alpha")
+        let invoker = makeInvoker(tools: [tool], enabledToolNames: ["alpha"])
+        let context = BrowserToolCallContext(ownerTabID: "owner-tab",
+                                             ownerWindowToken: "window-1",
+                                             isBurner: false,
+                                             supportsElicitationForm: true)
+
+        _ = await invoker.invoke(toolNamed: "alpha", arguments: nil, context: context)
+
+        XCTAssertEqual(tool.receivedContext?.ownerWindowToken, "window-1")
+        XCTAssertEqual(tool.receivedContext?.ownerTabID, "owner-tab")
+    }
+
     func testWhenCallSucceedsThenItMapsOntoTheMCPEnvelopeWithoutError() {
         let result = BrowserToolResult.success(["ok": true]).callToolResult
 
@@ -111,7 +126,10 @@ final class BrowserToolInvokerTests: XCTestCase {
     }
 
     private func context(isBurner: Bool = false) -> BrowserToolCallContext {
-        BrowserToolCallContext(ownerTabID: "owner-tab", isBurner: isBurner, supportsElicitationForm: true)
+        BrowserToolCallContext(ownerTabID: "owner-tab",
+                               ownerWindowToken: "window-1",
+                               isBurner: isBurner,
+                               supportsElicitationForm: true)
     }
 }
 
@@ -140,6 +158,7 @@ private final class SpyBrowserTool: BrowserTool {
 
     private(set) var didExecute = false
     private(set) var receivedArguments: JSONValue?
+    private(set) var receivedContext: BrowserToolCallContext?
     private let result: BrowserToolResult
 
     init(name: String, result: BrowserToolResult = .success([:])) {
@@ -150,6 +169,7 @@ private final class SpyBrowserTool: BrowserTool {
     func execute(arguments: JSONValue?, context: BrowserToolCallContext) async -> BrowserToolResult {
         didExecute = true
         receivedArguments = arguments
+        receivedContext = context
         return result
     }
 }

--- a/macOS/UnitTests/AIChat/BrowserTools/BrowserToolsWireFormatTests.swift
+++ b/macOS/UnitTests/AIChat/BrowserTools/BrowserToolsWireFormatTests.swift
@@ -19,8 +19,8 @@
 import XCTest
 @testable import AIChat
 
-/// Pins the browser-tools wire format. These shapes are shared with the Windows browser and read
-/// by the Duck.ai front end, so a change here is a change to an agreed contract, not a refactor.
+/// Pins the browser-tools wire format: these shapes are shared with Windows and read by the Duck.ai
+/// front end, so changing one changes an agreed contract.
 final class BrowserToolsWireFormatTests: XCTestCase {
 
     // MARK: - initialize

--- a/macOS/UnitTests/AIChat/BrowserTools/BrowserToolsWireFormatTests.swift
+++ b/macOS/UnitTests/AIChat/BrowserTools/BrowserToolsWireFormatTests.swift
@@ -1,0 +1,231 @@
+//
+//  BrowserToolsWireFormatTests.swift
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import XCTest
+@testable import AIChat
+
+/// Pins the browser-tools wire format. These shapes are shared with the Windows browser and read
+/// by the Duck.ai front end, so a change here is a change to an agreed contract, not a refactor.
+final class BrowserToolsWireFormatTests: XCTestCase {
+
+    // MARK: - initialize
+
+    func testWhenInitializeResultIsEncodedThenItAdvertisesToolsWithListChanged() throws {
+        let result = MCPInitializeResult(serverName: "macos-browser", serverVersion: "1.2.3")
+
+        try assertEncodes(result, to: """
+        {
+          "protocolVersion": "2025-11-25",
+          "capabilities": { "tools": { "listChanged": true } },
+          "serverInfo": { "name": "macos-browser", "version": "1.2.3" }
+        }
+        """)
+    }
+
+    func testWhenServerVersionIsMissingThenTheKeyIsOmitted() throws {
+        let result = MCPInitializeResult(serverName: "macos-browser", serverVersion: nil)
+
+        try assertEncodes(result, to: """
+        {
+          "protocolVersion": "2025-11-25",
+          "capabilities": { "tools": { "listChanged": true } },
+          "serverInfo": { "name": "macos-browser" }
+        }
+        """)
+    }
+
+    func testWhenClientDeclaresElicitationFormObjectThenItIsSupported() throws {
+        let request = try decodeInitializeRequest("""
+        {
+          "protocolVersion": "2025-11-25",
+          "capabilities": { "elicitation": { "form": {} } },
+          "clientInfo": { "name": "duck.ai", "version": "1" }
+        }
+        """)
+
+        XCTAssertTrue(request.supportsElicitationForm)
+        XCTAssertEqual(request.protocolVersion, "2025-11-25")
+        XCTAssertEqual(request.clientInfo?.name, "duck.ai")
+    }
+
+    /// Only an object declares the capability — a truthy value does not.
+    func testWhenElicitationFormIsNotAnObjectThenItIsNotSupported() throws {
+        for form in ["true", "\"form\"", "null", "[]"] {
+            let request = try decodeInitializeRequest("""
+            { "protocolVersion": "2025-11-25", "capabilities": { "elicitation": { "form": \(form) } } }
+            """)
+
+            XCTAssertFalse(request.supportsElicitationForm, "expected form: \(form) not to declare support")
+        }
+    }
+
+    func testWhenCapabilitiesAreAbsentOrMalformedThenTheRequestStillDecodes() throws {
+        let payloads = [
+            #"{ "protocolVersion": "2025-11-25" }"#,
+            #"{ "protocolVersion": "2025-11-25", "capabilities": {} }"#,
+            #"{ "protocolVersion": "2025-11-25", "capabilities": { "elicitation": "nonsense" } }"#,
+            #"{ }"#
+        ]
+
+        for payload in payloads {
+            let request = try decodeInitializeRequest(payload)
+            XCTAssertFalse(request.supportsElicitationForm, "expected \(payload) not to declare support")
+        }
+    }
+
+    // MARK: - tools/list
+
+    func testWhenToolsAreListedThenDescriptorsAreEmittedVerbatim() throws {
+        let descriptor = BrowserToolDescriptor(
+            name: "switchToTab",
+            title: "Switch to tab",
+            description: "Switch to an open tab in the current window by tabId from listOpenTabs.",
+            inputSchema: ["type": "object", "properties": ["tabId": ["type": "string"]], "required": ["tabId"]],
+            outputSchema: ["type": "object"],
+            annotations: MCPToolAnnotations(readOnlyHint: false, destructiveHint: false, idempotentHint: true, openWorldHint: false)
+        )
+
+        try assertEncodes(BrowserToolsListResponse(tools: [descriptor]), to: """
+        {
+          "tools": [
+            {
+              "name": "switchToTab",
+              "title": "Switch to tab",
+              "description": "Switch to an open tab in the current window by tabId from listOpenTabs.",
+              "inputSchema": { "type": "object", "properties": { "tabId": { "type": "string" } }, "required": ["tabId"] },
+              "outputSchema": { "type": "object" },
+              "annotations": {
+                "readOnlyHint": false, "destructiveHint": false, "idempotentHint": true, "openWorldHint": false
+              }
+            }
+          ]
+        }
+        """)
+    }
+
+    /// A listing failure is a top-level token, unlike an invocation failure.
+    func testWhenSessionIsNotInitializedThenListingReportsATopLevelError() throws {
+        try assertEncodes(BrowserToolsListResponse(failure: .notInitialized), to: """
+        { "tools": [], "error": "not_initialized" }
+        """)
+    }
+
+    func testWhenListingSucceedsThenNoErrorKeyIsEmitted() throws {
+        let encoded = try encoded(BrowserToolsListResponse(tools: []))
+
+        XCTAssertNil(encoded["error"], "a successful listing must not carry an error token")
+    }
+
+    // MARK: - tools/call
+
+    func testWhenToolSucceedsThenResultCarriesStructuredContentAndItsTextForm() throws {
+        let response = InvokeBrowserToolResponse(callId: "call_abc",
+                                                 result: .success(["tabId": "abc", "title": "Example"]))
+
+        try assertEncodes(response, to: """
+        {
+          "callId": "call_abc",
+          "status": "ok",
+          "result": {
+            "content": [{ "type": "text", "text": "{\\"tabId\\":\\"abc\\",\\"title\\":\\"Example\\"}" }],
+            "isError": false,
+            "structuredContent": { "tabId": "abc", "title": "Example" }
+          }
+        }
+        """)
+    }
+
+    /// Tool failure is `isError` inside the MCP result. The outer status describes the round trip
+    /// only, so it stays `ok` — a failing tool is not a transport error.
+    func testWhenToolFailsThenStatusIsStillOkAndTheTokenIsTheTextContent() throws {
+        let response = InvokeBrowserToolResponse(callId: "call_abc", result: .failure(.denied))
+
+        try assertEncodes(response, to: """
+        {
+          "callId": "call_abc",
+          "status": "ok",
+          "result": {
+            "content": [{ "type": "text", "text": "denied" }],
+            "isError": true
+          }
+        }
+        """)
+    }
+
+    func testWhenToolFailsThenStructuredContentIsOmitted() throws {
+        let encoded = try encoded(InvokeBrowserToolResponse(callId: "c", result: .failure(.unavailable)))
+
+        XCTAssertNil(encoded["result"]?["structuredContent"])
+    }
+
+    func testWhenCallIsRequestedThenNameCallIdAndArgumentsAreRead() throws {
+        let data = try XCTUnwrap(#"{ "name": "listOpenTabs", "callId": "c1", "arguments": { "limit": 20 } }"#.data(using: .utf8))
+
+        let request = try JSONDecoder().decode(InvokeBrowserToolRequest.self, from: data)
+
+        XCTAssertEqual(request.name, "listOpenTabs")
+        XCTAssertEqual(request.callId, "c1")
+        XCTAssertEqual(request.arguments?["limit"]?.intValue, 20)
+    }
+
+    // MARK: - Failure tokens
+
+    /// The front end branches on these strings, so their spelling is part of the contract.
+    func testFailureTokenSpellings() {
+        XCTAssertEqual(BrowserToolFailure.invalidArguments.rawValue, "invalid_arguments")
+        XCTAssertEqual(BrowserToolFailure.notFound.rawValue, "not_found")
+        XCTAssertEqual(BrowserToolFailure.unavailable.rawValue, "unavailable")
+        XCTAssertEqual(BrowserToolFailure.denied.rawValue, "denied")
+        XCTAssertEqual(BrowserToolFailure.cancelled.rawValue, "cancelled")
+        XCTAssertEqual(BrowserToolFailure.elicitationUnsupported.rawValue, "elicitation_unsupported")
+        XCTAssertEqual(BrowserToolFailure.invalidPermissionChoice.rawValue, "invalid_permission_choice")
+        XCTAssertEqual(BrowserToolFailure.notInitialized.rawValue, "not_initialized")
+        XCTAssertEqual(BrowserToolFailure.invalidRequest.rawValue, "invalid_request")
+    }
+
+    // MARK: - Message names
+
+    /// These are the literal strings on the wire; the Swift case names are incidental.
+    func testMCPMessageNames() {
+        XCTAssertEqual(AIChatUserScriptMessages.initialize.rawValue, "initialize")
+        XCTAssertEqual(AIChatUserScriptMessages.notificationsInitialized.rawValue, "notifications/initialized")
+        XCTAssertEqual(AIChatUserScriptMessages.toolsList.rawValue, "tools/list")
+        XCTAssertEqual(AIChatUserScriptMessages.toolsCall.rawValue, "tools/call")
+    }
+
+    // MARK: -
+
+    private func encoded<T: Encodable>(_ value: T) throws -> JSONValue {
+        let data = try JSONEncoder().encode(value)
+        return try JSONDecoder().decode(JSONValue.self, from: data)
+    }
+
+    /// Compares parsed JSON rather than raw strings, so key ordering and whitespace do not make
+    /// the assertion brittle.
+    private func assertEncodes<T: Encodable>(_ value: T,
+                                             to expected: String,
+                                             file: StaticString = #filePath,
+                                             line: UInt = #line) throws {
+        XCTAssertEqual(try encoded(value), try JSONValue(jsonString: expected), file: file, line: line)
+    }
+
+    private func decodeInitializeRequest(_ json: String) throws -> MCPInitializeRequest {
+        let data = try XCTUnwrap(json.data(using: .utf8))
+        return try JSONDecoder().decode(MCPInitializeRequest.self, from: data)
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1148564399326804/task/1218275233507705
Tech Design URL: https://app.asana.com/1/137249556945/project/1148564399326804/task/1218275233507701
CC:

### Description

First of four PRs implementing the Duck.ai browser tools. This PR covers the session handshake, tool discovery, and invocation, which is enough for one working tool. 
<img width="714" height="427" alt="Screenshot 2026-09-10 at 13 10 35" src="https://github.com/user-attachments/assets/86e34ce9-a629-4af3-8df9-c4b0d2caef4d" />


See [the tech design](https://app.asana.com/1/137249556945/project/1148564399326804/task/1218275233507701) for more info

### Testing Steps

1. Open a couple of tabs in one window
2. Open browser tools testing panel: Debug ▸ AI Chat ▸ Browser Tools Panel…
3. Click `tools/list` → fails with `not_initialized`, since no session exists yet
4. Click `initialize` → returns the protocol version and server info; the header now reads `awaiting notifications/initialized`
5. Click `notifications/initialized` → header in the testing panel now shows `initialized`
6. Click `tools/list` → returns the `switchToTab` descriptor
7. Click `Show tab IDs`, 
8. Copy one tab (not the current one) and paste it into the arguments field (`{"tabId": "4CDD4DC3-3F95-41B4-8D65-1FD18A470B3A"}`)
9. Click `Call` → **the browser switches to that tab,** and the reply echoes your call id with `isError: false`

### Impact

Low. No user-facing change: the feature is internal-only and off by default, and no front end can reach it.

#### What could go wrong?

- The BrowserServicesKit push change affects every subscription event on both platforms → mitigated by tests that execute the generated JavaScript for identifier, slashed, and quote-containing names; bracket notation is equivalent for every name shipping today.
- A tool could act on the wrong window, or reach across the Fire boundary → mitigated by scoping to the owner tab's window and refusing burner windows, both tested.

### Quality Considerations

Nothing leaves the device. The only tool switches between tabs the user already has open, and reports no page content.

Fire windows refuse every tool before it runs, with the same neutral `unavailable` a disabled feature gives — no error names Fire. Note that `tools/list` still advertises the catalogue there, matching the Windows browser: listing everything and then refusing every call is a pair no other state produces, so the situation remains inferable. That gap is deliberately kept identical across platforms rather than fixed on one, and is being raised with the Windows team to close on both.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new native↔web path that can change browser UI (tab focus) and changes subscription JS generation for all platforms; mitigated by internal-only flags, session gating, Fire/window scoping, and tests.
> 
> **Overview**
> Introduces a **Duck.ai browser tools bridge** on macOS: MCP-shaped messages (`initialize`, `notifications/initialized`, `tools/list`, `tools/call`) over the existing `aiChat` user-script channel, with per–owner-tab sessions, remote-config gating, and a pluggable tool catalog/invoker in shared **AIChat**.
> 
> Native config gains **`supportsBrowserTools`** so the web app only opens a session when the bridge exists. Privacy config and macOS feature flags add **`aiChatBrowserTools`** plus per-tool subfeatures; content-scope injection **excludes** that feature so it does not break the shared bridge. The first shipped tool is **`switchToTab`**, scoped to the chat window via an owner-tab/window token and refused in Fire windows as generic `unavailable`.
> 
> Wiring includes app-wide **`AIChatBrowserToolsService`**, handler routing in **`AIChatUserScript`**, and a DEBUG **Browser Tools Panel** for manual handshake/testing. **`SubscriptionEvent.toJS`** now uses bracket notation and JSON-escaped handler names so names like `notifications/initialized` work; tests execute the generated JS.
> 
> Unit tests cover session lifecycle, catalog/invoker gating, wire JSON contracts, and message routing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2618ccd11dd399518d52cdb5b28ae0b559cb8eb1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



