### PR TITLE
Add the New Tab Page customization sheet

### DIFF
--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -6506,6 +6506,10 @@ extension MainViewController: EscapeHatchActionRouter {
 
 extension MainViewController: NewTabPageControllerDelegate {
 
+    func newTabPageDidRequestSettings(_ controller: any NewTabPage) {
+        segueToSettings()
+    }
+
     func newTabPageDidSelectFavorite(_ controller: any NewTabPage, favorite: BookmarkEntity) {
         self.onSelectFavorite(favorite)
     }

--- a/iOS/DuckDuckGo/NewTabPage/NewTabPageControllerDelegate.swift
+++ b/iOS/DuckDuckGo/NewTabPage/NewTabPageControllerDelegate.swift
@@ -36,7 +36,6 @@ protocol NewTabPageControllerDelegate: AnyObject {
     func newTabPageDidScroll(_ controller: any NewTabPage)
     func newTabPage(_ controller: any NewTabPage, didInteractWithMessage interaction: NewTabPageMessageInteraction)
 
-    /// The customization sheet's link out to the rest of the New Tab Page options.
     func newTabPageDidRequestSettings(_ controller: any NewTabPage)
 }
 

--- a/iOS/DuckDuckGo/NewTabPage/NewTabPageControllerDelegate.swift
+++ b/iOS/DuckDuckGo/NewTabPage/NewTabPageControllerDelegate.swift
@@ -35,10 +35,14 @@ protocol NewTabPageControllerDelegate: AnyObject {
     func newTabPageDidDismissDuckAIFireOnboardingCompletion(_ controller: any NewTabPage)
     func newTabPageDidScroll(_ controller: any NewTabPage)
     func newTabPage(_ controller: any NewTabPage, didInteractWithMessage interaction: NewTabPageMessageInteraction)
+
+    /// The customization sheet's link out to the rest of the New Tab Page options.
+    func newTabPageDidRequestSettings(_ controller: any NewTabPage)
 }
 
 extension NewTabPageControllerDelegate {
     func newTabPageDidDismissDuckAIFireOnboardingCompletion(_ controller: any NewTabPage) { }
     func newTabPageDidScroll(_ controller: any NewTabPage) { }
     func newTabPage(_ controller: any NewTabPage, didInteractWithMessage interaction: NewTabPageMessageInteraction) { }
+    func newTabPageDidRequestSettings(_ controller: any NewTabPage) { }
 }

--- a/iOS/DuckDuckGo/NewTabPage/Redesign/Customization/NewTabPageCustomizationModel.swift
+++ b/iOS/DuckDuckGo/NewTabPage/Redesign/Customization/NewTabPageCustomizationModel.swift
@@ -20,8 +20,6 @@
 import Combine
 import Foundation
 
-/// Backs the "Customize Your Start" sheet: which sections the New Tab Page shows, plus the
-/// New Tab Page settings that are quick to reach from here rather than from Settings.
 final class NewTabPageCustomizationModel: ObservableObject {
 
     @Published var isFavoritesSectionVisible: Bool {
@@ -36,7 +34,6 @@ final class NewTabPageCustomizationModel: ObservableObject {
         didSet { keyboardSettings.onNewTab = isKeyboardShownOnNewTab }
     }
 
-    /// Opens the app's settings, where the rest of the New Tab Page options live.
     var onAllSettingsSelected: (() -> Void)?
 
     private var persistor: NewTabPageCustomizationPersisting

--- a/iOS/DuckDuckGo/NewTabPage/Redesign/Customization/NewTabPageCustomizationModel.swift
+++ b/iOS/DuckDuckGo/NewTabPage/Redesign/Customization/NewTabPageCustomizationModel.swift
@@ -1,0 +1,54 @@
+//
+//  NewTabPageCustomizationModel.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Combine
+import Foundation
+
+/// Backs the "Customize Your Start" sheet: which sections the New Tab Page shows, plus the
+/// New Tab Page settings that are quick to reach from here rather than from Settings.
+final class NewTabPageCustomizationModel: ObservableObject {
+
+    @Published var isFavoritesSectionVisible: Bool {
+        didSet { persistor.isFavoritesSectionVisible = isFavoritesSectionVisible }
+    }
+
+    @Published var isMessagesSectionVisible: Bool {
+        didSet { persistor.isMessagesSectionVisible = isMessagesSectionVisible }
+    }
+
+    @Published var isKeyboardShownOnNewTab: Bool {
+        didSet { keyboardSettings.onNewTab = isKeyboardShownOnNewTab }
+    }
+
+    /// Opens the app's settings, where the rest of the New Tab Page options live.
+    var onAllSettingsSelected: (() -> Void)?
+
+    private var persistor: NewTabPageCustomizationPersisting
+    private var keyboardSettings: KeyboardSettings
+
+    init(persistor: NewTabPageCustomizationPersisting = NewTabPageCustomizationStore(),
+         keyboardSettings: KeyboardSettings = KeyboardSettings()) {
+        self.persistor = persistor
+        self.keyboardSettings = keyboardSettings
+
+        isFavoritesSectionVisible = persistor.isFavoritesSectionVisible
+        isMessagesSectionVisible = persistor.isMessagesSectionVisible
+        isKeyboardShownOnNewTab = keyboardSettings.onNewTab
+    }
+}

--- a/iOS/DuckDuckGo/NewTabPage/Redesign/Customization/NewTabPageCustomizationStore.swift
+++ b/iOS/DuckDuckGo/NewTabPage/Redesign/Customization/NewTabPageCustomizationStore.swift
@@ -21,7 +21,6 @@ import Core
 import Foundation
 import Persistence
 
-/// Which sections of the New Tab Page the user has chosen to see.
 protocol NewTabPageCustomizationPersisting {
 
     var isFavoritesSectionVisible: Bool { get set }

--- a/iOS/DuckDuckGo/NewTabPage/Redesign/Customization/NewTabPageCustomizationStore.swift
+++ b/iOS/DuckDuckGo/NewTabPage/Redesign/Customization/NewTabPageCustomizationStore.swift
@@ -1,0 +1,62 @@
+//
+//  NewTabPageCustomizationStore.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Core
+import Foundation
+import Persistence
+
+/// Which sections of the New Tab Page the user has chosen to see.
+protocol NewTabPageCustomizationPersisting {
+
+    var isFavoritesSectionVisible: Bool { get set }
+    var isMessagesSectionVisible: Bool { get set }
+}
+
+private enum NewTabPageCustomizationStorageKeys: String, StorageKeyDescribing {
+    case isFavoritesSectionVisible = "com_duckduckgo_ios_newTabPage_favorites_isVisible"
+    case isMessagesSectionVisible = "com_duckduckgo_ios_newTabPage_messages_isVisible"
+}
+
+private struct NewTabPageCustomizationKeys: StoringKeys {
+    let isFavoritesSectionVisible = StorageKey<Bool>(NewTabPageCustomizationStorageKeys.isFavoritesSectionVisible)
+    let isMessagesSectionVisible = StorageKey<Bool>(NewTabPageCustomizationStorageKeys.isMessagesSectionVisible)
+}
+
+struct NewTabPageCustomizationStore: NewTabPageCustomizationPersisting {
+
+    private let keyValueStore: KeyValueStoring
+
+    init(keyValueStore: KeyValueStoring = UserDefaults.app) {
+        self.keyValueStore = keyValueStore
+    }
+
+    private var storage: any KeyedStoring<NewTabPageCustomizationKeys> {
+        keyValueStore.keyedStoring()
+    }
+
+    var isFavoritesSectionVisible: Bool {
+        get { storage.isFavoritesSectionVisible ?? true }
+        set { storage.isFavoritesSectionVisible = newValue }
+    }
+
+    var isMessagesSectionVisible: Bool {
+        get { storage.isMessagesSectionVisible ?? true }
+        set { storage.isMessagesSectionVisible = newValue }
+    }
+}

--- a/iOS/DuckDuckGo/NewTabPage/Redesign/Customization/NewTabPageCustomizationView.swift
+++ b/iOS/DuckDuckGo/NewTabPage/Redesign/Customization/NewTabPageCustomizationView.swift
@@ -25,7 +25,8 @@ struct NewTabPageCustomizationView: View {
 
     private enum Metrics {
         static let contentInset: CGFloat = 16
-        static let headerHeight: CGFloat = 68
+        static let headerMinHeight: CGFloat = 56
+        static let headerTopPadding: CGFloat = 16
         static let closeButtonIconPadding: CGFloat = 4
     }
 
@@ -42,61 +43,123 @@ struct NewTabPageCustomizationView: View {
                 keyboardSection
                 allSettingsSection
             }
+            .compactSectionSpacingIfAvailable()
             .applyInsetGroupedListStyle()
         }
         .background(Color(designSystemColor: .background))
     }
 
     private var header: some View {
-        ZStack {
+        HStack(alignment: .center, spacing: 0) {
+            closeButton
+                .hidden()
+
             Text(UserText.newTabPageCustomizationTitle)
                 .daxHeadline()
                 .foregroundColor(Color(designSystemColor: .textPrimary))
+                .multilineTextAlignment(.center)
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: .infinity)
 
-            HStack {
-                Spacer()
-                Button(action: onClose) {
-                    Image(uiImage: DesignSystemImages.Glyphs.Size24.close)
-                        .padding(Metrics.closeButtonIconPadding)
-                }
-                .buttonStyle(CloseButtonStyle())
-                .accessibilityLabel(UserText.keyCommandClose)
-            }
-            .padding(.horizontal, Metrics.contentInset - CloseButtonStyle.Constant.padding)
+            closeButton
         }
-        .frame(height: Metrics.headerHeight)
+        .padding(.horizontal, Metrics.contentInset - CloseButtonStyle.Constant.padding)
+        .padding(.top, Metrics.headerTopPadding)
+        .frame(minHeight: Metrics.headerMinHeight)
+    }
+
+    private var closeButton: some View {
+        Button(action: onClose) {
+            Image(uiImage: DesignSystemImages.Glyphs.Size24.close)
+                .padding(Metrics.closeButtonIconPadding)
+        }
+        .buttonStyle(CloseButtonStyle())
+        .fixedSize()
+        .accessibilityLabel(UserText.keyCommandClose)
     }
 
     private var sectionsSection: some View {
         Section {
-            SettingsCellView(label: UserText.sectionTitleFavorites,
-                             image: Image(uiImage: DesignSystemImages.Glyphs.Size24.bookmarkFavorite),
-                             accessory: .toggle(isOn: $model.isFavoritesSectionVisible))
+            NewTabPageCustomizationRow(title: UserText.sectionTitleFavorites,
+                                       image: DesignSystemImages.Glyphs.Size24.bookmarkFavorite,
+                                       control: .toggle($model.isFavoritesSectionVisible))
 
-            SettingsCellView(label: UserText.newTabPageCustomizationMessages,
-                             image: Image(uiImage: DesignSystemImages.Glyphs.Size24.chat),
-                             accessory: .toggle(isOn: $model.isMessagesSectionVisible))
+            NewTabPageCustomizationRow(title: UserText.newTabPageCustomizationMessages,
+                                       image: DesignSystemImages.Glyphs.Size24.chat,
+                                       control: .toggle($model.isMessagesSectionVisible))
         }
-        .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
     }
 
     private var keyboardSection: some View {
         Section {
-            SettingsCellView(label: UserText.newTabPageCustomizationAlwaysShowKeyboard,
-                             accessory: .toggle(isOn: $model.isKeyboardShownOnNewTab))
+            NewTabPageCustomizationRow(title: UserText.newTabPageCustomizationAlwaysShowKeyboard,
+                                       control: .toggle($model.isKeyboardShownOnNewTab))
         }
-        .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
     }
 
     private var allSettingsSection: some View {
         Section {
-            SettingsCellView(label: UserText.newTabPageCustomizationAllSettings,
-                             image: Image(uiImage: DesignSystemImages.Glyphs.Size24.settings),
-                             action: { model.onAllSettingsSelected?() },
-                             webLinkIndicator: true,
-                             isButton: true)
+            NewTabPageCustomizationRow(title: UserText.newTabPageCustomizationAllSettings,
+                                       image: DesignSystemImages.Glyphs.Size24.settings,
+                                       control: .button { model.onAllSettingsSelected?() })
+        }
+    }
+}
+
+private struct NewTabPageCustomizationRow: View {
+
+    enum Control {
+        case toggle(Binding<Bool>)
+        case button(() -> Void)
+    }
+
+    let title: String
+    var image: UIImage?
+    let control: Control
+
+    var body: some View {
+        Group {
+            switch control {
+            case .toggle(let isOn):
+                Toggle(isOn: isOn) {
+                    label
+                }
+                .toggleStyle(SwitchToggleStyle(tint: Color(designSystemColor: .accentPrimary)))
+            case .button(let action):
+                Button(action: action) {
+                    HStack(alignment: .firstTextBaseline, spacing: 8) {
+                        label
+                        Spacer(minLength: 8)
+                        Image(uiImage: DesignSystemImages.Glyphs.Size16.openIn)
+                            .foregroundColor(Color(designSystemColor: .iconsSecondary))
+                            .alignmentGuide(.firstTextBaseline, computeValue: iconBaseline)
+                            .accessibilityHidden(true)
+                    }
+                    .contentShape(Rectangle())
+                }
+            }
         }
         .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
+    }
+
+    private var label: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 8) {
+            if let image {
+                Image(uiImage: image)
+                    .foregroundColor(Color(designSystemColor: .icons))
+                    .alignmentGuide(.firstTextBaseline, computeValue: iconBaseline)
+                    .accessibilityHidden(true)
+            }
+            Text(title)
+                .daxBodyRegular()
+                .foregroundColor(Color(designSystemColor: .textPrimary))
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    private func iconBaseline(_ dimensions: ViewDimensions) -> CGFloat {
+        // Center each glyph on the first line's capital letters as text size changes.
+        dimensions[VerticalAlignment.center] + UIFont.daxBodyRegular().capHeight / 2
     }
 }
 

--- a/iOS/DuckDuckGo/NewTabPage/Redesign/Customization/NewTabPageCustomizationView.swift
+++ b/iOS/DuckDuckGo/NewTabPage/Redesign/Customization/NewTabPageCustomizationView.swift
@@ -1,0 +1,191 @@
+//
+//  NewTabPageCustomizationView.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import DesignResourcesKit
+import DesignResourcesKitIcons
+import SwiftUI
+
+/// The "Customize Your Start" sheet: what the New Tab Page shows, and the settings closest to it.
+struct NewTabPageCustomizationView: View {
+
+    private enum Metrics {
+        static let contentInset: CGFloat = 16
+        static let groupSpacing: CGFloat = 24
+        static let groupCornerRadius: CGFloat = 12
+        static let rowHeight: CGFloat = 52
+        static let rowSpacing: CGFloat = 12
+        static let headerHeight: CGFloat = 68
+        static let closeButtonSize: CGFloat = 40
+    }
+
+    @ObservedObject var model: NewTabPageCustomizationModel
+
+    let onClose: () -> Void
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+
+            ScrollView {
+                VStack(spacing: Metrics.groupSpacing) {
+                    sectionsGroup
+                    keyboardGroup
+                    allSettingsGroup
+                }
+                .padding(.horizontal, Metrics.contentInset)
+                .padding(.bottom, Metrics.groupSpacing)
+            }
+        }
+        .background(Color(designSystemColor: .backgroundSheets))
+    }
+
+    private var header: some View {
+        ZStack {
+            Text(UserText.newTabPageCustomizationTitle)
+                .daxHeadline()
+                .foregroundColor(Color(designSystemColor: .textPrimary))
+
+            HStack {
+                Spacer()
+                CircularCloseButton(action: onClose)
+                    .frame(width: Metrics.closeButtonSize, height: Metrics.closeButtonSize)
+            }
+            .padding(.horizontal, Metrics.contentInset)
+        }
+        .frame(height: Metrics.headerHeight)
+    }
+
+    private var sectionsGroup: some View {
+        group {
+            toggleRow(icon: DesignSystemImages.Glyphs.Size24.bookmarkFavorite,
+                      title: UserText.sectionTitleFavorites,
+                      isOn: $model.isFavoritesSectionVisible)
+
+            Divider().padding(.leading, Metrics.contentInset)
+
+            toggleRow(icon: DesignSystemImages.Glyphs.Size24.chat,
+                      title: UserText.newTabPageCustomizationMessages,
+                      isOn: $model.isMessagesSectionVisible)
+        }
+    }
+
+    private var keyboardGroup: some View {
+        group {
+            toggleRow(icon: nil,
+                      title: UserText.newTabPageCustomizationAlwaysShowKeyboard,
+                      isOn: $model.isKeyboardShownOnNewTab)
+        }
+    }
+
+    private var allSettingsGroup: some View {
+        group {
+            Button {
+                model.onAllSettingsSelected?()
+            } label: {
+                HStack(spacing: Metrics.rowSpacing) {
+                    Image(uiImage: DesignSystemImages.Glyphs.Size24.settings)
+                        .foregroundColor(Color(designSystemColor: .icons))
+
+                    Text(UserText.newTabPageCustomizationAllSettings)
+                        .daxBodyRegular()
+                        .foregroundColor(Color(designSystemColor: .textPrimary))
+
+                    Spacer()
+
+                    Image(uiImage: DesignSystemImages.Glyphs.Size24.openIn)
+                        .foregroundColor(Color(designSystemColor: .iconsSecondary))
+                }
+                .padding(.horizontal, Metrics.contentInset)
+                .frame(height: Metrics.rowHeight)
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+        }
+    }
+
+    private func toggleRow(icon: UIImage?, title: String, isOn: Binding<Bool>) -> some View {
+        HStack(spacing: Metrics.rowSpacing) {
+            if let icon {
+                Image(uiImage: icon)
+                    .foregroundColor(Color(designSystemColor: .icons))
+            }
+
+            Toggle(isOn: isOn) {
+                Text(title)
+                    .daxBodyRegular()
+                    .foregroundColor(Color(designSystemColor: .textPrimary))
+            }
+            .toggleStyle(SwitchToggleStyle(tint: Color(designSystemColor: .accentPrimary)))
+        }
+        .padding(.horizontal, Metrics.contentInset)
+        .frame(height: Metrics.rowHeight)
+    }
+
+    private func group<Content: View>(@ViewBuilder content: () -> Content) -> some View {
+        VStack(spacing: 0) {
+            content()
+        }
+        .background(
+            RoundedRectangle(cornerRadius: Metrics.groupCornerRadius)
+                .fill(Color(designSystemColor: .surface))
+        )
+    }
+}
+
+/// The sheet's close control, drawn with the same button the page uses to open the sheet.
+private struct CircularCloseButton: UIViewRepresentable {
+
+    let action: () -> Void
+
+    func makeUIView(context: Context) -> CircularButton {
+        let button = CircularButton()
+        button.isShadowHidden = true
+        button.setImage(DesignSystemImages.Glyphs.Size24.close, for: .normal)
+        button.setColors(foreground: UIColor(designSystemColor: .icons),
+                         background: UIColor(designSystemColor: .controlsFillPrimary))
+        button.accessibilityLabel = UserText.keyCommandClose
+        button.addTarget(context.coordinator, action: #selector(Coordinator.buttonTapped), for: .touchUpInside)
+        return button
+    }
+
+    func updateUIView(_ uiView: CircularButton, context: Context) {
+        context.coordinator.action = action
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(action: action)
+    }
+
+    final class Coordinator {
+
+        var action: () -> Void
+
+        init(action: @escaping () -> Void) {
+            self.action = action
+        }
+
+        @objc func buttonTapped() {
+            action()
+        }
+    }
+}
+
+#Preview {
+    NewTabPageCustomizationView(model: NewTabPageCustomizationModel(), onClose: {})
+}

--- a/iOS/DuckDuckGo/NewTabPage/Redesign/Customization/NewTabPageCustomizationView.swift
+++ b/iOS/DuckDuckGo/NewTabPage/Redesign/Customization/NewTabPageCustomizationView.swift
@@ -31,7 +31,7 @@ struct NewTabPageCustomizationView: View {
         static let rowHeight: CGFloat = 52
         static let rowSpacing: CGFloat = 12
         static let headerHeight: CGFloat = 68
-        static let closeButtonSize: CGFloat = 40
+        static let closeButtonIconPadding: CGFloat = 4
     }
 
     @ObservedObject var model: NewTabPageCustomizationModel
@@ -63,10 +63,14 @@ struct NewTabPageCustomizationView: View {
 
             HStack {
                 Spacer()
-                CircularCloseButton(action: onClose)
-                    .frame(width: Metrics.closeButtonSize, height: Metrics.closeButtonSize)
+                Button(action: onClose) {
+                    Image(uiImage: DesignSystemImages.Glyphs.Size24.close)
+                        .padding(Metrics.closeButtonIconPadding)
+                }
+                .buttonStyle(CloseButtonStyle())
+                .accessibilityLabel(UserText.keyCommandClose)
             }
-            .padding(.horizontal, Metrics.contentInset)
+            .padding(.horizontal, Metrics.contentInset - CloseButtonStyle.Constant.padding)
         }
         .frame(height: Metrics.headerHeight)
     }
@@ -145,44 +149,6 @@ struct NewTabPageCustomizationView: View {
             RoundedRectangle(cornerRadius: Metrics.groupCornerRadius)
                 .fill(Color(designSystemColor: .surface))
         )
-    }
-}
-
-/// The sheet's close control, drawn with the same button the page uses to open the sheet.
-private struct CircularCloseButton: UIViewRepresentable {
-
-    let action: () -> Void
-
-    func makeUIView(context: Context) -> CircularButton {
-        let button = CircularButton()
-        button.isShadowHidden = true
-        button.setImage(DesignSystemImages.Glyphs.Size24.close, for: .normal)
-        button.setColors(foreground: UIColor(designSystemColor: .icons),
-                         background: UIColor(designSystemColor: .controlsFillPrimary))
-        button.accessibilityLabel = UserText.keyCommandClose
-        button.addTarget(context.coordinator, action: #selector(Coordinator.buttonTapped), for: .touchUpInside)
-        return button
-    }
-
-    func updateUIView(_ uiView: CircularButton, context: Context) {
-        context.coordinator.action = action
-    }
-
-    func makeCoordinator() -> Coordinator {
-        Coordinator(action: action)
-    }
-
-    final class Coordinator {
-
-        var action: () -> Void
-
-        init(action: @escaping () -> Void) {
-            self.action = action
-        }
-
-        @objc func buttonTapped() {
-            action()
-        }
     }
 }
 

--- a/iOS/DuckDuckGo/NewTabPage/Redesign/Customization/NewTabPageCustomizationView.swift
+++ b/iOS/DuckDuckGo/NewTabPage/Redesign/Customization/NewTabPageCustomizationView.swift
@@ -25,10 +25,6 @@ struct NewTabPageCustomizationView: View {
 
     private enum Metrics {
         static let contentInset: CGFloat = 16
-        static let groupSpacing: CGFloat = 24
-        static let groupCornerRadius: CGFloat = 12
-        static let rowHeight: CGFloat = 52
-        static let rowSpacing: CGFloat = 12
         static let headerHeight: CGFloat = 68
         static let closeButtonIconPadding: CGFloat = 4
     }
@@ -41,17 +37,14 @@ struct NewTabPageCustomizationView: View {
         VStack(spacing: 0) {
             header
 
-            ScrollView {
-                VStack(spacing: Metrics.groupSpacing) {
-                    sectionsGroup
-                    keyboardGroup
-                    allSettingsGroup
-                }
-                .padding(.horizontal, Metrics.contentInset)
-                .padding(.bottom, Metrics.groupSpacing)
+            List {
+                sectionsSection
+                keyboardSection
+                allSettingsSection
             }
+            .applyInsetGroupedListStyle()
         }
-        .background(Color(designSystemColor: .backgroundSheets))
+        .background(Color(designSystemColor: .background))
     }
 
     private var header: some View {
@@ -74,80 +67,36 @@ struct NewTabPageCustomizationView: View {
         .frame(height: Metrics.headerHeight)
     }
 
-    private var sectionsGroup: some View {
-        group {
-            toggleRow(icon: DesignSystemImages.Glyphs.Size24.bookmarkFavorite,
-                      title: UserText.sectionTitleFavorites,
-                      isOn: $model.isFavoritesSectionVisible)
+    private var sectionsSection: some View {
+        Section {
+            SettingsCellView(label: UserText.sectionTitleFavorites,
+                             image: Image(uiImage: DesignSystemImages.Glyphs.Size24.bookmarkFavorite),
+                             accessory: .toggle(isOn: $model.isFavoritesSectionVisible))
 
-            Divider().padding(.leading, Metrics.contentInset)
-
-            toggleRow(icon: DesignSystemImages.Glyphs.Size24.chat,
-                      title: UserText.newTabPageCustomizationMessages,
-                      isOn: $model.isMessagesSectionVisible)
+            SettingsCellView(label: UserText.newTabPageCustomizationMessages,
+                             image: Image(uiImage: DesignSystemImages.Glyphs.Size24.chat),
+                             accessory: .toggle(isOn: $model.isMessagesSectionVisible))
         }
+        .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
     }
 
-    private var keyboardGroup: some View {
-        group {
-            toggleRow(icon: nil,
-                      title: UserText.newTabPageCustomizationAlwaysShowKeyboard,
-                      isOn: $model.isKeyboardShownOnNewTab)
+    private var keyboardSection: some View {
+        Section {
+            SettingsCellView(label: UserText.newTabPageCustomizationAlwaysShowKeyboard,
+                             accessory: .toggle(isOn: $model.isKeyboardShownOnNewTab))
         }
+        .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
     }
 
-    private var allSettingsGroup: some View {
-        group {
-            Button {
-                model.onAllSettingsSelected?()
-            } label: {
-                HStack(spacing: Metrics.rowSpacing) {
-                    Image(uiImage: DesignSystemImages.Glyphs.Size24.settings)
-                        .foregroundColor(Color(designSystemColor: .icons))
-
-                    Text(UserText.newTabPageCustomizationAllSettings)
-                        .daxBodyRegular()
-                        .foregroundColor(Color(designSystemColor: .textPrimary))
-
-                    Spacer()
-
-                    Image(uiImage: DesignSystemImages.Glyphs.Size24.openIn)
-                        .foregroundColor(Color(designSystemColor: .iconsSecondary))
-                }
-                .padding(.horizontal, Metrics.contentInset)
-                .frame(height: Metrics.rowHeight)
-                .contentShape(Rectangle())
-            }
-            .buttonStyle(.plain)
+    private var allSettingsSection: some View {
+        Section {
+            SettingsCellView(label: UserText.newTabPageCustomizationAllSettings,
+                             image: Image(uiImage: DesignSystemImages.Glyphs.Size24.settings),
+                             action: { model.onAllSettingsSelected?() },
+                             webLinkIndicator: true,
+                             isButton: true)
         }
-    }
-
-    private func toggleRow(icon: UIImage?, title: String, isOn: Binding<Bool>) -> some View {
-        HStack(spacing: Metrics.rowSpacing) {
-            if let icon {
-                Image(uiImage: icon)
-                    .foregroundColor(Color(designSystemColor: .icons))
-            }
-
-            Toggle(isOn: isOn) {
-                Text(title)
-                    .daxBodyRegular()
-                    .foregroundColor(Color(designSystemColor: .textPrimary))
-            }
-            .toggleStyle(SwitchToggleStyle(tint: Color(designSystemColor: .accentPrimary)))
-        }
-        .padding(.horizontal, Metrics.contentInset)
-        .frame(height: Metrics.rowHeight)
-    }
-
-    private func group<Content: View>(@ViewBuilder content: () -> Content) -> some View {
-        VStack(spacing: 0) {
-            content()
-        }
-        .background(
-            RoundedRectangle(cornerRadius: Metrics.groupCornerRadius)
-                .fill(Color(designSystemColor: .surface))
-        )
+        .listRowBackground(Color(singleUseColor: .groupedListContentBackground))
     }
 }
 

--- a/iOS/DuckDuckGo/NewTabPage/Redesign/Customization/NewTabPageCustomizationView.swift
+++ b/iOS/DuckDuckGo/NewTabPage/Redesign/Customization/NewTabPageCustomizationView.swift
@@ -21,7 +21,6 @@ import DesignResourcesKit
 import DesignResourcesKitIcons
 import SwiftUI
 
-/// The "Customize Your Start" sheet: what the New Tab Page shows, and the settings closest to it.
 struct NewTabPageCustomizationView: View {
 
     private enum Metrics {

--- a/iOS/DuckDuckGo/NewTabPage/Redesign/Customization/NewTabPageCustomizationViewController.swift
+++ b/iOS/DuckDuckGo/NewTabPage/Redesign/Customization/NewTabPageCustomizationViewController.swift
@@ -20,11 +20,8 @@
 import SwiftUI
 import UIKit
 
-/// Hosts the "Customize Your Start" sheet.
 final class NewTabPageCustomizationViewController: UIHostingController<NewTabPageCustomizationView> {
 
-    /// Asks the presenter to open the app's settings. Raised here rather than presented directly,
-    /// so settings replace this sheet instead of stacking on top of it.
     var onAllSettingsSelected: (() -> Void)?
 
     private let model: NewTabPageCustomizationModel
@@ -41,6 +38,7 @@ final class NewTabPageCustomizationViewController: UIHostingController<NewTabPag
 
         model.onAllSettingsSelected = { [weak self] in
             guard let self else { return }
+            // Dismiss first, so settings replace this sheet rather than stacking on top of it.
             dismiss(animated: true) {
                 self.onAllSettingsSelected?()
             }

--- a/iOS/DuckDuckGo/NewTabPage/Redesign/Customization/NewTabPageCustomizationViewController.swift
+++ b/iOS/DuckDuckGo/NewTabPage/Redesign/Customization/NewTabPageCustomizationViewController.swift
@@ -1,0 +1,63 @@
+//
+//  NewTabPageCustomizationViewController.swift
+//  DuckDuckGo
+//
+//  Copyright © 2026 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import SwiftUI
+import UIKit
+
+/// Hosts the "Customize Your Start" sheet.
+final class NewTabPageCustomizationViewController: UIHostingController<NewTabPageCustomizationView> {
+
+    /// Asks the presenter to open the app's settings. Raised here rather than presented directly,
+    /// so settings replace this sheet instead of stacking on top of it.
+    var onAllSettingsSelected: (() -> Void)?
+
+    private let model: NewTabPageCustomizationModel
+
+    init(model: NewTabPageCustomizationModel = NewTabPageCustomizationModel()) {
+        self.model = model
+
+        var onClose: (() -> Void)?
+        super.init(rootView: NewTabPageCustomizationView(model: model, onClose: { onClose?() }))
+
+        onClose = { [weak self] in
+            self?.dismiss(animated: true)
+        }
+
+        model.onAllSettingsSelected = { [weak self] in
+            guard let self else { return }
+            dismiss(animated: true) {
+                self.onAllSettingsSelected?()
+            }
+        }
+    }
+
+    @available(*, unavailable)
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        if let sheet = sheetPresentationController {
+            sheet.detents = [.medium(), .large()]
+            sheet.prefersGrabberVisible = true
+        }
+    }
+}

--- a/iOS/DuckDuckGo/NewTabPage/Redesign/RedesignedNewTabPageViewController.swift
+++ b/iOS/DuckDuckGo/NewTabPage/Redesign/RedesignedNewTabPageViewController.swift
@@ -54,8 +54,10 @@ final class RedesignedNewTabPageViewController: UIViewController, NewTabPage {
         let button = CircularButton()
         button.isShadowHidden = true
         button.setImage(DesignSystemImages.Glyphs.Size24.options, for: .normal)
-        button.setColors(foreground: UIColor(designSystemColor: .icons),
-                         background: UIColor(designSystemColor: .controlsFillPrimary))
+        button.setColors(foreground: UIColor(designSystemColor: .iconsSecondary),
+                         background: UIColor(designSystemColor: .controlsFillPrimary),
+                         pressedForeground: UIColor(designSystemColor: .iconsSecondary),
+                         pressedBackground: UIColor(designSystemColor: .controlsFillTertiary))
         button.accessibilityLabel = UserText.newTabPageCustomizationTitle
         button.addTarget(self, action: #selector(customizeButtonTapped), for: .touchUpInside)
         return button

--- a/iOS/DuckDuckGo/NewTabPage/Redesign/RedesignedNewTabPageViewController.swift
+++ b/iOS/DuckDuckGo/NewTabPage/Redesign/RedesignedNewTabPageViewController.swift
@@ -49,7 +49,6 @@ final class RedesignedNewTabPageViewController: UIViewController, NewTabPage {
         return stackView
     }()
 
-    /// Opens the customization sheet. Sits above the scrolling content, so it stays reachable.
     private lazy var customizeButton: CircularButton = {
         let button = CircularButton()
         button.isShadowHidden = true

--- a/iOS/DuckDuckGo/NewTabPage/Redesign/RedesignedNewTabPageViewController.swift
+++ b/iOS/DuckDuckGo/NewTabPage/Redesign/RedesignedNewTabPageViewController.swift
@@ -18,10 +18,17 @@
 //
 
 import DesignResourcesKit
+import DesignResourcesKitIcons
 import UIKit
 
 /// A New Tab Page built as a vertical stack of independent blocks.
 final class RedesignedNewTabPageViewController: UIViewController, NewTabPage {
+
+    private enum Metrics {
+        static let customizeButtonTopMargin: CGFloat = 10
+        static let customizeButtonTrailingMargin: CGFloat = 20
+        static let customizeButtonSize: CGFloat = 44
+    }
 
     weak var delegate: NewTabPageControllerDelegate?
     weak var chromeDelegate: BrowserChromeDelegate?
@@ -42,6 +49,18 @@ final class RedesignedNewTabPageViewController: UIViewController, NewTabPage {
         return stackView
     }()
 
+    /// Opens the customization sheet. Sits above the scrolling content, so it stays reachable.
+    private lazy var customizeButton: CircularButton = {
+        let button = CircularButton()
+        button.isShadowHidden = true
+        button.setImage(DesignSystemImages.Glyphs.Size24.options, for: .normal)
+        button.setColors(foreground: UIColor(designSystemColor: .icons),
+                         background: UIColor(designSystemColor: .controlsFillPrimary))
+        button.accessibilityLabel = UserText.newTabPageCustomizationTitle
+        button.addTarget(self, action: #selector(customizeButtonTapped), for: .touchUpInside)
+        return button
+    }()
+
     init(blocks: [any NewTabPageBlock]) {
         self.blocks = blocks
         super.init(nibName: nil, bundle: nil)
@@ -60,6 +79,16 @@ final class RedesignedNewTabPageViewController: UIViewController, NewTabPage {
         installBlocks()
     }
 
+    @objc private func customizeButtonTapped() {
+        let customizationViewController = NewTabPageCustomizationViewController()
+        customizationViewController.onAllSettingsSelected = { [weak self] in
+            guard let self else { return }
+            delegate?.newTabPageDidRequestSettings(self)
+        }
+
+        present(customizationViewController, animated: true)
+    }
+
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
 
@@ -71,9 +100,11 @@ final class RedesignedNewTabPageViewController: UIViewController, NewTabPage {
     private func addSubviews() {
         view.addSubview(scrollView)
         scrollView.addSubview(blocksStackView)
+        view.addSubview(customizeButton)
 
         scrollView.translatesAutoresizingMaskIntoConstraints = false
         blocksStackView.translatesAutoresizingMaskIntoConstraints = false
+        customizeButton.translatesAutoresizingMaskIntoConstraints = false
 
         NSLayoutConstraint.activate([
             scrollView.topAnchor.constraint(equalTo: view.topAnchor),
@@ -88,7 +119,14 @@ final class RedesignedNewTabPageViewController: UIViewController, NewTabPage {
 
             // Pinning the content width to the visible width leaves block heights as the only
             // thing that can make the page scroll.
-            blocksStackView.widthAnchor.constraint(equalTo: scrollView.frameLayoutGuide.widthAnchor)
+            blocksStackView.widthAnchor.constraint(equalTo: scrollView.frameLayoutGuide.widthAnchor),
+
+            customizeButton.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor,
+                                                 constant: Metrics.customizeButtonTopMargin),
+            customizeButton.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor,
+                                                      constant: -Metrics.customizeButtonTrailingMargin),
+            customizeButton.widthAnchor.constraint(equalToConstant: Metrics.customizeButtonSize),
+            customizeButton.heightAnchor.constraint(equalToConstant: Metrics.customizeButtonSize)
         ])
     }
 

--- a/iOS/DuckDuckGo/UserText.swift
+++ b/iOS/DuckDuckGo/UserText.swift
@@ -1832,6 +1832,13 @@ public struct UserText {
 
     // Customize Section
     public static let settingsCustomizeSection = NSLocalizedString("settings.customize", value: "Customize", comment: "Settings title for the customize section")
+
+    // MARK: - New Tab Page customization
+
+    public static let newTabPageCustomizationTitle = NSLocalizedString("new-tab-page.customization.title", value: "Customize Your Start", comment: "Title of the sheet for customizing the New Tab Page")
+    public static let newTabPageCustomizationMessages = NSLocalizedString("new-tab-page.customization.messages", value: "Messages", comment: "Name of the New Tab Page section showing messages, in the customization sheet")
+    public static let newTabPageCustomizationAlwaysShowKeyboard = NSLocalizedString("new-tab-page.customization.always-show-keyboard", value: "Always Show Keyboard", comment: "Setting to always show the keyboard when a new tab is opened")
+    public static let newTabPageCustomizationAllSettings = NSLocalizedString("new-tab-page.customization.all-settings", value: "All Settings", comment: "Opens the app settings from the New Tab Page customization sheet")
     public static let settingsKeyboard = NSLocalizedString("settings.keyboard", value: "Keyboard", comment: "Settings screen cell for Keyboard")
     public static let settingsPreviews = NSLocalizedString("settings.previews", value: "Long-Press Previews", comment: "Settings screen cell for long press previews")
     public static let settingsAutocompleteLabel = NSLocalizedString("settings.autocomplete", value: "Search Suggestions", comment: "Settings screen cell for autocomplete")

--- a/iOS/DuckDuckGo/UserText.swift
+++ b/iOS/DuckDuckGo/UserText.swift
@@ -1835,10 +1835,10 @@ public struct UserText {
 
     // MARK: - New Tab Page customization
 
-    public static let newTabPageCustomizationTitle = NSLocalizedString("new-tab-page.customization.title", value: "Customize Your Start", comment: "Title of the sheet for customizing the New Tab Page")
-    public static let newTabPageCustomizationMessages = NSLocalizedString("new-tab-page.customization.messages", value: "Messages", comment: "Name of the New Tab Page section showing messages, in the customization sheet")
-    public static let newTabPageCustomizationAlwaysShowKeyboard = NSLocalizedString("new-tab-page.customization.always-show-keyboard", value: "Always Show Keyboard", comment: "Setting to always show the keyboard when a new tab is opened")
-    public static let newTabPageCustomizationAllSettings = NSLocalizedString("new-tab-page.customization.all-settings", value: "All Settings", comment: "Opens the app settings from the New Tab Page customization sheet")
+    public static let newTabPageCustomizationTitle = NotLocalizedString("new-tab-page.customization.title", value: "Customize Your Start", comment: "Title of the sheet for customizing the New Tab Page")
+    public static let newTabPageCustomizationMessages = NotLocalizedString("new-tab-page.customization.messages", value: "Messages", comment: "Name of the New Tab Page section showing messages, in the customization sheet")
+    public static let newTabPageCustomizationAlwaysShowKeyboard = NotLocalizedString("new-tab-page.customization.always-show-keyboard", value: "Always Show Keyboard", comment: "Setting to always show the keyboard when a new tab is opened")
+    public static let newTabPageCustomizationAllSettings = NotLocalizedString("new-tab-page.customization.all-settings", value: "All Settings", comment: "Opens the app settings from the New Tab Page customization sheet")
     public static let settingsKeyboard = NSLocalizedString("settings.keyboard", value: "Keyboard", comment: "Settings screen cell for Keyboard")
     public static let settingsPreviews = NSLocalizedString("settings.previews", value: "Long-Press Previews", comment: "Settings screen cell for long press previews")
     public static let settingsAutocompleteLabel = NSLocalizedString("settings.autocomplete", value: "Search Suggestions", comment: "Settings screen cell for autocomplete")

--- a/iOS/DuckDuckGo/en.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/en.lproj/Localizable.strings
@@ -3403,18 +3403,6 @@ https://duckduckgo.com/mac";
 /* Title for the Strict Routing setting item. */
 "network.protection.vpn.strict.routing.setting.title" = "Enforce Strict Routing (Recommended)";
 
-/* Opens the app settings from the New Tab Page customization sheet */
-"new-tab-page.customization.all-settings" = "All Settings";
-
-/* Setting to always show the keyboard when a new tab is opened */
-"new-tab-page.customization.always-show-keyboard" = "Always Show Keyboard";
-
-/* Name of the New Tab Page section showing messages, in the customization sheet */
-"new-tab-page.customization.messages" = "Messages";
-
-/* Title of the sheet for customizing the New Tab Page */
-"new-tab-page.customization.title" = "Customize Your Start";
-
 /* Confirm button for the new address bar picker */
 "new.address.bar.picker.confirm" = "Confirm";
 

--- a/iOS/DuckDuckGo/en.lproj/Localizable.strings
+++ b/iOS/DuckDuckGo/en.lproj/Localizable.strings
@@ -3403,6 +3403,18 @@ https://duckduckgo.com/mac";
 /* Title for the Strict Routing setting item. */
 "network.protection.vpn.strict.routing.setting.title" = "Enforce Strict Routing (Recommended)";
 
+/* Opens the app settings from the New Tab Page customization sheet */
+"new-tab-page.customization.all-settings" = "All Settings";
+
+/* Setting to always show the keyboard when a new tab is opened */
+"new-tab-page.customization.always-show-keyboard" = "Always Show Keyboard";
+
+/* Name of the New Tab Page section showing messages, in the customization sheet */
+"new-tab-page.customization.messages" = "Messages";
+
+/* Title of the sheet for customizing the New Tab Page */
+"new-tab-page.customization.title" = "Customize Your Start";
+
 /* Confirm button for the new address bar picker */
 "new.address.bar.picker.confirm" = "Confirm";
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206226850447395/task/1217541351504816
Tech Design URL:
CC:

### Description
- Add "Customize Your Start" controller with a launching button to the redesigned New Tab Page.
- Add section visibility persistence

### Testing Steps
1. Launch the app with the redesign flag on.
2. On the New Tab Page, verify the customize button appears in the top right corner.
3. Tap it, verify the "Customize Your Start" sheet appears with Favorites, Messages, Always Show Keyboard and All Settings.
4. Toggle Favorites off, close the sheet, reopen it, verify the toggle is still off.
5. Force quit the app, relaunch, open the sheet again, verify the toggle is still off.
6. Toggle Always Show Keyboard, open Settings, Keyboard, verify the value matches.
7. Tap All Settings, verify the sheet dismisses and Settings opens.
9. Turn the redesign flag off, verify the current New Tab Page is unchanged.

### Impact and Risks
Low. All new code is guarded by `newTabPageRedesign` flag, which is disabled.

#### What could go wrong?
--

### Quality Considerations
-- 

### Notes to Reviewer
A bunch of user strings are defined as `NotLocalizedString`. These will be translated once the copy is finalized.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New UI and preference writes behind the NTP redesign path; keyboard uses an existing setting API with no auth or data-handling changes.
> 
> **Overview**
> Adds a **Customize Your Start** flow on the redesigned New Tab Page: a top-trailing options button opens a medium/large sheet where users can toggle **Favorites** and **Messages** visibility (stored in `UserDefaults` via `NewTabPageCustomizationStore`), flip **Always Show Keyboard** (wired to existing `KeyboardSettings.onNewTab`), or jump to **All Settings**.
> 
> **All Settings** dismisses the sheet first, then routes through a new `newTabPageDidRequestSettings` delegate callback so `MainViewController` can call `segueToSettings()` without stacking modals. Copy for the sheet is added under `UserText` as `NotLocalizedString` placeholders.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ebc4f1f1c0f4fb27a91dc7cb51c6965c0e22a07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->