### PR TITLE
[iOS] Reduce link-cleaning work for large Cocoa-backed URLs

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/LinkProtection/LinkCleaner.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/BrowserServicesKit/LinkProtection/LinkCleaner.swift
@@ -128,46 +128,40 @@ private struct PercentEncodedQueryFilter {
     }
 
     func filter(url: URL) -> URL? {
-        let source = url.relativeString
-        let bytes = source.utf8
+        var source = url.relativeString
+        // Acquire Cocoa-backed UTF-8 storage once instead of looking up its pointer for every byte.
+        return source.withUTF8 { bytes in
+            let fragmentStart = bytes.firstIndex(of: ASCII.numberSign) ?? bytes.endIndex
+            guard let questionMark = bytes[..<fragmentStart].firstIndex(of: ASCII.questionMark) else {
+                return nil
+            }
 
-        let fragmentStart = bytes.firstIndex(of: ASCII.numberSign) ?? bytes.endIndex
-        guard let questionMark = bytes[..<fragmentStart].firstIndex(of: ASCII.questionMark) else {
-            return nil
+            let queryRange = (questionMark + 1)..<fragmentStart
+            guard !queryRange.isEmpty,
+                  let inspection = inspectQuery(in: bytes, range: queryRange) else { return nil }
+
+            let cleanedURLString = rebuildURLString(bytes: bytes, queryRange: queryRange, inspection: inspection)
+            if cleanedURLString.isEmpty {
+                return URLComponents().url(relativeTo: url.baseURL)
+            }
+            return URL(string: cleanedURLString, relativeTo: url.baseURL)
         }
-
-        let queryStart = bytes.index(after: questionMark)
-        let queryRange = queryStart..<fragmentStart
-        guard !queryRange.isEmpty,
-              let inspection = inspectQuery(in: source, bytes: bytes, range: queryRange) else { return nil }
-
-        let cleanedURLString = rebuildURLString(
-            source,
-            bytes: bytes,
-            queryRange: queryRange,
-            inspection: inspection
-        )
-        if cleanedURLString.isEmpty {
-            return URLComponents().url(relativeTo: url.baseURL)
-        }
-        return URL(string: cleanedURLString, relativeTo: url.baseURL)
     }
 
     private func inspectQuery(
-        in source: String,
-        bytes: String.UTF8View,
-        range: Range<String.Index>
+        in bytes: UnsafeBufferPointer<UInt8>,
+        range: Range<Int>
     ) -> QueryInspection? {
         var didRemoveParameters = false
         var preservedItemCount = 0
         var preservedItemByteCount = 0
 
         forEachQueryItem(in: bytes, range: range) { itemRange in
-            if isTrackingParameter(in: source, bytes: bytes, itemRange: itemRange) {
+            if isTrackingParameter(in: bytes, itemRange: itemRange) {
                 didRemoveParameters = true
             } else {
                 preservedItemCount += 1
-                preservedItemByteCount += bytes.distance(from: itemRange.lowerBound, to: itemRange.upperBound)
+                preservedItemByteCount += itemRange.count
             }
         }
 
@@ -179,76 +173,76 @@ private struct PercentEncodedQueryFilter {
     }
 
     private func rebuildURLString(
-        _ source: String,
-        bytes: String.UTF8View,
-        queryRange: Range<String.Index>,
+        bytes: UnsafeBufferPointer<UInt8>,
+        queryRange: Range<Int>,
         inspection: QueryInspection
     ) -> String {
-        let questionMark = bytes.index(before: queryRange.lowerBound)
+        let questionMark = queryRange.lowerBound - 1
         let fragmentStart = queryRange.upperBound
-        let prefixByteCount = bytes.distance(from: bytes.startIndex, to: questionMark)
-        let fragmentByteCount = bytes.distance(from: fragmentStart, to: bytes.endIndex)
+        let fragmentByteCount = bytes.count - fragmentStart
         let separatorByteCount = max(inspection.preservedItemCount - 1, 0)
         let queryByteCount = inspection.preservedItemCount > 0
             ? 1 + inspection.preservedItemByteCount + separatorByteCount
             : 0
+        let capacity = questionMark + queryByteCount + fragmentByteCount
 
-        var result = String()
-        result.reserveCapacity(prefixByteCount + queryByteCount + fragmentByteCount)
-        result.append(contentsOf: source[..<questionMark])
+        // Copy directly into the final string so large surviving items need no temporary strings.
+        return String(unsafeUninitializedCapacity: capacity) { output in
+            var written = 0
 
-        if inspection.preservedItemCount > 0 {
-            result.append("?")
-            var didAppendItem = false
-
-            forEachQueryItem(in: bytes, range: queryRange) { itemRange in
-                guard !isTrackingParameter(in: source, bytes: bytes, itemRange: itemRange) else {
-                    return
-                }
-
-                if didAppendItem {
-                    result.append("&")
-                }
-                result.append(contentsOf: source[itemRange])
-                didAppendItem = true
+            func append(_ range: Range<Int>) {
+                written = output[written...].initialize(fromContentsOf: bytes[range])
             }
-        }
 
-        result.append(contentsOf: source[fragmentStart...])
-        return result
+            append(bytes.startIndex..<questionMark)
+
+            if inspection.preservedItemCount > 0 {
+                output[written] = ASCII.questionMark
+                written += 1
+                var didAppendItem = false
+
+                forEachQueryItem(in: bytes, range: queryRange) { itemRange in
+                    guard !isTrackingParameter(in: bytes, itemRange: itemRange) else {
+                        return
+                    }
+
+                    if didAppendItem {
+                        output[written] = ASCII.ampersand
+                        written += 1
+                    }
+                    append(itemRange)
+                    didAppendItem = true
+                }
+            }
+
+            append(fragmentStart..<bytes.endIndex)
+            return written
+        }
     }
 
     private func forEachQueryItem(
-        in bytes: String.UTF8View,
-        range: Range<String.Index>,
-        perform action: (Range<String.Index>) -> Void
+        in bytes: UnsafeBufferPointer<UInt8>,
+        range: Range<Int>,
+        perform action: (Range<Int>) -> Void
     ) {
         var itemStart = range.lowerBound
-        var index = range.lowerBound
-
-        while index != range.upperBound {
-            if bytes[index] == ASCII.ampersand {
-                action(itemStart..<index)
-                itemStart = bytes.index(after: index)
-            }
-            index = bytes.index(after: index)
+        for index in range where bytes[index] == ASCII.ampersand {
+            action(itemStart..<index)
+            itemStart = index + 1
         }
-
         action(itemStart..<range.upperBound)
     }
 
     private func isTrackingParameter(
-        in source: String,
-        bytes: String.UTF8View,
-        itemRange: Range<String.Index>
+        in bytes: UnsafeBufferPointer<UInt8>,
+        itemRange: Range<Int>
     ) -> Bool {
-        let nameEnd = bytes[itemRange].firstIndex(of: ASCII.equalsSign) ?? itemRange.upperBound
-        // A name longer than every configured name can't match, and rejecting it here keeps the
-        // temporary String bounded by configuration rather than by page-controlled input.
-        let nameBytes = bytes[itemRange.lowerBound..<nameEnd]
-        guard nameBytes.dropFirst(maximumParameterNameByteCount).isEmpty else {
+        // Include the byte after the longest possible name so '=' at that boundary still matches.
+        // Searching the whole item first can rescan megabytes of a name that cannot match.
+        let nameEnd = bytes[itemRange].prefix(maximumParameterNameByteCount + 1).firstIndex(of: ASCII.equalsSign) ?? itemRange.upperBound
+        guard nameEnd - itemRange.lowerBound <= maximumParameterNameByteCount else {
             return false
         }
-        return parameterNames.contains(String(source[itemRange.lowerBound..<nameEnd]))
+        return parameterNames.contains(String(decoding: bytes[itemRange.lowerBound..<nameEnd], as: UTF8.self))
     }
 }

--- a/SharedPackages/BrowserServicesKit/Tests/BrowserServicesKitTests/LinkProtection/URLParameterTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/BrowserServicesKitTests/LinkProtection/URLParameterTests.swift
@@ -145,6 +145,29 @@ final class URLParameterTests: XCTestCase {
         XCTAssertFalse(linkCleaner.urlParametersRemoved)
     }
 
+    func testWhenParameterNameReachesLengthLimitThenOnlyExactMatchesAreRemoved() throws {
+        let config = MockPrivacyConfiguration()
+        config.featureSettings = ["parameters": ["track"]]
+        let linkCleaner = LinkCleaner(privacyManager: MockPrivacyConfigurationManager(privacyConfig: config))
+        let testCases = [
+            (query: "track=value&safe=1", expected: "safe=1", removed: true),
+            (query: "track&safe=1", expected: "safe=1", removed: true),
+            (query: "tracks=value&safe=1", expected: "tracks=value&safe=1", removed: false),
+            (query: "tracks&safe=1", expected: "tracks&safe=1", removed: false),
+            (query: "safe&track=value", expected: "safe", removed: true),
+            (query: "&track=&", expected: "&", removed: true)
+        ]
+
+        for testCase in testCases {
+            let url = try XCTUnwrap(URL(string: "https://example.com/?\(testCase.query)"))
+
+            let result = linkCleaner.cleanTrackingParameters(initiator: nil, url: url)
+
+            XCTAssertEqual(result?.absoluteString, "https://example.com/?\(testCase.expected)")
+            XCTAssertEqual(linkCleaner.urlParametersRemoved, testCase.removed)
+        }
+    }
+
     func testURLParamStrippingSupportsLargeTrackingParameterValue() throws {
         let largeValue = String(repeating: "a", count: 1_000_000)
         let url = try XCTUnwrap(URL(string: "https://example.com/?safe=1&utm_source=\(largeValue)#fragment"))
@@ -176,6 +199,31 @@ final class URLParameterTests: XCTestCase {
 
         XCTAssertEqual(result?.absoluteString, "https://example.com/?\(largeName)#fragment")
         XCTAssertTrue(linkCleaner.urlParametersRemoved)
+    }
+
+    func testWhenURLIsBridgedFromNSURLThenLargeQueryItemsAreCleaned() throws {
+        let config = MockPrivacyConfiguration()
+        config.featureSettings = ["parameters": ["track"]]
+        let linkCleaner = LinkCleaner(privacyManager: MockPrivacyConfigurationManager(privacyConfig: config))
+        let largeItem = String(repeating: "a", count: 1_000_000)
+        let testCases = [
+            (query: "\(largeItem)&track=x", expected: largeItem, removed: true),
+            (query: "\(largeItem)=x&track=x", expected: "\(largeItem)=x", removed: true),
+            (query: "track=\(largeItem)&safe=1", expected: "safe=1", removed: true),
+            (query: largeItem, expected: largeItem, removed: false)
+        ]
+
+        for testCase in testCases {
+            let input = "https://example.com/?\(testCase.query)#fragment"
+            // WebKit URLs can retain Cocoa string storage, unlike URLs built from native Swift strings.
+            let string = try input.withCString { try XCTUnwrap(NSString(utf8String: $0)) }
+            let url = try XCTUnwrap(NSURL(string: string as String)) as URL
+
+            let result = linkCleaner.cleanTrackingParameters(initiator: nil, url: url)
+
+            XCTAssertEqual(result?.absoluteString, "https://example.com/?\(testCase.expected)#fragment")
+            XCTAssertEqual(linkCleaner.urlParametersRemoved, testCase.removed)
+        }
     }
 
     func testURLParamStrippingPreservesRelativeURLAndBaseURL() throws {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214294661819890/task/1218362083473998?focus=true
Tech Design URL: N/A
CC:

### Description

Reduce link-cleaning work for very large URLs to address the suspected watchdog regression in iOS 7.236.0. Preserve query parameter removal, percent encoding, fragments, and relative URLs.

### Testing Steps

1. Run `xcodebuildmcp swift-package test --package-path SharedPackages/BrowserServicesKit --filter URLParameterTests`. Expect all 10 tests to pass, including name-length boundaries and large Cocoa-backed URLs.
2. Run the checks on the [query-parameter protection test page](https://privacy-test-pages.site/privacy-protections/query-parameters/). Confirm that tracking parameters are removed and surviving URL content stays intact.

Completed: all 10 focused tests passed on macOS. An independent local harness compared the old and new parsers across 18,432 URL/configuration cases; all results matched. Manual browser testing remains outstanding.

### Impact

High: this shared code participates in navigation and tracking-parameter removal on iOS and macOS.

#### What could go wrong?

- Incorrect parameter boundaries could preserve tracking parameters or remove legitimate data; boundary tests and differential checks cover these cases.
- Incorrect output allocation or copying could corrupt a URL; existing tests cover empty output, empty items, fragments, relative URLs, and large values.
- A storage change could restore costly scans for Cocoa-backed URLs; the added NSURL cases exercise that input path.

### Quality Considerations

The affected parser arrived in #6520 (`398f850e8f`), first included in iOS 7.236.0 build 13. Sentry captures a parameter-name scan with repeated CoreFoundation access. The triggering URL is absent, so the exact watchdog event could not be replayed.

- Acquire the UTF-8 buffer once to avoid repeated CoreFoundation pointer lookups during byte scans.
- Bound parameter-name searches by the longest configured name, including the next byte for an equals sign at the boundary.
- Preserve the two-pass design and copy surviving bytes directly into the final string, without a full source copy or large temporary parameter strings.
- Local release benchmark, 10 MB Cocoa-backed query with no equals sign: median 358 ms before, 14 ms after (about 25 times faster). These are macOS measurements, not device watchdog timings.
- Swift slices retain their parent indices. The evidence supports a performance defect, not the previously suggested invalid-index loop.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)
