### PR TITLE
iOS: Use native material for the embedded floating address bar

### DIFF
--- a/SharedPackages/Infrastructure/DesignResourcesKit/Sources/DesignResourcesKit/Colors/ColorPalettes/DefaultColorPalette.swift
+++ b/SharedPackages/Infrastructure/DesignResourcesKit/Sources/DesignResourcesKit/Colors/ColorPalettes/DefaultColorPalette.swift
@@ -343,7 +343,7 @@ struct DefaultColorPalette: ColorPaletteDefinition {
         case .floatingAddressBarBackground:
             return DynamicColor(lightColor: .shade(0.05), darkColor: .tint(0.08))
         case .floatingEmbeddedAddressBarBackground:
-            return DynamicColor(lightColor: .shade(0.05), darkColor: .tint(0.08))
+            return DynamicColor(lightColor: .shade(0.06), darkColor: .tint(0.03))
         case .unifiedToggleInputAttachmentErrorBannerBackground:
             return DynamicColor(lightColor: xF6CDD1, darkColor: x5A2A2A)
         case .unifiedToggleInputAttachmentErrorText:

--- a/iOS/DuckDuckGo/DefaultOmniBarView.swift
+++ b/iOS/DuckDuckGo/DefaultOmniBarView.swift
@@ -916,6 +916,8 @@ final class DefaultOmniBarView: UIView, OmniBarView, ExpandableOmniBarView {
 
             setFieldBackgroundColor(.clear)
             searchAreaContainerView.layoutIfNeeded()
+            // The new glassEffect has no corner radius yet; only layoutSubviews() sets it otherwise.
+            applyOmnibarCornerStyle()
         }
     }
 

--- a/iOS/DuckDuckGo/DefaultOmniBarView.swift
+++ b/iOS/DuckDuckGo/DefaultOmniBarView.swift
@@ -768,9 +768,18 @@ final class DefaultOmniBarView: UIView, OmniBarView, ExpandableOmniBarView {
         UITraitCollection(userInterfaceStyle: configuration.interfaceStyle).performAsCurrent {
             if #available(iOS 26.0, *) {
                 if configuration.kind == .embedded {
-                    // Flat fill: the chrome underneath is already glass.
-                    view = UIVisualEffectView(effect: nil)
-                    view.backgroundColor = UIColor(singleUseColor: .floatingEmbeddedAddressBarBackground)
+                    // Native regular material, tinted so it still reads as our surface colour.
+                    view = UIVisualEffectView(effect: UIBlurEffect(style: .systemMaterial))
+                    let tintView = UIView()
+                    tintView.backgroundColor = UIColor(singleUseColor: .floatingEmbeddedAddressBarBackground)
+                    tintView.translatesAutoresizingMaskIntoConstraints = false
+                    view.contentView.addSubview(tintView)
+                    NSLayoutConstraint.activate([
+                        tintView.topAnchor.constraint(equalTo: view.contentView.topAnchor),
+                        tintView.leadingAnchor.constraint(equalTo: view.contentView.leadingAnchor),
+                        tintView.trailingAnchor.constraint(equalTo: view.contentView.trailingAnchor),
+                        tintView.bottomAnchor.constraint(equalTo: view.contentView.bottomAnchor)
+                    ])
                 } else {
                     let effect = UIGlassEffect(style: .regular)
                     if configuration.fireMode {
@@ -783,6 +792,9 @@ final class DefaultOmniBarView: UIView, OmniBarView, ExpandableOmniBarView {
         }
         if configuration.kind == .embedded {
             view.overrideUserInterfaceStyle = configuration.interfaceStyle
+            // `cornerConfiguration` only shapes glass effects; a classic UIBlurEffect needs a
+            // manual capsule radius, kept in sync with its height in `applyOmnibarCornerStyle()`.
+            view.clipsToBounds = true
         }
         return view
     }
@@ -1730,6 +1742,11 @@ final class DefaultOmniBarView: UIView, OmniBarView, ExpandableOmniBarView {
         searchAreaContainerView.layer.cornerRadius = cornerRadius
         searchAreaView.layer.cornerRadius = cornerRadius
         activeOutlineView.layer.cornerRadius = cornerRadius + Metrics.activeBorderWidth
+
+        // The embedded field's classic UIBlurEffect ignores `cornerConfiguration`; radius it by hand.
+        if glassEffectConfiguration?.kind == .embedded {
+            glassEffect.layer.cornerRadius = glassEffect.bounds.height / 2
+        }
 
         // The pre-iOS 26 blur fallback needs an explicit capsule radius (iOS 26 uses `.capsule()`).
         if #unavailable(iOS 26.0) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414235014887631/task/1216033800174500
Tech Design URL: N/A
CC: 

## Description
The embedded (bottom floating) address field previously used a flat colour fill instead of a real material. Switches it to `UIBlurEffect(.systemMaterial)`, tinted with `floatingEmbeddedAddressBarBackground` so it still reads as our surface colour rather than a plain system blur.

`cornerConfiguration` (the iOS 26 concentric-corner API) only shapes glass effects, not classic `UIBlurEffect`, so the capsule radius is now set by hand on the embedded field's layer, kept in sync with its height in `applyOmnibarCornerStyle()`.

`floatingEmbeddedAddressBarBackground` also moves off its one-off 5%/8% shade/tint values onto the design system's standard scale: 6% black in light mode, 3% white in dark mode.

### Testing Steps
1. Enable Floating UI, move the address bar to the bottom.
2. Light mode: confirm the address field reads as a subtly darkened material capsule, fully rounded on both ends.
3. Dark mode: confirm the same, with a subtle light tint instead.
4. Focus the field (opens Unified Toggle Input) and dismiss it — confirm no flash of a stray gray background during the transition.

### Impact
Low: visual-only change to the bottom floating address field's surface and two colour token values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual-only omnibar and design-token tweaks for the bottom floating address field; no auth, data, or business-logic changes.
> 
> **Overview**
> The **bottom embedded floating address bar** no longer uses a flat color fill on iOS 26+ floating UI. It now uses **`UIBlurEffect(.systemMaterial)`** with a full-bleed tint of `floatingEmbeddedAddressBarBackground` so the field reads as a real material while keeping the branded surface color.
> 
> Because **`cornerConfiguration` does not clip classic blur**, the embedded glass gets **`clipsToBounds`**, a **manual capsule `layer.cornerRadius`** (half height) in `applyOmnibarCornerStyle()`, and an extra **`applyOmnibarCornerStyle()`** call when glass is rebuilt so corners are correct before layout.
> 
> The **`floatingEmbeddedAddressBarBackground`** token shifts to the standard scale: **6% shade (light)** and **3% tint (dark)** instead of 5%/8%.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89f4462935bbab4b1099abf63a69e37c9a2ea55a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->