### PR TITLE
[iOS] Reduce memory used when checking large URLs for threats

### DIFF
--- a/SharedPackages/BrowserServicesKit/Tests/MaliciousSiteProtectionTests/MaliciousSiteDetectorTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/MaliciousSiteProtectionTests/MaliciousSiteDetectorTests.swift
@@ -72,9 +72,9 @@ class MaliciousSiteDetectorTests: XCTestCase {
 
     func testWhenThreatMarkerIsAtEndOfLargeQueryThenLocalAndAPIMatchesDetectIt() async throws {
         let hostHash = "255a8a793097aeea1f06a19c08cde28db0eb34c660c6e4e7480c9525d034b16d"
-        let regex = #"^https://malicious\.com/phishing\?q=a+&marker=threat$"#
+        let regex = #"^https://malicious\.com/phishing\?q=(?:a/)+&marker=threat$"#
         let filter = Filter(hash: hostHash, regex: regex)
-        let url = try XCTUnwrap(URL(string: "https://malicious.com/PHISHING?q=" + String(repeating: "A", count: 100_000) + "&MARKER=THREAT"))
+        let url = try XCTUnwrap(URL(string: "https://malicious.com/PHISHING?q=" + String(repeating: "A///", count: 100_000) + "&MARKER=THREAT"))
         try await mockDataManager.store(HashPrefixSet(revision: 0, items: ["255a8a79"]), for: .hashPrefixes(threatKind: .phishing))
 
         var apiCallCount = 0

--- a/SharedPackages/BrowserServicesKit/Tests/MaliciousSiteProtectionTests/MaliciousSiteProtectionURLTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/MaliciousSiteProtectionTests/MaliciousSiteProtectionURLTests.swift
@@ -55,4 +55,30 @@ class MaliciousSiteProtectionURLTests: XCTestCase {
         XCTAssertEqual(url.canonicalURL()?.absoluteString, "http://example.com/phishing#section")
     }
 
+    func testWhenURLHasRepeatedSlashesThenCanonicalizationPreservesSchemeAndCollapsesSlashScalars() throws {
+        let cases = [
+            ("https://example.com/", "https://example.com/"),
+            ("https://example.com//A///B?q=HTTPS://OTHER.COM///C", "https://example.com/a/b?q=https:/other.com/c"),
+            ("https://example.com/%2F%2FA?q=%2F%2FB", "https://example.com/a?q=/b"),
+            ("https://example.com//\u{0301}A?q=//\u{0301}B", "https://example.com/%CC%81a?q=/%CC%81b")
+        ]
+
+        for (input, expected) in cases {
+            let url = try XCTUnwrap(URL(string: input))
+
+            XCTAssertEqual(url.canonicalURL()?.absoluteString, expected)
+        }
+    }
+
+    func testWhenURLHasLargeQueryThenCanonicalizationPreservesItsEndWithOrWithoutRepeatedSlashes() throws {
+        for segment in ["A", "A/", "A///"] {
+            let payload = String(repeating: segment, count: 1_000_000)
+            let url = try XCTUnwrap(URL(string: "https://example.com/PHISHING?q=\(payload)&MARKER=THREAT"))
+            let expectedSegment = segment == "A" ? "a" : "a/"
+            let expected = "https://example.com/phishing?q=" + String(repeating: expectedSegment, count: 1_000_000) + "&marker=threat"
+
+            XCTAssertEqual(url.canonicalURL()?.absoluteString, expected)
+        }
+    }
+
 }

--- a/SharedPackages/Common/Sources/Common/Extensions/URLExtension.swift
+++ b/SharedPackages/Common/Sources/Common/Extensions/URLExtension.swift
@@ -698,10 +698,18 @@ extension URL {
         }
 
         // Step 5: Remove all occurrences of more than one "/", but not in the protocol part
-        if let range = urlString.range(of: "://") {
-            let protocolPart = urlString[..<range.upperBound]
-            let restOfURL = urlString[range.upperBound...]
-            urlString = protocolPart + restOfURL.replacingOccurrences(of: "/+", with: "/", options: .regularExpression)
+        if let range = urlString.range(of: "://"), urlString.range(of: "//", options: .literal, range: range.upperBound..<urlString.endIndex) != nil {
+            // Avoid regex replacement allocations for large URLs, while preserving the complete query for threat matching.
+            var collapsedURL = String(urlString[..<range.upperBound])
+            collapsedURL.reserveCapacity(urlString.utf8.count)
+            var previousWasSlash = false
+            for scalar in urlString[range.upperBound...].unicodeScalars {
+                if scalar != "/" || !previousWasSlash {
+                    collapsedURL.unicodeScalars.append(scalar)
+                }
+                previousWasSlash = scalar == "/"
+            }
+            urlString = collapsedURL
         }
 
         // Step 6: Remove all occurrences of "/./" in the path


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214294661819890/task/1218349233057142?focus=true

### Description

Reduce memory used when checking very large URLs for malicious content, addressing the allocation failure reported in [APPLE-IOS-FWRP](https://errors.duckduckgo.com/organizations/ddg/issues/APPLE-IOS-FWRP/?project=8). Complete URLs, including threat markers at the end of long queries, continue to be checked. This supplements the mitigation in #6745.

### Testing Steps

Run these checks in an iOS build of this PR. Enable **Site Safety Warnings** in **Settings → Scam Blocker**. Use a new tab for each warning check. Do not bypass warnings until steps 1–4 are complete.

1. Open the [Malicious Site Protection test page](https://privacy-test-pages.site/security/badware/). Open **Standard Phishing Test**, then **Standard Malware Test**. Each link should show the corresponding warning.

2. Paste `https://privacy-test-pages.site//security///badware//phishing.html` into the address bar. Expect the phishing warning despite the repeated path slashes.

3. Paste `https://privacy-test-pages.site/%2Fsecurity/%2Fbadware/%2Fphishing.html` into the address bar. Expect the same phishing warning after the app normalizes the encoded slashes.

4. From the test page, open **Phishing page flagged in the local data (doesn't require API request)**. Expect a phishing warning.

5. Paste `https://privacy-test-pages.site/security/badware/?q=A/B//C///D&marker=END` into the address bar. Expect the test index to load without a warning or crash. Copy the loaded URL from the address bar. Check that the query still contains `q=A/B//C///D&marker=END`. Normalization for threat checks must not rewrite the navigation URL.

6. Open **Standard Phishing Test** in a new tab. Select **Leave This Site** on the warning. Expect to leave the warning page. Open a normal site. Switch tabs. Browsing should work normally.

I have not run these proposed manual checks. They check functional behavior, not the multi-megabyte allocation improvement. Do not add query strings to the phishing or malware test URLs. The test rules can require an exact URL match. The UI cannot prove whether local or API matching handled a standard test URL.

### Impact

High if incorrect: the shared URL processing affects malicious-site protection on iOS and macOS. The intended blocking behavior is unchanged.

#### What could go wrong?

- Changing slash normalization could prevent a threat from matching → tests cover path/query normalization, encoded slashes, root URLs, and slash-adjacent combining marks.
- Shortening or skipping large URLs could bypass protection → full-output assertions and local/API matching tests retain and detect the query's final threat marker; no length cutoff is introduced.

### Quality Considerations

- Automated validation completed on macOS: 77 Common URL tests and 73 MaliciousSiteProtection tests passed.
- The Sentry stack confirms an out-of-memory exception during regex slash replacement. Replace that operation with a single Unicode-scalar pass, and skip replacement when no repeated slashes exist.
- #6520 is a plausible release-specific trigger: it first appears in 7.236 build 13 and reduces allocations before malicious-site evaluation. The previous cleaner also preserved large URLs, and canonicalization did not change between 7.235 and 7.236. Causality remains unconfirmed.
- The report contains neither the offending URL nor its size. The exact iOS crash was not reproduced; later URL transformations still allocate memory proportional to input size.

A synthetic macOS release benchmark compared the full canonicalization function at `475adc25b8` with this patch using 10,000,000-byte query payloads. These are medians of three fresh processes per version and payload; full outputs and hashes matched in all runs. Peak RSS includes input creation and output verification. This measures allocation improvement, not on-device crash reproduction.

| Query payload | Peak RSS before | Peak RSS after |
| --- | ---: | ---: |
| Plain text | 64.4 MiB | 44.7 MiB |
| Repeated `A/` | 473.4 MiB | 44.7 MiB |
| Repeated `A///` | 270.3 MiB | 35.2 MiB |

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)
