### PR TITLE
[macOS] Add pixels for the simplified Sync setup screens

### DIFF
--- a/macOS/DuckDuckGo/Preferences/Model/SyncDialogController.swift
+++ b/macOS/DuckDuckGo/Preferences/Model/SyncDialogController.swift
@@ -469,6 +469,7 @@ extension SyncDialogController: ManagementDialogModelDelegate {
             do {
                 let devices = try await syncService.updateDeviceName(name)
                 mapDevices(devices)
+                pixelFiring?.fire(SyncSettingsPixelKitEvent.thisDeviceDetailsNameUpdated)
                 managementDialogModel.endFlow()
             } catch {
                 if case SyncError.unauthenticatedWhileLoggedIn = error {
@@ -482,6 +483,9 @@ extension SyncDialogController: ManagementDialogModelDelegate {
     }
 
     func presentRemoveDeviceConfirmation(_ device: SyncDevice) {
+        pixelFiring?.fire(device.isCurrent
+                          ? SyncSettingsPixelKitEvent.thisDeviceDetailsTurnOffSyncTapped
+                          : SyncSettingsPixelKitEvent.otherDeviceDetailsRemoveDeviceTapped)
         presentDialog(for: .removeDeviceV2(device))
     }
 
@@ -588,6 +592,25 @@ extension SyncDialogController: ManagementDialogModelDelegate {
         pixelFiring?.fire(SyncSettingsPixelKitEvent.anotherDevicePromptShown)
     }
 
+    func syncSuccessViewDidAppear() {
+        pixelFiring?.fire(SyncSettingsPixelKitEvent.successScreenShown)
+    }
+
+    func syncSuccessCopyCodePressed(_ code: String) {
+        pixelFiring?.fire(SyncSettingsPixelKitEvent.successScreenCopyCodeTapped)
+        copyCode(code)
+    }
+
+    func syncSuccessSaveRecoveryPDFPressed() {
+        pixelFiring?.fire(SyncSettingsPixelKitEvent.successScreenDownloadRecoveryPDFTapped)
+        saveRecoveryPDF(requiresAuthentication: false)
+    }
+
+    func syncSuccessDonePressed() {
+        pixelFiring?.fire(SyncSettingsPixelKitEvent.successScreenDoneTapped)
+        managementDialogModel.endFlow()
+    }
+
     func syncThisDeviceOnlyFromPrompt() async {
         guard !managementDialogModel.isConnecting else { return }
         pixelFiring?.fire(SyncSettingsPixelKitEvent.anotherDevicePromptOptionTapped(option: .thisDeviceOnly))
@@ -617,6 +640,7 @@ extension SyncDialogController: ManagementDialogModelDelegate {
     }
 
     func enterRecoveryCodePressed() {
+        pixelFiring?.fire(SyncSettingsPixelKitEvent.recoveryConfirmedTapped)
         startPollingForRecoveryKey(isRecovery: true)
     }
 
@@ -677,11 +701,18 @@ extension SyncDialogController: ManagementDialogModelDelegate {
         let continuation = authenticationCancelledPromptContinuation
         authenticationCancelledPromptContinuation = nil
         managementDialogModel.currentDialog = nil
-        guard let continuation,
-              await userAuthenticator.authenticateUser(reason: .syncSettings).authenticated else {
+        guard let continuation else {
+            pixelFiring?.fire(SyncSettingsPixelKitEvent.authenticationCancelledPromptDismissed)
             managementDialogModel.endFlow()
             return
         }
+        pixelFiring?.fire(SyncSettingsPixelKitEvent.authenticationCancelledPromptRetryTapped)
+        guard await userAuthenticator.authenticateUser(reason: .syncSettings).authenticated else {
+            pixelFiring?.fire(SyncSettingsPixelKitEvent.authenticationCancelledPromptRetryFailed)
+            managementDialogModel.endFlow()
+            return
+        }
+        pixelFiring?.fire(SyncSettingsPixelKitEvent.authenticationCancelledPromptRetrySucceeded)
         continuation()
     }
 
@@ -716,6 +747,9 @@ extension SyncDialogController: SyncSettingsViewHandling {
         guard await checkAuthenticated() else {
             return
         }
+        pixelFiring?.fire(device.isCurrent
+                          ? SyncSettingsPixelKitEvent.thisDeviceDetailsScreenShown
+                          : SyncSettingsPixelKitEvent.otherDeviceDetailsScreenShown)
         presentDialog(for: .deviceDetailsV2(device))
     }
 
@@ -752,6 +786,7 @@ extension SyncDialogController: SyncSettingsViewHandling {
 
     @MainActor
     func syncWithServerPressed() async {
+        pixelFiring?.fire(SyncSettingsPixelKitEvent.backUpThisDeviceTapped)
         let isSimplifiedSetupV2 = featureFlagger.isFeatureOn(.simplifiedSyncSetupV2)
         guard await checkAuthenticated(presentDialogOnCancel: isSimplifiedSetupV2,
                                        continueAfterPromptRetry: { [weak self] in
@@ -773,6 +808,7 @@ extension SyncDialogController: SyncSettingsViewHandling {
 
     @MainActor
     func recoverDataPressed() async {
+        pixelFiring?.fire(SyncSettingsPixelKitEvent.recoverSyncedDataTapped)
         guard await checkAuthenticated() else {
             return
         }

--- a/macOS/DuckDuckGo/Preferences/Model/SyncPreferences.swift
+++ b/macOS/DuckDuckGo/Preferences/Model/SyncPreferences.swift
@@ -204,6 +204,7 @@ final class SyncPreferences: ObservableObject, SyncUI_macOS.ManagementViewModel 
 
     private let syncPausedStateManager: any SyncPausedStateManaging
     let syncSettingsHandler: SyncSettingsViewHandling
+    private let pixelFiring: PixelFiring?
 
     private func updateSyncFeatureFlags(_ syncFeatureFlags: SyncFeatureFlags) {
         isDataSyncingAvailable = syncFeatureFlags.contains(.dataSyncing)
@@ -234,7 +235,8 @@ final class SyncPreferences: ObservableObject, SyncUI_macOS.ManagementViewModel 
         userAuthenticator: UserAuthenticating = DeviceAuthenticator.shared,
         syncPausedStateManager: any SyncPausedStateManaging,
         connectionControllerFactory: ((DDGSyncing, SyncConnectionControllerDelegate) -> SyncConnectionControlling)? = nil,
-        featureFlagger: FeatureFlagger = Application.appDelegate.featureFlagger
+        featureFlagger: FeatureFlagger = Application.appDelegate.featureFlagger,
+        pixelFiring: PixelFiring? = PixelKit.shared
     ) {
         self.syncService = syncService
         self.syncBookmarksAdapter = syncBookmarksAdapter
@@ -245,6 +247,7 @@ final class SyncPreferences: ObservableObject, SyncUI_macOS.ManagementViewModel 
         self.syncFeatureFlags = syncService.featureFlags
         self.syncPausedStateManager = syncPausedStateManager
         self.featureFlagger = featureFlagger
+        self.pixelFiring = pixelFiring
         self.isAppRebranded = DesignSystemRebrand.isAppRebranded()
         self.isAIChatSyncEnabled = featureFlagger.isFeatureOn(.aiChatSync)
         self.isSimplifiedSyncSetupV2Enabled = featureFlagger.isFeatureOn(.simplifiedSyncSetupV2)
@@ -403,6 +406,11 @@ final class SyncPreferences: ObservableObject, SyncUI_macOS.ManagementViewModel 
                 }
             }
             .store(in: &cancellables)
+    }
+
+    @MainActor
+    func settingsScreenDidAppear() {
+        pixelFiring?.fire(SyncSettingsPixelKitEvent.settingsScreenShown(isSyncEnabled: isSyncEnabled))
     }
 
     // MARK: - Delegation to syncSettingsHandler

--- a/macOS/DuckDuckGo/Sync/SyncPixels.swift
+++ b/macOS/DuckDuckGo/Sync/SyncPixels.swift
@@ -53,6 +53,7 @@ enum SyncFeatureUsagePixels: PixelKit.Event {
 }
 
 enum SyncSettingsPixelKitEvent: PixelKit.Event {
+    var namePrefix: PixelKitNamePrefix { .none }
 
     enum ParameterKey {
         static let syncPromptOption = "option"
@@ -87,26 +88,26 @@ enum SyncSettingsPixelKitEvent: PixelKit.Event {
 
     var name: String {
         switch self {
-        case .settingsScreenShown: return "settings_sync_open"
-        case .backUpThisDeviceTapped: return "settings_sync_back_up_this_device_tapped"
-        case .recoverSyncedDataTapped: return "settings_sync_recover_synced_data_tapped"
-        case .recoveryConfirmedTapped: return "settings_sync_recovery_confirmed_tapped"
-        case .anotherDevicePromptShown: return "settings_sync_another_device_prompt_shown"
-        case .anotherDevicePromptOptionTapped: return "settings_sync_another_device_prompt_option_tapped"
-        case .authenticationCancelledPromptShown: return "settings_sync_authentication_cancelled_prompt_shown"
-        case .authenticationCancelledPromptRetryTapped: return "settings_sync_authentication_cancelled_prompt_retry_tapped"
-        case .authenticationCancelledPromptDismissed: return "settings_sync_authentication_cancelled_prompt_dismissed"
-        case .authenticationCancelledPromptRetrySucceeded: return "settings_sync_authentication_cancelled_prompt_retry_succeeded"
-        case .authenticationCancelledPromptRetryFailed: return "settings_sync_authentication_cancelled_prompt_retry_failed"
-        case .successScreenShown: return "settings_sync_success_screen_shown"
-        case .successScreenCopyCodeTapped: return "settings_sync_success_screen_copy_code_tapped"
-        case .successScreenDownloadRecoveryPDFTapped: return "settings_sync_success_screen_download_recovery_pdf_tapped"
-        case .successScreenDoneTapped: return "settings_sync_success_screen_done_tapped"
-        case .thisDeviceDetailsScreenShown: return "settings_sync_this_device_details_screen_shown"
-        case .thisDeviceDetailsNameUpdated: return "settings_sync_this_device_details_name_updated"
-        case .thisDeviceDetailsTurnOffSyncTapped: return "settings_sync_this_device_details_turn_off_sync_tapped"
-        case .otherDeviceDetailsScreenShown: return "settings_sync_other_device_details_screen_shown"
-        case .otherDeviceDetailsRemoveDeviceTapped: return "settings_sync_other_device_details_remove_device_tapped"
+        case .settingsScreenShown: return "sync_settings_open_mac"
+        case .backUpThisDeviceTapped: return "sync_settings_back_up_this_device_tapped_mac"
+        case .recoverSyncedDataTapped: return "sync_settings_recover_synced_data_tapped_mac"
+        case .recoveryConfirmedTapped: return "sync_settings_recovery_confirmed_tapped_mac"
+        case .anotherDevicePromptShown: return "sync_settings_another_device_prompt_shown_mac"
+        case .anotherDevicePromptOptionTapped: return "sync_settings_another_device_prompt_option_tapped_mac"
+        case .authenticationCancelledPromptShown: return "sync_settings_authentication_cancelled_prompt_shown_mac"
+        case .authenticationCancelledPromptRetryTapped: return "sync_settings_authentication_cancelled_prompt_retry_tapped_mac"
+        case .authenticationCancelledPromptDismissed: return "sync_settings_authentication_cancelled_prompt_dismissed_mac"
+        case .authenticationCancelledPromptRetrySucceeded: return "sync_settings_authentication_cancelled_prompt_retry_succeeded_mac"
+        case .authenticationCancelledPromptRetryFailed: return "sync_settings_authentication_cancelled_prompt_retry_failed_mac"
+        case .successScreenShown: return "sync_settings_success_screen_shown_mac"
+        case .successScreenCopyCodeTapped: return "sync_settings_success_screen_copy_code_tapped_mac"
+        case .successScreenDownloadRecoveryPDFTapped: return "sync_settings_success_screen_download_recovery_pdf_tapped_mac"
+        case .successScreenDoneTapped: return "sync_settings_success_screen_done_tapped_mac"
+        case .thisDeviceDetailsScreenShown: return "sync_settings_this_device_details_screen_shown_mac"
+        case .thisDeviceDetailsNameUpdated: return "sync_settings_this_device_details_name_updated_mac"
+        case .thisDeviceDetailsTurnOffSyncTapped: return "sync_settings_this_device_details_turn_off_sync_tapped_mac"
+        case .otherDeviceDetailsScreenShown: return "sync_settings_other_device_details_screen_shown_mac"
+        case .otherDeviceDetailsRemoveDeviceTapped: return "sync_settings_other_device_details_remove_device_tapped_mac"
         }
     }
 

--- a/macOS/DuckDuckGo/Sync/SyncPixels.swift
+++ b/macOS/DuckDuckGo/Sync/SyncPixels.swift
@@ -55,7 +55,8 @@ enum SyncFeatureUsagePixels: PixelKit.Event {
 enum SyncSettingsPixelKitEvent: PixelKit.Event {
 
     enum ParameterKey {
-        static let syncPromptOption = "sync_prompt_option"
+        static let syncPromptOption = "option"
+        static let isEnabled = "is_enabled"
     }
 
     enum AnotherDevicePromptOption: String {
@@ -63,36 +64,65 @@ enum SyncSettingsPixelKitEvent: PixelKit.Event {
         case syncAnotherDevice = "sync_another_device"
     }
 
+    case settingsScreenShown(isSyncEnabled: Bool)
+    case backUpThisDeviceTapped
+    case recoverSyncedDataTapped
+    case recoveryConfirmedTapped
     case anotherDevicePromptShown
     case anotherDevicePromptOptionTapped(option: AnotherDevicePromptOption)
     case authenticationCancelledPromptShown
+    case authenticationCancelledPromptRetryTapped
+    case authenticationCancelledPromptDismissed
+    case authenticationCancelledPromptRetrySucceeded
+    case authenticationCancelledPromptRetryFailed
+    case successScreenShown
+    case successScreenCopyCodeTapped
+    case successScreenDownloadRecoveryPDFTapped
+    case successScreenDoneTapped
+    case thisDeviceDetailsScreenShown
+    case thisDeviceDetailsNameUpdated
+    case thisDeviceDetailsTurnOffSyncTapped
+    case otherDeviceDetailsScreenShown
+    case otherDeviceDetailsRemoveDeviceTapped
 
     var name: String {
         switch self {
+        case .settingsScreenShown: return "settings_sync_open"
+        case .backUpThisDeviceTapped: return "settings_sync_back_up_this_device_tapped"
+        case .recoverSyncedDataTapped: return "settings_sync_recover_synced_data_tapped"
+        case .recoveryConfirmedTapped: return "settings_sync_recovery_confirmed_tapped"
         case .anotherDevicePromptShown: return "settings_sync_another_device_prompt_shown"
         case .anotherDevicePromptOptionTapped: return "settings_sync_another_device_prompt_option_tapped"
         case .authenticationCancelledPromptShown: return "settings_sync_authentication_cancelled_prompt_shown"
+        case .authenticationCancelledPromptRetryTapped: return "settings_sync_authentication_cancelled_prompt_retry_tapped"
+        case .authenticationCancelledPromptDismissed: return "settings_sync_authentication_cancelled_prompt_dismissed"
+        case .authenticationCancelledPromptRetrySucceeded: return "settings_sync_authentication_cancelled_prompt_retry_succeeded"
+        case .authenticationCancelledPromptRetryFailed: return "settings_sync_authentication_cancelled_prompt_retry_failed"
+        case .successScreenShown: return "settings_sync_success_screen_shown"
+        case .successScreenCopyCodeTapped: return "settings_sync_success_screen_copy_code_tapped"
+        case .successScreenDownloadRecoveryPDFTapped: return "settings_sync_success_screen_download_recovery_pdf_tapped"
+        case .successScreenDoneTapped: return "settings_sync_success_screen_done_tapped"
+        case .thisDeviceDetailsScreenShown: return "settings_sync_this_device_details_screen_shown"
+        case .thisDeviceDetailsNameUpdated: return "settings_sync_this_device_details_name_updated"
+        case .thisDeviceDetailsTurnOffSyncTapped: return "settings_sync_this_device_details_turn_off_sync_tapped"
+        case .otherDeviceDetailsScreenShown: return "settings_sync_other_device_details_screen_shown"
+        case .otherDeviceDetailsRemoveDeviceTapped: return "settings_sync_other_device_details_remove_device_tapped"
         }
     }
 
     var parameters: [String: String]? {
         switch self {
-        case .anotherDevicePromptShown:
-            return nil
+        case .settingsScreenShown(let isSyncEnabled):
+            return [ParameterKey.isEnabled: isSyncEnabled ? "1" : "0"]
         case .anotherDevicePromptOptionTapped(let option):
             return [ParameterKey.syncPromptOption: option.rawValue]
-        case .authenticationCancelledPromptShown:
+        default:
             return nil
         }
     }
 
     var standardParameters: [PixelKitStandardParameter]? {
-        switch self {
-        case .anotherDevicePromptShown,
-                .anotherDevicePromptOptionTapped,
-                .authenticationCancelledPromptShown:
-            return [.pixelSource]
-        }
+        [.pixelSource]
     }
 }
 

--- a/macOS/LocalPackages/FeatureFlags-macOS/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags-macOS/Sources/FeatureFlags/FeatureFlag.swift
@@ -867,7 +867,7 @@ extension FeatureFlag: FeatureFlagDescribing {
         case .syncCanReadUnifiedDeviceList:
             Config(source: .remoteReleasable(SyncSubfeature.canReadUnifiedDeviceList), category: .sync)
         case .simplifiedSyncSetupV2:
-            Config(source: .remoteReleasable(SyncSubfeature.simplifiedSyncSetupV2), category: .sync)
+            Config(defaultValue: .enabled, source: .remoteReleasable(SyncSubfeature.simplifiedSyncSetupV2), category: .sync)
         case .promptBar:
             Config(defaultValue: .internalOnly, source: .remoteReleasable(AIChatSubfeature.promptBar), category: .duckAI)
         case .bookmarksReorderByName:

--- a/macOS/LocalPackages/SyncUI-macOS/Sources/SyncUI-macOS/ViewModels/ManagementDialogModel.swift
+++ b/macOS/LocalPackages/SyncUI-macOS/Sources/SyncUI-macOS/ViewModels/ManagementDialogModel.swift
@@ -34,6 +34,10 @@ public protocol ManagementDialogModelDelegate: AnyObject {
     func enterRecoveryCodePressed()
     func copyCode(_ code: String)
     func syncAnotherDevicePromptDidAppear()
+    func syncSuccessViewDidAppear()
+    func syncSuccessCopyCodePressed(_ code: String)
+    func syncSuccessSaveRecoveryPDFPressed()
+    func syncSuccessDonePressed()
     func syncThisDeviceOnlyFromPrompt() async
     func syncWithAnotherDeviceFromPrompt()
     func openSystemPasswordSettings()

--- a/macOS/LocalPackages/SyncUI-macOS/Sources/SyncUI-macOS/ViewModels/ManagementViewModel.swift
+++ b/macOS/LocalPackages/SyncUI-macOS/Sources/SyncUI-macOS/ViewModels/ManagementViewModel.swift
@@ -78,6 +78,7 @@ public protocol ManagementViewModel: ObservableObject {
     func manageCreditCards()
     func manageIdentities()
 
+    func settingsScreenDidAppear()
     func syncWithAnotherDevicePressed() async
     func syncWithServerPressed() async
     func recoverDataPressed() async

--- a/macOS/LocalPackages/SyncUI-macOS/Sources/SyncUI-macOS/Views/Dialogs/SyncSuccessViewV2.swift
+++ b/macOS/LocalPackages/SyncUI-macOS/Sources/SyncUI-macOS/Views/Dialogs/SyncSuccessViewV2.swift
@@ -62,10 +62,13 @@ struct SyncSuccessViewV2: View {
         } buttons: {
             Spacer()
             Button(UserText.done) {
-                model.endFlow()
+                model.delegate?.syncSuccessDonePressed()
             }
             .buttonStyle(DefaultActionButtonStyle(enabled: true, stateColors: .themedActionButton))
             .accessibilityIdentifier("SyncSuccessDoneButton")
+        }
+        .onAppear {
+            model.delegate?.syncSuccessViewDidAppear()
         }
     }
 
@@ -92,7 +95,7 @@ struct SyncSuccessViewV2: View {
 
                 HStack(spacing: 8) {
                     Button {
-                        model.delegate?.copyCode(code)
+                        model.delegate?.syncSuccessCopyCodePressed(code)
                         showCopyConfirmation = true
                     } label: {
                         HStack(spacing: 6) {
@@ -110,7 +113,7 @@ struct SyncSuccessViewV2: View {
                     .accessibilityIdentifier("SyncSuccessCopyCodeButton")
 
                     Button {
-                        model.delegate?.saveRecoveryPDF(requiresAuthentication: false)
+                        model.delegate?.syncSuccessSaveRecoveryPDFPressed()
                     } label: {
                         Text(UserText.syncSuccessDownloadPDFButtonV2)
                             .frame(maxWidth: .infinity)

--- a/macOS/LocalPackages/SyncUI-macOS/Sources/SyncUI-macOS/Views/ManagementView.swift
+++ b/macOS/LocalPackages/SyncUI-macOS/Sources/SyncUI-macOS/Views/ManagementView.swift
@@ -56,6 +56,9 @@ public struct ManagementView<ViewModel>: View where ViewModel: ManagementViewMod
                 legacyContent
             }
         }
+        .onAppear {
+            model.settingsScreenDidAppear()
+        }
     }
 
     @ViewBuilder

--- a/macOS/LocalPackages/SyncUI-macOS/Sources/SyncUI-macOS/Views/ManagementView_PreviewMocks.swift
+++ b/macOS/LocalPackages/SyncUI-macOS/Sources/SyncUI-macOS/Views/ManagementView_PreviewMocks.swift
@@ -101,6 +101,7 @@ final class PreviewManagementViewModel: ManagementViewModel {
     func manageLogins() {}
     func manageCreditCards() {}
     func manageIdentities() {}
+    func settingsScreenDidAppear() {}
     func syncWithAnotherDevicePressed() async {}
     func syncWithServerPressed() async {}
     func recoverDataPressed() async {}

--- a/macOS/PixelDefinitions/pixels/definitions/sync_setup.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/sync_setup.json5
@@ -356,7 +356,7 @@
             "pixelSource",
             "channel",
             {
-                "key": "sync_prompt_option",
+                "key": "option",
                 "type": "string",
                 "description": "Which option the user tapped on the device-selection prompt.",
                 "enum": ["this_device_only", "sync_another_device"]
@@ -365,6 +365,118 @@
     },
     "m_mac_settings_sync_authentication_cancelled_prompt_shown": {
         "description": "Fired when the prompt asking the user to authenticate is shown after they cancel the device authentication prompt while setting up Sync in the simplified V2 setup.",
+        "owners": ["pballart"],
+        "triggers": ["other"],
+        "parameters": ["appVersion", "pixelSource", "channel"]
+    },
+    "m_mac_settings_sync_authentication_cancelled_prompt_retry_tapped": {
+        "description": "Fired when the user taps 'Try Again' on the authentication-cancelled prompt, asking to be shown the device authentication prompt once more.",
+        "owners": ["pballart"],
+        "triggers": ["other"],
+        "parameters": ["appVersion", "pixelSource", "channel"]
+    },
+    "m_mac_settings_sync_authentication_cancelled_prompt_dismissed": {
+        "description": "Fired when the user closes the authentication-cancelled prompt without a retry being offered, ending the Sync setup flow.",
+        "owners": ["pballart"],
+        "triggers": ["other"],
+        "parameters": ["appVersion", "pixelSource", "channel"]
+    },
+    "m_mac_settings_sync_authentication_cancelled_prompt_retry_succeeded": {
+        "description": "Fired when the user authenticates successfully after retrying from the authentication-cancelled prompt, and the Sync setup flow continues.",
+        "owners": ["pballart"],
+        "triggers": ["other"],
+        "parameters": ["appVersion", "pixelSource", "channel"]
+    },
+    "m_mac_settings_sync_authentication_cancelled_prompt_retry_failed": {
+        "description": "Fired when the user fails or cancels device authentication again after retrying from the authentication-cancelled prompt, ending the Sync setup flow.",
+        "owners": ["pballart"],
+        "triggers": ["other"],
+        "parameters": ["appVersion", "pixelSource", "channel"]
+    },
+    "m_mac_settings_sync_open": {
+        "description": "Fired when the Sync & Back Up settings pane is shown.",
+        "owners": ["pballart"],
+        "triggers": ["other"],
+        "parameters": [
+            "appVersion",
+            "pixelSource",
+            "channel",
+            {
+                "key": "is_enabled",
+                "type": "string",
+                "description": "Whether Sync is enabled when the pane is shown.",
+                "enum": ["0", "1"]
+            }
+        ]
+    },
+    "m_mac_settings_sync_back_up_this_device_tapped": {
+        "description": "Fired when the user turns on the 'Sync and Back Up This Device' toggle on the Sync settings pane.",
+        "owners": ["pballart"],
+        "triggers": ["other"],
+        "parameters": ["appVersion", "pixelSource", "channel"]
+    },
+    "m_mac_settings_sync_recover_synced_data_tapped": {
+        "description": "Fired when the user taps the entry point to the Recover Synced Data flow on the Sync settings pane.",
+        "owners": ["pballart"],
+        "triggers": ["other"],
+        "parameters": ["appVersion", "pixelSource", "channel"]
+    },
+    "m_mac_settings_sync_recovery_confirmed_tapped": {
+        "description": "Fired when the user taps the primary button on the Recover Synced Data dialog, confirming intent to begin recovery.",
+        "owners": ["pballart"],
+        "triggers": ["other"],
+        "parameters": ["appVersion", "pixelSource", "channel"]
+    },
+    "m_mac_settings_sync_success_screen_shown": {
+        "description": "Fired when the Sync setup success screen, which shows the recovery code, is displayed in the simplified V2 setup.",
+        "owners": ["pballart"],
+        "triggers": ["other"],
+        "parameters": ["appVersion", "pixelSource", "channel"]
+    },
+    "m_mac_settings_sync_success_screen_copy_code_tapped": {
+        "description": "Fired when the user taps 'Copy Code' on the Sync setup success screen in the simplified V2 setup.",
+        "owners": ["pballart"],
+        "triggers": ["other"],
+        "parameters": ["appVersion", "pixelSource", "channel"]
+    },
+    "m_mac_settings_sync_success_screen_download_recovery_pdf_tapped": {
+        "description": "Fired when the user taps the button to download the recovery PDF on the Sync setup success screen in the simplified V2 setup.",
+        "owners": ["pballart"],
+        "triggers": ["other"],
+        "parameters": ["appVersion", "pixelSource", "channel"]
+    },
+    "m_mac_settings_sync_success_screen_done_tapped": {
+        "description": "Fired when the user taps 'Done' on the Sync setup success screen in the simplified V2 setup, completing the flow.",
+        "owners": ["pballart"],
+        "triggers": ["other"],
+        "parameters": ["appVersion", "pixelSource", "channel"]
+    },
+    "m_mac_settings_sync_this_device_details_screen_shown": {
+        "description": "Fired when the device details screen is shown for the current device in the simplified V2 setup.",
+        "owners": ["pballart"],
+        "triggers": ["other"],
+        "parameters": ["appVersion", "pixelSource", "channel"]
+    },
+    "m_mac_settings_sync_this_device_details_name_updated": {
+        "description": "Fired when the name of the current device is successfully updated from its device details screen.",
+        "owners": ["pballart"],
+        "triggers": ["other"],
+        "parameters": ["appVersion", "pixelSource", "channel"]
+    },
+    "m_mac_settings_sync_this_device_details_turn_off_sync_tapped": {
+        "description": "Fired when the user taps 'Turn Off Sync & Backup' on the details screen of the current device, opening the confirmation dialog.",
+        "owners": ["pballart"],
+        "triggers": ["other"],
+        "parameters": ["appVersion", "pixelSource", "channel"]
+    },
+    "m_mac_settings_sync_other_device_details_screen_shown": {
+        "description": "Fired when the device details screen is shown for another synced device in the simplified V2 setup.",
+        "owners": ["pballart"],
+        "triggers": ["other"],
+        "parameters": ["appVersion", "pixelSource", "channel"]
+    },
+    "m_mac_settings_sync_other_device_details_remove_device_tapped": {
+        "description": "Fired when the user taps 'Remove Device' on the details screen of another synced device, opening the confirmation dialog.",
         "owners": ["pballart"],
         "triggers": ["other"],
         "parameters": ["appVersion", "pixelSource", "channel"]

--- a/macOS/PixelDefinitions/pixels/definitions/sync_setup.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/sync_setup.json5
@@ -341,13 +341,13 @@
             }
         ]
     },
-    "m_mac_settings_sync_another_device_prompt_shown": {
+    "sync_settings_another_device_prompt_shown_mac": {
         "description": "Fired when the device-selection prompt (sync with another device or just this device) is shown after enabling Sync in the simplified V2 setup.",
         "owners": ["pballart"],
         "triggers": ["other"],
         "parameters": ["appVersion", "pixelSource", "channel"]
     },
-    "m_mac_settings_sync_another_device_prompt_option_tapped": {
+    "sync_settings_another_device_prompt_option_tapped_mac": {
         "description": "Fired when the user taps an option on the device-selection prompt shown after enabling Sync in the simplified V2 setup.",
         "owners": ["pballart"],
         "triggers": ["other"],
@@ -363,37 +363,37 @@
             }
         ]
     },
-    "m_mac_settings_sync_authentication_cancelled_prompt_shown": {
+    "sync_settings_authentication_cancelled_prompt_shown_mac": {
         "description": "Fired when the prompt asking the user to authenticate is shown after they cancel the device authentication prompt while setting up Sync in the simplified V2 setup.",
         "owners": ["pballart"],
         "triggers": ["other"],
         "parameters": ["appVersion", "pixelSource", "channel"]
     },
-    "m_mac_settings_sync_authentication_cancelled_prompt_retry_tapped": {
+    "sync_settings_authentication_cancelled_prompt_retry_tapped_mac": {
         "description": "Fired when the user taps 'Try Again' on the authentication-cancelled prompt, asking to be shown the device authentication prompt once more.",
         "owners": ["pballart"],
         "triggers": ["other"],
         "parameters": ["appVersion", "pixelSource", "channel"]
     },
-    "m_mac_settings_sync_authentication_cancelled_prompt_dismissed": {
+    "sync_settings_authentication_cancelled_prompt_dismissed_mac": {
         "description": "Fired when the user closes the authentication-cancelled prompt without a retry being offered, ending the Sync setup flow.",
         "owners": ["pballart"],
         "triggers": ["other"],
         "parameters": ["appVersion", "pixelSource", "channel"]
     },
-    "m_mac_settings_sync_authentication_cancelled_prompt_retry_succeeded": {
+    "sync_settings_authentication_cancelled_prompt_retry_succeeded_mac": {
         "description": "Fired when the user authenticates successfully after retrying from the authentication-cancelled prompt, and the Sync setup flow continues.",
         "owners": ["pballart"],
         "triggers": ["other"],
         "parameters": ["appVersion", "pixelSource", "channel"]
     },
-    "m_mac_settings_sync_authentication_cancelled_prompt_retry_failed": {
+    "sync_settings_authentication_cancelled_prompt_retry_failed_mac": {
         "description": "Fired when the user fails or cancels device authentication again after retrying from the authentication-cancelled prompt, ending the Sync setup flow.",
         "owners": ["pballart"],
         "triggers": ["other"],
         "parameters": ["appVersion", "pixelSource", "channel"]
     },
-    "m_mac_settings_sync_open": {
+    "sync_settings_open_mac": {
         "description": "Fired when the Sync & Back Up settings pane is shown.",
         "owners": ["pballart"],
         "triggers": ["other"],
@@ -409,73 +409,73 @@
             }
         ]
     },
-    "m_mac_settings_sync_back_up_this_device_tapped": {
+    "sync_settings_back_up_this_device_tapped_mac": {
         "description": "Fired when the user turns on the 'Sync and Back Up This Device' toggle on the Sync settings pane.",
         "owners": ["pballart"],
         "triggers": ["other"],
         "parameters": ["appVersion", "pixelSource", "channel"]
     },
-    "m_mac_settings_sync_recover_synced_data_tapped": {
+    "sync_settings_recover_synced_data_tapped_mac": {
         "description": "Fired when the user taps the entry point to the Recover Synced Data flow on the Sync settings pane.",
         "owners": ["pballart"],
         "triggers": ["other"],
         "parameters": ["appVersion", "pixelSource", "channel"]
     },
-    "m_mac_settings_sync_recovery_confirmed_tapped": {
+    "sync_settings_recovery_confirmed_tapped_mac": {
         "description": "Fired when the user taps the primary button on the Recover Synced Data dialog, confirming intent to begin recovery.",
         "owners": ["pballart"],
         "triggers": ["other"],
         "parameters": ["appVersion", "pixelSource", "channel"]
     },
-    "m_mac_settings_sync_success_screen_shown": {
+    "sync_settings_success_screen_shown_mac": {
         "description": "Fired when the Sync setup success screen, which shows the recovery code, is displayed in the simplified V2 setup.",
         "owners": ["pballart"],
         "triggers": ["other"],
         "parameters": ["appVersion", "pixelSource", "channel"]
     },
-    "m_mac_settings_sync_success_screen_copy_code_tapped": {
+    "sync_settings_success_screen_copy_code_tapped_mac": {
         "description": "Fired when the user taps 'Copy Code' on the Sync setup success screen in the simplified V2 setup.",
         "owners": ["pballart"],
         "triggers": ["other"],
         "parameters": ["appVersion", "pixelSource", "channel"]
     },
-    "m_mac_settings_sync_success_screen_download_recovery_pdf_tapped": {
+    "sync_settings_success_screen_download_recovery_pdf_tapped_mac": {
         "description": "Fired when the user taps the button to download the recovery PDF on the Sync setup success screen in the simplified V2 setup.",
         "owners": ["pballart"],
         "triggers": ["other"],
         "parameters": ["appVersion", "pixelSource", "channel"]
     },
-    "m_mac_settings_sync_success_screen_done_tapped": {
+    "sync_settings_success_screen_done_tapped_mac": {
         "description": "Fired when the user taps 'Done' on the Sync setup success screen in the simplified V2 setup, completing the flow.",
         "owners": ["pballart"],
         "triggers": ["other"],
         "parameters": ["appVersion", "pixelSource", "channel"]
     },
-    "m_mac_settings_sync_this_device_details_screen_shown": {
+    "sync_settings_this_device_details_screen_shown_mac": {
         "description": "Fired when the device details screen is shown for the current device in the simplified V2 setup.",
         "owners": ["pballart"],
         "triggers": ["other"],
         "parameters": ["appVersion", "pixelSource", "channel"]
     },
-    "m_mac_settings_sync_this_device_details_name_updated": {
+    "sync_settings_this_device_details_name_updated_mac": {
         "description": "Fired when the name of the current device is successfully updated from its device details screen.",
         "owners": ["pballart"],
         "triggers": ["other"],
         "parameters": ["appVersion", "pixelSource", "channel"]
     },
-    "m_mac_settings_sync_this_device_details_turn_off_sync_tapped": {
+    "sync_settings_this_device_details_turn_off_sync_tapped_mac": {
         "description": "Fired when the user taps 'Turn Off Sync & Backup' on the details screen of the current device, opening the confirmation dialog.",
         "owners": ["pballart"],
         "triggers": ["other"],
         "parameters": ["appVersion", "pixelSource", "channel"]
     },
-    "m_mac_settings_sync_other_device_details_screen_shown": {
+    "sync_settings_other_device_details_screen_shown_mac": {
         "description": "Fired when the device details screen is shown for another synced device in the simplified V2 setup.",
         "owners": ["pballart"],
         "triggers": ["other"],
         "parameters": ["appVersion", "pixelSource", "channel"]
     },
-    "m_mac_settings_sync_other_device_details_remove_device_tapped": {
+    "sync_settings_other_device_details_remove_device_tapped_mac": {
         "description": "Fired when the user taps 'Remove Device' on the details screen of another synced device, opening the confirmation dialog.",
         "owners": ["pballart"],
         "triggers": ["other"],

--- a/macOS/UnitTests/Sync/SyncDialogControllerTests.swift
+++ b/macOS/UnitTests/Sync/SyncDialogControllerTests.swift
@@ -319,7 +319,7 @@ final class SyncDialogControllerTests: XCTestCase {
 
         XCTAssertNil(managementDialogModel.currentDialog)
         XCTAssertEqual(mockKeyValueStore.object(forKey: "sync.authentication-cancelled-prompt.presented-count") as? Int, 1)
-        let fireCount = pixelKitMock.actualFireCalls.filter { $0.pixel.name == "settings_sync_authentication_cancelled_prompt_shown" }.count
+        let fireCount = pixelKitMock.actualFireCalls.filter { $0.pixel.name == "sync_settings_authentication_cancelled_prompt_shown_mac" }.count
         XCTAssertEqual(fireCount, 1)
     }
 
@@ -382,7 +382,7 @@ final class SyncDialogControllerTests: XCTestCase {
             await syncDialogController.syncWithServerPressed()
         }
 
-        let fireCount = pixelKitMock.actualFireCalls.filter { $0.pixel.name == "settings_sync_authentication_cancelled_prompt_shown" }.count
+        let fireCount = pixelKitMock.actualFireCalls.filter { $0.pixel.name == "sync_settings_authentication_cancelled_prompt_shown_mac" }.count
         XCTAssertEqual(fireCount, 2)
     }
 
@@ -1313,7 +1313,7 @@ final class SyncDialogControllerTests: XCTestCase {
         syncDialogController.syncAnotherDevicePromptDidAppear()
 
         XCTAssertTrue(pixelKitMock.actualFireCalls.contains {
-            $0.pixel.name == "settings_sync_another_device_prompt_shown"
+            $0.pixel.name == "sync_settings_another_device_prompt_shown_mac"
         })
     }
 
@@ -1321,7 +1321,7 @@ final class SyncDialogControllerTests: XCTestCase {
         await syncDialogController.syncThisDeviceOnlyFromPrompt()
 
         XCTAssertTrue(pixelKitMock.actualFireCalls.contains {
-            $0.pixel.name == "settings_sync_another_device_prompt_option_tapped"
+            $0.pixel.name == "sync_settings_another_device_prompt_option_tapped_mac"
             && $0.pixel.parameters?["option"] == "this_device_only"
         })
     }
@@ -1342,7 +1342,7 @@ final class SyncDialogControllerTests: XCTestCase {
         syncDialogController.syncWithAnotherDeviceFromPrompt()
 
         XCTAssertFalse(pixelKitMock.actualFireCalls.contains {
-            $0.pixel.name == "settings_sync_another_device_prompt_option_tapped"
+            $0.pixel.name == "sync_settings_another_device_prompt_option_tapped_mac"
         })
     }
 
@@ -1350,7 +1350,7 @@ final class SyncDialogControllerTests: XCTestCase {
         syncDialogController.syncWithAnotherDeviceFromPrompt()
 
         XCTAssertTrue(pixelKitMock.actualFireCalls.contains {
-            $0.pixel.name == "settings_sync_another_device_prompt_option_tapped"
+            $0.pixel.name == "sync_settings_another_device_prompt_option_tapped_mac"
             && $0.pixel.parameters?["option"] == "sync_another_device"
         })
     }
@@ -1963,19 +1963,19 @@ final class SyncDialogControllerTests: XCTestCase {
     func testSyncWithServerPressed_firesBackUpThisDeviceTappedPixel() async {
         await syncDialogController.syncWithServerPressed()
 
-        XCTAssertEqual(firedPixelNames(matching: "settings_sync_back_up_this_device_tapped").count, 1)
+        XCTAssertEqual(firedPixelNames(matching: "sync_settings_back_up_this_device_tapped_mac").count, 1)
     }
 
     func testRecoverDataPressed_firesRecoverSyncedDataTappedPixel() async {
         await syncDialogController.recoverDataPressed()
 
-        XCTAssertEqual(firedPixelNames(matching: "settings_sync_recover_synced_data_tapped").count, 1)
+        XCTAssertEqual(firedPixelNames(matching: "sync_settings_recover_synced_data_tapped_mac").count, 1)
     }
 
     func testEnterRecoveryCodePressed_firesRecoveryConfirmedTappedPixel() {
         syncDialogController.enterRecoveryCodePressed()
 
-        XCTAssertEqual(firedPixelNames(matching: "settings_sync_recovery_confirmed_tapped").count, 1)
+        XCTAssertEqual(firedPixelNames(matching: "sync_settings_recovery_confirmed_tapped_mac").count, 1)
     }
 
     func testAuthenticationCancelledPromptClosePressed_whenRetryOfferedAndRetrySucceeds_firesRetryTappedAndSucceededPixels() async {
@@ -1985,9 +1985,9 @@ final class SyncDialogControllerTests: XCTestCase {
 
         await syncDialogController.authenticationCancelledPromptClosePressed()
 
-        XCTAssertEqual(firedPixelNames(matching: "settings_sync_authentication_cancelled_prompt_retry_tapped").count, 1)
-        XCTAssertEqual(firedPixelNames(matching: "settings_sync_authentication_cancelled_prompt_retry_succeeded").count, 1)
-        XCTAssertTrue(firedPixelNames(matching: "settings_sync_authentication_cancelled_prompt_dismissed").isEmpty)
+        XCTAssertEqual(firedPixelNames(matching: "sync_settings_authentication_cancelled_prompt_retry_tapped_mac").count, 1)
+        XCTAssertEqual(firedPixelNames(matching: "sync_settings_authentication_cancelled_prompt_retry_succeeded_mac").count, 1)
+        XCTAssertTrue(firedPixelNames(matching: "sync_settings_authentication_cancelled_prompt_dismissed_mac").isEmpty)
     }
 
     func testAuthenticationCancelledPromptClosePressed_whenRetryFails_firesRetryFailedPixel() async {
@@ -1997,8 +1997,8 @@ final class SyncDialogControllerTests: XCTestCase {
 
         await syncDialogController.authenticationCancelledPromptClosePressed()
 
-        XCTAssertEqual(firedPixelNames(matching: "settings_sync_authentication_cancelled_prompt_retry_tapped").count, 1)
-        XCTAssertEqual(firedPixelNames(matching: "settings_sync_authentication_cancelled_prompt_retry_failed").count, 1)
+        XCTAssertEqual(firedPixelNames(matching: "sync_settings_authentication_cancelled_prompt_retry_tapped_mac").count, 1)
+        XCTAssertEqual(firedPixelNames(matching: "sync_settings_authentication_cancelled_prompt_retry_failed_mac").count, 1)
     }
 
     func testAuthenticationCancelledPromptClosePressed_whenRetryNotOffered_firesDismissedPixel() async {
@@ -2009,20 +2009,20 @@ final class SyncDialogControllerTests: XCTestCase {
 
         await syncDialogController.authenticationCancelledPromptClosePressed()
 
-        XCTAssertEqual(firedPixelNames(matching: "settings_sync_authentication_cancelled_prompt_dismissed").count, 1)
-        XCTAssertTrue(firedPixelNames(matching: "settings_sync_authentication_cancelled_prompt_retry_tapped").isEmpty)
+        XCTAssertEqual(firedPixelNames(matching: "sync_settings_authentication_cancelled_prompt_dismissed_mac").count, 1)
+        XCTAssertTrue(firedPixelNames(matching: "sync_settings_authentication_cancelled_prompt_retry_tapped_mac").isEmpty)
     }
 
     func testSyncSuccessViewDidAppear_firesSuccessScreenShownPixel() {
         syncDialogController.syncSuccessViewDidAppear()
 
-        XCTAssertEqual(firedPixelNames(matching: "settings_sync_success_screen_shown").count, 1)
+        XCTAssertEqual(firedPixelNames(matching: "sync_settings_success_screen_shown_mac").count, 1)
     }
 
     func testSyncSuccessCopyCodePressed_firesCopyCodeTappedPixel() {
         syncDialogController.syncSuccessCopyCodePressed(testRecoveryCode)
 
-        XCTAssertEqual(firedPixelNames(matching: "settings_sync_success_screen_copy_code_tapped").count, 1)
+        XCTAssertEqual(firedPixelNames(matching: "sync_settings_success_screen_copy_code_tapped_mac").count, 1)
     }
 
     func testSyncSuccessDonePressed_firesDoneTappedPixelAndEndsFlow() {
@@ -2030,7 +2030,7 @@ final class SyncDialogControllerTests: XCTestCase {
 
         syncDialogController.syncSuccessDonePressed()
 
-        XCTAssertEqual(firedPixelNames(matching: "settings_sync_success_screen_done_tapped").count, 1)
+        XCTAssertEqual(firedPixelNames(matching: "sync_settings_success_screen_done_tapped_mac").count, 1)
         XCTAssertNil(managementDialogModel.currentDialog)
     }
 
@@ -2039,8 +2039,8 @@ final class SyncDialogControllerTests: XCTestCase {
 
         await syncDialogController.presentDeviceDetails(SyncDevice(kind: .current, name: "test", id: "test"))
 
-        XCTAssertEqual(firedPixelNames(matching: "settings_sync_this_device_details_screen_shown").count, 1)
-        XCTAssertTrue(firedPixelNames(matching: "settings_sync_other_device_details_screen_shown").isEmpty)
+        XCTAssertEqual(firedPixelNames(matching: "sync_settings_this_device_details_screen_shown_mac").count, 1)
+        XCTAssertTrue(firedPixelNames(matching: "sync_settings_other_device_details_screen_shown_mac").isEmpty)
     }
 
     func testPresentDeviceDetails_forOtherDevice_firesOtherDeviceDetailsShownPixel() async {
@@ -2048,8 +2048,8 @@ final class SyncDialogControllerTests: XCTestCase {
 
         await syncDialogController.presentDeviceDetails(SyncDevice(kind: .mobile, name: "test", id: "test"))
 
-        XCTAssertEqual(firedPixelNames(matching: "settings_sync_other_device_details_screen_shown").count, 1)
-        XCTAssertTrue(firedPixelNames(matching: "settings_sync_this_device_details_screen_shown").isEmpty)
+        XCTAssertEqual(firedPixelNames(matching: "sync_settings_other_device_details_screen_shown_mac").count, 1)
+        XCTAssertTrue(firedPixelNames(matching: "sync_settings_this_device_details_screen_shown_mac").isEmpty)
     }
 
     func testPresentDeviceDetails_whenAuthenticationCancelled_doesNotFireDeviceDetailsShownPixel() async {
@@ -2058,19 +2058,19 @@ final class SyncDialogControllerTests: XCTestCase {
 
         await syncDialogController.presentDeviceDetails(SyncDevice(kind: .current, name: "test", id: "test"))
 
-        XCTAssertTrue(firedPixelNames(matching: "settings_sync_this_device_details_screen_shown").isEmpty)
+        XCTAssertTrue(firedPixelNames(matching: "sync_settings_this_device_details_screen_shown_mac").isEmpty)
     }
 
     func testPresentRemoveDeviceConfirmation_forOtherDevice_firesRemoveDeviceTappedPixel() {
         syncDialogController.presentRemoveDeviceConfirmation(SyncDevice(kind: .mobile, name: "test", id: "test"))
 
-        XCTAssertEqual(firedPixelNames(matching: "settings_sync_other_device_details_remove_device_tapped").count, 1)
+        XCTAssertEqual(firedPixelNames(matching: "sync_settings_other_device_details_remove_device_tapped_mac").count, 1)
     }
 
     func testPresentRemoveDeviceConfirmation_forCurrentDevice_firesTurnOffSyncTappedPixel() {
         syncDialogController.presentRemoveDeviceConfirmation(SyncDevice(kind: .current, name: "test", id: "test"))
 
-        XCTAssertEqual(firedPixelNames(matching: "settings_sync_this_device_details_turn_off_sync_tapped").count, 1)
+        XCTAssertEqual(firedPixelNames(matching: "sync_settings_this_device_details_turn_off_sync_tapped_mac").count, 1)
     }
 
     func testUpdateDeviceName_whenSucceeds_firesNameUpdatedPixel() async {
@@ -2085,7 +2085,7 @@ final class SyncDialogControllerTests: XCTestCase {
         syncDialogController.updateDeviceName("New Name")
 
         await fulfillment(of: [expectation], timeout: 5)
-        XCTAssertEqual(firedPixelNames(matching: "settings_sync_this_device_details_name_updated").count, 1)
+        XCTAssertEqual(firedPixelNames(matching: "sync_settings_this_device_details_name_updated_mac").count, 1)
     }
 
     func testUpdateDeviceName_whenFails_doesNotFireNameUpdatedPixel() async {
@@ -2100,7 +2100,7 @@ final class SyncDialogControllerTests: XCTestCase {
         syncDialogController.updateDeviceName("New Name")
 
         await fulfillment(of: [expectation], timeout: 5)
-        XCTAssertTrue(firedPixelNames(matching: "settings_sync_this_device_details_name_updated").isEmpty)
+        XCTAssertTrue(firedPixelNames(matching: "sync_settings_this_device_details_name_updated_mac").isEmpty)
     }
 
     private func firedPixelNames(matching name: String) -> [String] {

--- a/macOS/UnitTests/Sync/SyncDialogControllerTests.swift
+++ b/macOS/UnitTests/Sync/SyncDialogControllerTests.swift
@@ -1322,7 +1322,7 @@ final class SyncDialogControllerTests: XCTestCase {
 
         XCTAssertTrue(pixelKitMock.actualFireCalls.contains {
             $0.pixel.name == "settings_sync_another_device_prompt_option_tapped"
-            && $0.pixel.parameters?["sync_prompt_option"] == "this_device_only"
+            && $0.pixel.parameters?["option"] == "this_device_only"
         })
     }
 
@@ -1351,7 +1351,7 @@ final class SyncDialogControllerTests: XCTestCase {
 
         XCTAssertTrue(pixelKitMock.actualFireCalls.contains {
             $0.pixel.name == "settings_sync_another_device_prompt_option_tapped"
-            && $0.pixel.parameters?["sync_prompt_option"] == "sync_another_device"
+            && $0.pixel.parameters?["option"] == "sync_another_device"
         })
     }
 
@@ -1958,6 +1958,153 @@ final class SyncDialogControllerTests: XCTestCase {
         }
 
         return code
+    }
+
+    func testSyncWithServerPressed_firesBackUpThisDeviceTappedPixel() async {
+        await syncDialogController.syncWithServerPressed()
+
+        XCTAssertEqual(firedPixelNames(matching: "settings_sync_back_up_this_device_tapped").count, 1)
+    }
+
+    func testRecoverDataPressed_firesRecoverSyncedDataTappedPixel() async {
+        await syncDialogController.recoverDataPressed()
+
+        XCTAssertEqual(firedPixelNames(matching: "settings_sync_recover_synced_data_tapped").count, 1)
+    }
+
+    func testEnterRecoveryCodePressed_firesRecoveryConfirmedTappedPixel() {
+        syncDialogController.enterRecoveryCodePressed()
+
+        XCTAssertEqual(firedPixelNames(matching: "settings_sync_recovery_confirmed_tapped").count, 1)
+    }
+
+    func testAuthenticationCancelledPromptClosePressed_whenRetryOfferedAndRetrySucceeds_firesRetryTappedAndSucceededPixels() async {
+        featureFlagger.isFeatureOn[FeatureFlag.simplifiedSyncSetupV2.rawValue] = true
+        authenticator.stubbedAuthenticationResults = [.failure, .success]
+        await syncDialogController.syncWithServerPressed()
+
+        await syncDialogController.authenticationCancelledPromptClosePressed()
+
+        XCTAssertEqual(firedPixelNames(matching: "settings_sync_authentication_cancelled_prompt_retry_tapped").count, 1)
+        XCTAssertEqual(firedPixelNames(matching: "settings_sync_authentication_cancelled_prompt_retry_succeeded").count, 1)
+        XCTAssertTrue(firedPixelNames(matching: "settings_sync_authentication_cancelled_prompt_dismissed").isEmpty)
+    }
+
+    func testAuthenticationCancelledPromptClosePressed_whenRetryFails_firesRetryFailedPixel() async {
+        featureFlagger.isFeatureOn[FeatureFlag.simplifiedSyncSetupV2.rawValue] = true
+        authenticator.stubAuthenticateUser = .failure
+        await syncDialogController.syncWithServerPressed()
+
+        await syncDialogController.authenticationCancelledPromptClosePressed()
+
+        XCTAssertEqual(firedPixelNames(matching: "settings_sync_authentication_cancelled_prompt_retry_tapped").count, 1)
+        XCTAssertEqual(firedPixelNames(matching: "settings_sync_authentication_cancelled_prompt_retry_failed").count, 1)
+    }
+
+    func testAuthenticationCancelledPromptClosePressed_whenRetryNotOffered_firesDismissedPixel() async {
+        featureFlagger.isFeatureOn[FeatureFlag.simplifiedSyncSetupV2.rawValue] = true
+        authenticator.stubAuthenticateUser = .failure
+        mockKeyValueStore.set(1, forKey: "sync.authentication-cancelled-prompt.presented-count")
+        await syncDialogController.syncWithServerPressed()
+
+        await syncDialogController.authenticationCancelledPromptClosePressed()
+
+        XCTAssertEqual(firedPixelNames(matching: "settings_sync_authentication_cancelled_prompt_dismissed").count, 1)
+        XCTAssertTrue(firedPixelNames(matching: "settings_sync_authentication_cancelled_prompt_retry_tapped").isEmpty)
+    }
+
+    func testSyncSuccessViewDidAppear_firesSuccessScreenShownPixel() {
+        syncDialogController.syncSuccessViewDidAppear()
+
+        XCTAssertEqual(firedPixelNames(matching: "settings_sync_success_screen_shown").count, 1)
+    }
+
+    func testSyncSuccessCopyCodePressed_firesCopyCodeTappedPixel() {
+        syncDialogController.syncSuccessCopyCodePressed(testRecoveryCode)
+
+        XCTAssertEqual(firedPixelNames(matching: "settings_sync_success_screen_copy_code_tapped").count, 1)
+    }
+
+    func testSyncSuccessDonePressed_firesDoneTappedPixelAndEndsFlow() {
+        managementDialogModel.currentDialog = .saveRecoveryCode(testRecoveryCode)
+
+        syncDialogController.syncSuccessDonePressed()
+
+        XCTAssertEqual(firedPixelNames(matching: "settings_sync_success_screen_done_tapped").count, 1)
+        XCTAssertNil(managementDialogModel.currentDialog)
+    }
+
+    func testPresentDeviceDetails_forCurrentDevice_firesThisDeviceDetailsShownPixel() async {
+        featureFlagger.isFeatureOn[FeatureFlag.simplifiedSyncSetupV2.rawValue] = true
+
+        await syncDialogController.presentDeviceDetails(SyncDevice(kind: .current, name: "test", id: "test"))
+
+        XCTAssertEqual(firedPixelNames(matching: "settings_sync_this_device_details_screen_shown").count, 1)
+        XCTAssertTrue(firedPixelNames(matching: "settings_sync_other_device_details_screen_shown").isEmpty)
+    }
+
+    func testPresentDeviceDetails_forOtherDevice_firesOtherDeviceDetailsShownPixel() async {
+        featureFlagger.isFeatureOn[FeatureFlag.simplifiedSyncSetupV2.rawValue] = true
+
+        await syncDialogController.presentDeviceDetails(SyncDevice(kind: .mobile, name: "test", id: "test"))
+
+        XCTAssertEqual(firedPixelNames(matching: "settings_sync_other_device_details_screen_shown").count, 1)
+        XCTAssertTrue(firedPixelNames(matching: "settings_sync_this_device_details_screen_shown").isEmpty)
+    }
+
+    func testPresentDeviceDetails_whenAuthenticationCancelled_doesNotFireDeviceDetailsShownPixel() async {
+        featureFlagger.isFeatureOn[FeatureFlag.simplifiedSyncSetupV2.rawValue] = true
+        authenticator.stubAuthenticateUser = .failure
+
+        await syncDialogController.presentDeviceDetails(SyncDevice(kind: .current, name: "test", id: "test"))
+
+        XCTAssertTrue(firedPixelNames(matching: "settings_sync_this_device_details_screen_shown").isEmpty)
+    }
+
+    func testPresentRemoveDeviceConfirmation_forOtherDevice_firesRemoveDeviceTappedPixel() {
+        syncDialogController.presentRemoveDeviceConfirmation(SyncDevice(kind: .mobile, name: "test", id: "test"))
+
+        XCTAssertEqual(firedPixelNames(matching: "settings_sync_other_device_details_remove_device_tapped").count, 1)
+    }
+
+    func testPresentRemoveDeviceConfirmation_forCurrentDevice_firesTurnOffSyncTappedPixel() {
+        syncDialogController.presentRemoveDeviceConfirmation(SyncDevice(kind: .current, name: "test", id: "test"))
+
+        XCTAssertEqual(firedPixelNames(matching: "settings_sync_this_device_details_turn_off_sync_tapped").count, 1)
+    }
+
+    func testUpdateDeviceName_whenSucceeds_firesNameUpdatedPixel() async {
+        managementDialogModel.currentDialog = .deviceDetailsV2(SyncDevice(kind: .current, name: "Old Name", id: "test"))
+        let expectation = expectation(description: "device details flow ended")
+        managementDialogModel.$currentDialog.sink {
+            if $0 == nil {
+                expectation.fulfill()
+            }
+        }.store(in: &cancellables)
+
+        syncDialogController.updateDeviceName("New Name")
+
+        await fulfillment(of: [expectation], timeout: 5)
+        XCTAssertEqual(firedPixelNames(matching: "settings_sync_this_device_details_name_updated").count, 1)
+    }
+
+    func testUpdateDeviceName_whenFails_doesNotFireNameUpdatedPixel() async {
+        let expectation = expectation(description: "Update device errored")
+        managementDialogModel.$syncErrorMessage.sink {
+            if $0 != nil {
+                expectation.fulfill()
+            }
+        }.store(in: &cancellables)
+        ddgSyncing.updateDeviceNameError = SyncError.failedToLoadAccount
+
+        syncDialogController.updateDeviceName("New Name")
+
+        await fulfillment(of: [expectation], timeout: 5)
+        XCTAssertTrue(firedPixelNames(matching: "settings_sync_this_device_details_name_updated").isEmpty)
+    }
+
+    private func firedPixelNames(matching name: String) -> [String] {
+        pixelKitMock.actualFireCalls.map(\.pixel.name).filter { $0 == name }
     }
 }
 

--- a/macOS/UnitTests/Sync/SyncPreferencesTests.swift
+++ b/macOS/UnitTests/Sync/SyncPreferencesTests.swift
@@ -22,6 +22,7 @@ import Combine
 import FeatureFlags_macOS
 @_spi(Testing) import Persistence
 import XCTest
+@_spi(Testing) import PixelKit
 import PrivacyConfig
 import PrivacyConfigTestsUtils
 @testable import DDGSync
@@ -85,6 +86,7 @@ final class SyncPreferencesTests: XCTestCase {
     var syncPreferences: SyncPreferences!
     var pausedStateManager: MockSyncPausedStateManaging!
     var connectionController: MockSyncConnectionControlling!
+    var pixelKitMock: PixelKitMock!
     var featureFlagger: MockSyncFeatureFlagger!
     var testRecoveryCode = "eyJyZWNvdmVyeSI6eyJ1c2VyX2lkIjoiMDZGODhFNzEtNDFBRS00RTUxLUE2UkRtRkEwOTcwMDE5QkYwIiwicHJpbWFyeV9rZXkiOiI1QTk3U3dsQVI5RjhZakJaU09FVXBzTktnSnJEYnE3aWxtUmxDZVBWazgwPSJ9fQ=="
     lazy var testRecoveryKey = try! SyncCode.decodeBase64String(testRecoveryCode).recovery!.defaultCredentialRecoveryKey()
@@ -110,6 +112,7 @@ final class SyncPreferencesTests: XCTestCase {
         featureFlagger = MockSyncFeatureFlagger()
         featureFlagger.isFeatureOn[FeatureFlag.syncSeamlessAccountSwitching.rawValue] = true
         connectionController = MockSyncConnectionControlling()
+        pixelKitMock = PixelKitMock()
 
         syncPreferences = SyncPreferences(
             syncService: ddgSyncing,
@@ -124,7 +127,8 @@ final class SyncPreferencesTests: XCTestCase {
                 guard let self else { return MockSyncConnectionControlling() }
                 return connectionController
             },
-            featureFlagger: featureFlagger
+            featureFlagger: featureFlagger,
+            pixelFiring: pixelKitMock
         )
     }
 
@@ -138,6 +142,7 @@ final class SyncPreferencesTests: XCTestCase {
         appearancePreferences = nil
         connectionController = nil
         featureFlagger = nil
+        pixelKitMock = nil
         scheduler = nil
         syncBookmarksAdapter = nil
         syncCredentialsAdapter = nil
@@ -440,6 +445,26 @@ final class SyncPreferencesTests: XCTestCase {
         appearancePreferences.favoritesDisplayMode = .displayUnified(native: .desktop)
 
         await fulfillment(of: [expectation], timeout: 5.0)
+    }
+
+    @MainActor
+    func testSettingsScreenDidAppear_whenSyncDisabled_firesOpenPixelWithSyncNotEnabled() {
+        ddgSyncing.account = nil
+
+        syncPreferences.settingsScreenDidAppear()
+
+        let fireCall = pixelKitMock.actualFireCalls.first { $0.pixel.name == "settings_sync_open" }
+        XCTAssertEqual(fireCall?.pixel.parameters?["is_enabled"], "0")
+    }
+
+    @MainActor
+    func testSettingsScreenDidAppear_whenSyncEnabled_firesOpenPixelWithSyncEnabled() {
+        ddgSyncing.account = .mock
+
+        syncPreferences.settingsScreenDidAppear()
+
+        let fireCall = pixelKitMock.actualFireCalls.first { $0.pixel.name == "settings_sync_open" }
+        XCTAssertEqual(fireCall?.pixel.parameters?["is_enabled"], "1")
     }
 
 }

--- a/macOS/UnitTests/Sync/SyncPreferencesTests.swift
+++ b/macOS/UnitTests/Sync/SyncPreferencesTests.swift
@@ -453,7 +453,7 @@ final class SyncPreferencesTests: XCTestCase {
 
         syncPreferences.settingsScreenDidAppear()
 
-        let fireCall = pixelKitMock.actualFireCalls.first { $0.pixel.name == "settings_sync_open" }
+        let fireCall = pixelKitMock.actualFireCalls.first { $0.pixel.name == "sync_settings_open_mac" }
         XCTAssertEqual(fireCall?.pixel.parameters?["is_enabled"], "0")
     }
 
@@ -463,7 +463,7 @@ final class SyncPreferencesTests: XCTestCase {
 
         syncPreferences.settingsScreenDidAppear()
 
-        let fireCall = pixelKitMock.actualFireCalls.first { $0.pixel.name == "settings_sync_open" }
+        let fireCall = pixelKitMock.actualFireCalls.first { $0.pixel.name == "sync_settings_open_mac" }
         XCTAssertEqual(fireCall?.pixel.parameters?["is_enabled"], "1")
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1217193469998959

### Description

Adds the pixels for the simplified Sync setup on macOS, bringing it in line with the iOS counterpart and covering the screens V2 introduced that had no telemetry at all: the authentication-cancelled prompt's retry, the setup success screen, and the two device details screens. 

### Testing Steps

With outgoing pixel requests visible (Console or a proxy), and Sync off to start:

1. Open Settings → Sync & Backup → `m_mac_settings_sync_open` fires with `is_enabled=0`.
2. Turn on "Sync and Back Up This Device" and **cancel** the Touch ID prompt → `back_up_this_device_tapped`, then `..._authentication_cancelled_prompt_shown`; the alert reads "Try Again".
3. Tap "Try Again" and authenticate successfully → `..._retry_tapped` then `..._retry_succeeded`, and the device-choice prompt appears. Choose "This Device Only" and finish setup → `success_screen_shown`.
4. On the success screen tap Copy Code, then Download PDF, then Done → one pixel each, and each still performs its action (code on the clipboard, save panel opens, dialog closes).
5. Reopen Settings → Sync & Backup → `settings_sync_open` now fires with `is_enabled=1`. Open this device from My Devices → `this_device_details_screen_shown`; rename it and press Done → `..._name_updated`. Open another synced device → `other_device_details_screen_shown`; tap Remove Device → `..._remove_device_tapped` and the confirmation dialog appears.

### Impact

Medium — the second commit changes what every user sees in Sync settings by default. The flag stays remote-releasable, so the privacy config keeps a kill switch and internal users keep the local override.

#### What could go wrong?

- A pixel fires on the wrong path or twice → mitigated by unit tests covering each new pixel in `SyncDialogControllerTests` / `SyncPreferencesTests`, including the negative cases (no device-details pixel when authentication is cancelled, no `name_updated` when the rename fails).
- The success screen's buttons now route through new delegate methods rather than calling the model directly → mitigated by tests asserting Done still ends the flow; Copy and Download PDF were verified manually since the save panel can't be exercised in a unit test.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default exposure of simplified Sync setup V2 for all users while refactoring success-screen and auth-cancelled flows through new delegate paths; mitigated by tests but still affects visible Sync settings behavior.
> 
> **Overview**
> Adds **macOS Sync settings telemetry** for the simplified V2 setup: opening the pane (`sync_settings_open_mac` with `is_enabled`), backup/recover entry points, auth-cancelled retry/dismiss outcomes, success-screen actions, and this/other device detail flows (shown, rename, remove/turn off).
> 
> **Renames** existing settings-sync pixels to the `sync_settings_*_mac` scheme and changes the another-device prompt parameter from `sync_prompt_option` to **`option`**, with matching updates in `SyncPixels.swift` and `sync_setup.json5`.
> 
> **Wires firing** through `SyncDialogController` / `SyncPreferences` (injectable `PixelFiring`) and new delegate hooks from `SyncSuccessViewV2` so pixels run before copy/PDF/done behavior. The auth-cancelled “close” path now fires **dismissed** when no retry continuation exists, otherwise **retry tapped** plus success/failure.
> 
> **Enables simplified Sync setup V2 by default** via `FeatureFlag.simplifiedSyncSetupV2` `defaultValue: .enabled` (still remote-releasable). Unit tests cover each new pixel and several negative cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 028ecc927696e465ca2ca698856b2d5958ab05b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->