### PR TITLE
[iOS] Fix floating UI button menus on iOS 26.5 Simulator

### DIFF
--- a/iOS/AtbUITests/FloatingUIXCUITests.swift
+++ b/iOS/AtbUITests/FloatingUIXCUITests.swift
@@ -190,6 +190,8 @@ class FloatingUIXCUITestCase: XCTestCase {
     func verifyAddressBarButtonMenus() {
         app.terminate()
         launchApp(additionalArguments: [
+            "-ff.contextualDuckAIMode", "true",
+            "-ff.pageContextFeature", "true",
             "-ff.aiChatContextualFloatingInput", "true",
             "-ff.aiChatNativeChatHistory", "true",
             "-ff.aiChatAddressBarRecentChats", "true",

--- a/iOS/AtbUITests/FloatingUIXCUITests.swift
+++ b/iOS/AtbUITests/FloatingUIXCUITests.swift
@@ -74,6 +74,8 @@ class FloatingUIXCUITestCase: XCTestCase {
         static let toolbarFire = "Browser.Toolbar.Button.Fire"
         static let toolbarMenu = "Browser.Toolbar.Button.Menu"
         static let domainCapsule = "Browser.FloatingDomainCapsule"
+        static let aiChat = "Browser.OmniBar.Button.AIChat"
+        static let customizable = "Browser.OmniBar.Button.Customizable"
     }
 
     private enum Page {
@@ -183,6 +185,41 @@ class FloatingUIXCUITestCase: XCTestCase {
 
         XCTAssertTrue(app.buttons["New Tab"].waitForExistence(timeout: timeout))
         XCTAssertTrue(app.buttons["New Fire Tab"].exists)
+    }
+
+    func verifyAddressBarButtonMenus() {
+        app.terminate()
+        launchApp(additionalArguments: [
+            "-ff.aiChatContextualFloatingInput", "true",
+            "-ff.aiChatNativeChatHistory", "true",
+            "-ff.aiChatAddressBarRecentChats", "true",
+            "-ff.customizeNTPIcons", "true",
+            "-aichat.settings.isEnabled", "true",
+        ])
+
+        let aiChatButton = element(withIdentifier: AccessibilityID.aiChat)
+        XCTAssertTrue(aiChatButton.waitForHittable(timeout: timeout))
+        aiChatButton.tap()
+        XCTAssertTrue(app.buttons["New Chat"].waitForHittable(timeout: timeout))
+        XCTAssertTrue(app.buttons["Chats"].waitForHittable(timeout: timeout))
+        XCTAssertFalse(app.buttons["Ask About Page"].exists)
+        dismissMenu(containing: "New Chat")
+
+        openPage(path: "/page-one", heading: Page.oneHeading)
+
+        XCTAssertTrue(aiChatButton.waitForHittable(timeout: timeout))
+        aiChatButton.tap()
+        XCTAssertTrue(app.buttons["Ask About Page"].waitForHittable(timeout: timeout))
+        dismissMenu(containing: "Ask About Page")
+
+        aiChatButton.press(forDuration: 0.8)
+        XCTAssertTrue(app.buttons["Ask About Page"].waitForHittable(timeout: timeout))
+        dismissMenu(containing: "Ask About Page")
+
+        let customizableButton = element(withIdentifier: AccessibilityID.customizable)
+        XCTAssertTrue(customizableButton.waitForHittable(timeout: timeout))
+        customizableButton.press(forDuration: 0.8)
+        XCTAssertTrue(app.buttons["Customize"].waitForHittable(timeout: timeout))
     }
 
     func verifyBrowserChromeInLandscape() {
@@ -516,11 +553,12 @@ class FloatingUIXCUITestCase: XCTestCase {
         app.webViews.firstMatch
     }
 
-    private func launchApp(toggleEnabled: Bool? = nil) {
+    private func launchApp(toggleEnabled: Bool? = nil, additionalArguments: [String] = []) {
         app.launchArguments = [
             "-clearAllDefaults",
             "isRunningUITests",
             "-isOnboardingCompleted", "true",
+            "-isInternalUser", "true",
             "-ff.floatingUIAugust2026", "true",
             "-ff.omniBarLongPressMenu", "true",
             "-AppleLanguages", "(en)",
@@ -532,6 +570,7 @@ class FloatingUIXCUITestCase: XCTestCase {
                 "-aichat.settings.showAIChatExperimentalSearchInput", String(toggleEnabled),
             ]
         }
+        app.launchArguments += additionalArguments
         app.launchEnvironment = [
             "UITEST_MODE": "1",
             "BASE_URL": serverBaseURL,
@@ -603,6 +642,11 @@ class FloatingUIXCUITestCase: XCTestCase {
             XCTFail("Address bar did not move to \(position.rawValue). Search field: \(searchField.debugDescription)", file: file, line: line)
         }
         assertBarPosition(position, file: file, line: line)
+    }
+
+    private func dismissMenu(containing actionTitle: String) {
+        app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.45)).tap()
+        XCTAssertTrue(app.buttons[actionTitle].waitForNonExistence(timeout: timeout))
     }
 
     private func collapseChrome(file: StaticString = #filePath, line: UInt = #line) {
@@ -889,6 +933,7 @@ final class FloatingUITopBarTests: FloatingUIXCUITestCase {
     func testUnifiedToggleInputTransitions() { verifyUnifiedToggleInputTransitions() }
     func testTabSwitcherTransitions() { verifyTabSwitcherTransitions() }
     func testBrowserChromeLongPressMenus() { verifyBrowserChromeLongPressMenus() }
+    func testAddressBarButtonMenus() { verifyAddressBarButtonMenus() }
     func testBrowserChromeInLandscape() { verifyBrowserChromeInLandscape() }
     func testDomainCapsuleAppears() { verifyDomainCapsuleAppears() }
     func testBrowsingMenuOpens() { verifyBrowsingMenuOpens() }
@@ -920,6 +965,7 @@ final class FloatingUIBottomBarTests: FloatingUIXCUITestCase {
     func testUnifiedToggleInputTransitions() { verifyUnifiedToggleInputTransitions() }
     func testTabSwitcherTransitions() { verifyTabSwitcherTransitions() }
     func testBrowserChromeLongPressMenus() { verifyBrowserChromeLongPressMenus() }
+    func testAddressBarButtonMenus() { verifyAddressBarButtonMenus() }
     func testBrowserChromeInLandscape() { verifyBrowserChromeInLandscape() }
     func testDomainCapsuleAppears() { verifyDomainCapsuleAppears() }
     func testBrowsingMenuOpens() { verifyBrowsingMenuOpens() }

--- a/iOS/DuckDuckGo/DefaultOmniBarView.swift
+++ b/iOS/DuckDuckGo/DefaultOmniBarView.swift
@@ -787,6 +787,15 @@ final class DefaultOmniBarView: UIView, OmniBarView, ExpandableOmniBarView {
         return view
     }
 
+    private var needsSimulatorContextMenuWorkaround: Bool {
+#if targetEnvironment(simulator)
+        let version = ProcessInfo.processInfo.operatingSystemVersion
+        return version.majorVersion == 26 && version.minorVersion <= 5
+#else
+        return false
+#endif
+    }
+
     private var glassEffectConstraints: [NSLayoutConstraint] = []
     private var floatingHostToContainerConstraints: [NSLayoutConstraint] = []
     private var floatingHostToGlassContentConstraints: [NSLayoutConstraint] = []
@@ -854,6 +863,11 @@ final class DefaultOmniBarView: UIView, OmniBarView, ExpandableOmniBarView {
 
     func makeGlass() {
         guard isFloatingUIEnabled else {
+            makeOpaque()
+            return
+        }
+        // iOS 26.5 Simulator glass breaks button menus.
+        if needsSimulatorContextMenuWorkaround {
             makeOpaque()
             return
         }
@@ -1388,6 +1402,8 @@ final class DefaultOmniBarView: UIView, OmniBarView, ExpandableOmniBarView {
         aiChatButton.accessibilityLabel = UserText.duckAiFeatureName
         aiChatButton.accessibilityIdentifier = "\(Constant.accessibilityPrefix).Button.AIChat"
         aiChatButton.accessibilityTraits = .button
+
+        customizableButton.accessibilityIdentifier = "\(Constant.accessibilityPrefix).Button.Customizable"
 
         // This is for compatibility purposes with old OmniBar
         searchAreaView.textField.accessibilityIdentifier = "searchEntry"

--- a/iOS/DuckDuckGo/DefaultOmniBarView.swift
+++ b/iOS/DuckDuckGo/DefaultOmniBarView.swift
@@ -787,15 +787,16 @@ final class DefaultOmniBarView: UIView, OmniBarView, ExpandableOmniBarView {
         return view
     }
 
-    private var needsSimulatorContextMenuWorkaround: Bool {
+    private static var defaultSupportsButtonMenusInGlass: Bool {
 #if targetEnvironment(simulator)
         let version = ProcessInfo.processInfo.operatingSystemVersion
-        return version.majorVersion == 26 && version.minorVersion <= 5
+        return version.majorVersion != 26 || version.minorVersion > 5
 #else
-        return false
+        return true
 #endif
     }
 
+    private let supportsButtonMenusInGlass: Bool
     private var glassEffectConstraints: [NSLayoutConstraint] = []
     private var floatingHostToContainerConstraints: [NSLayoutConstraint] = []
     private var floatingHostToGlassContentConstraints: [NSLayoutConstraint] = []
@@ -831,8 +832,14 @@ final class DefaultOmniBarView: UIView, OmniBarView, ExpandableOmniBarView {
         Self.init(isFloatingUIEnabled: false)
     }
 
-    init(isFloatingUIEnabled: Bool) {
+    convenience init(isFloatingUIEnabled: Bool) {
+        self.init(isFloatingUIEnabled: isFloatingUIEnabled,
+                  supportsButtonMenusInGlass: Self.defaultSupportsButtonMenusInGlass)
+    }
+
+    init(isFloatingUIEnabled: Bool, supportsButtonMenusInGlass: Bool) {
         self.isFloatingUIEnabled = isFloatingUIEnabled
+        self.supportsButtonMenusInGlass = supportsButtonMenusInGlass
         self.searchAreaView = DefaultOmniBarSearchView(centersContentVertically: isFloatingUIEnabled)
         if isFloatingUIEnabled {
             self.searchAreaContainerView = SearchAreaContainerView()
@@ -867,7 +874,7 @@ final class DefaultOmniBarView: UIView, OmniBarView, ExpandableOmniBarView {
             return
         }
         // iOS 26.5 Simulator glass breaks button menus.
-        if needsSimulatorContextMenuWorkaround {
+        if !supportsButtonMenusInGlass {
             makeOpaque()
             return
         }

--- a/iOS/DuckDuckGoTests/FloatingUITests.swift
+++ b/iOS/DuckDuckGoTests/FloatingUITests.swift
@@ -691,6 +691,10 @@ final class FloatingUILayoutPolicyTests: XCTestCase {
 
 final class DefaultOmniBarViewMinimalChromeTests: XCTestCase {
 
+    private func makeBarView(isFloatingUIEnabled: Bool) -> DefaultOmniBarView {
+        DefaultOmniBarView(isFloatingUIEnabled: isFloatingUIEnabled, supportsButtonMenusInGlass: true)
+    }
+
     private func firstGlassView(in view: UIView) -> UIVisualEffectView? {
         if let glassView = view as? UIVisualEffectView {
             return glassView
@@ -710,8 +714,16 @@ final class DefaultOmniBarViewMinimalChromeTests: XCTestCase {
         return view.subviews.lazy.compactMap(floatingContentHost(in:)).first
     }
 
+    func testWhenButtonMenusDoNotSupportGlassThenFloatingFieldIsOpaque() throws {
+        let barView = DefaultOmniBarView(isFloatingUIEnabled: true, supportsButtonMenusInGlass: false)
+        let searchContainer = try XCTUnwrap(barView.searchContainer)
+
+        XCTAssertNil(firstGlassView(in: searchContainer))
+        XCTAssertFalse(searchContainer.backgroundColor == .clear)
+    }
+
     func testWhenFloatingMinimalChromeBarEnabledThenLeadingAndTrailingGlassGroupsAreAddedAndRemoved() {
-        let barView = DefaultOmniBarView.create(isFloatingUIEnabled: true)
+        let barView = makeBarView(isFloatingUIEnabled: true)
         barView.frame = CGRect(x: 0, y: 0, width: 700, height: 60)
 
         // The address bar field already carries its own glass; enabling adds the two button groups.
@@ -725,7 +737,7 @@ final class DefaultOmniBarViewMinimalChromeTests: XCTestCase {
     }
 
     func testWhenFloatingUIDisabledThenMinimalChromeBarAddsNoGlassGroups() {
-        let barView = DefaultOmniBarView.create(isFloatingUIEnabled: false)
+        let barView = makeBarView(isFloatingUIEnabled: false)
         barView.frame = CGRect(x: 0, y: 0, width: 700, height: 60)
 
         let baseline = glassViewCount(in: barView)
@@ -735,7 +747,7 @@ final class DefaultOmniBarViewMinimalChromeTests: XCTestCase {
     }
 
     func testWhenFloatingBarResizesThenFieldGlassMatchesItsContainerBounds() {
-        let barView = DefaultOmniBarView.create(isFloatingUIEnabled: true)
+        let barView = makeBarView(isFloatingUIEnabled: true)
         barView.frame = CGRect(x: 0, y: 0, width: 390, height: 60)
         barView.layoutIfNeeded()
 
@@ -755,7 +767,7 @@ final class DefaultOmniBarViewMinimalChromeTests: XCTestCase {
     }
 
     func testWhenFloatingFieldIsAtBottomThenContentIsHostedInsideUntintedGlass() throws {
-        let barView = DefaultOmniBarView.create(isFloatingUIEnabled: true)
+        let barView = makeBarView(isFloatingUIEnabled: true)
         barView.frame = CGRect(x: 0, y: 0, width: 390, height: DefaultOmniBarView.expectedHeight)
         barView.isUsingSmallTopSpacing = true
         barView.layoutIfNeeded()
@@ -772,7 +784,7 @@ final class DefaultOmniBarViewMinimalChromeTests: XCTestCase {
     }
 
     func testWhenShieldAndLoupeShareTheIconSlotThenTheyShareACentre() throws {
-        let barView = DefaultOmniBarView.create(isFloatingUIEnabled: true)
+        let barView = makeBarView(isFloatingUIEnabled: true)
         barView.isUsingSmallTopSpacing = true
         barView.frame = CGRect(x: 0, y: 0, width: 390, height: barView.expectedHeight)
         let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 800))
@@ -800,7 +812,7 @@ final class DefaultOmniBarViewMinimalChromeTests: XCTestCase {
     }
 
     func testWhenEmbeddedFieldIsTallerThanItsControlsThenTheRowStaysCentred() throws {
-        let barView = DefaultOmniBarView.create(isFloatingUIEnabled: true)
+        let barView = makeBarView(isFloatingUIEnabled: true)
         barView.isUsingSmallTopSpacing = true
         barView.frame = CGRect(x: 0, y: 0, width: 390, height: barView.expectedHeight)
         let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 800))
@@ -820,7 +832,7 @@ final class DefaultOmniBarViewMinimalChromeTests: XCTestCase {
     }
 
     func testWhenEmbeddedFieldLaysOutThenIconSlotsAreInsetFromTheCapsuleEnds() throws {
-        let barView = DefaultOmniBarView.create(isFloatingUIEnabled: true)
+        let barView = makeBarView(isFloatingUIEnabled: true)
         barView.isUsingSmallTopSpacing = true
         barView.frame = CGRect(x: 0, y: 0, width: 390, height: barView.expectedHeight)
         let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 390, height: 800))
@@ -858,7 +870,7 @@ final class DefaultOmniBarViewMinimalChromeTests: XCTestCase {
     }
 
     func testWhenNonFloatingIPadSearchAreaExpandsThenModeToggleDoesNotOverlapBottomControls() throws {
-        let barView = DefaultOmniBarView.create(isFloatingUIEnabled: false)
+        let barView = makeBarView(isFloatingUIEnabled: false)
         barView.frame = CGRect(x: 0, y: 0, width: 1024, height: DefaultOmniBarView.expectedHeight)
         barView.setLayoutMode(.expandedPad)
         barView.isModeToggleHidden = false
@@ -873,7 +885,7 @@ final class DefaultOmniBarViewMinimalChromeTests: XCTestCase {
     }
 
     func testWhenFieldIsEmbeddedAtBottomThenItFillsTheFullSlotHeight() throws {
-        let barView = DefaultOmniBarView.create(isFloatingUIEnabled: true)
+        let barView = makeBarView(isFloatingUIEnabled: true)
         barView.isUsingSmallTopSpacing = true
         barView.frame = CGRect(x: 0, y: 0, width: 390, height: barView.expectedHeight)
         barView.layoutIfNeeded()
@@ -892,7 +904,7 @@ final class DefaultOmniBarViewMinimalChromeTests: XCTestCase {
         let toolbar = BrowserToolbarView(frame: CGRect(x: 0, y: 0, width: 390, height: 200))
         toolbar.overrideUserInterfaceStyle = .light
         toolbar.setFloatingStyleEnabled(true)
-        let barView = DefaultOmniBarView.create(isFloatingUIEnabled: true)
+        let barView = makeBarView(isFloatingUIEnabled: true)
         barView.isUsingSmallTopSpacing = true
         toolbar.setOmnibarView(barView, height: barView.expectedHeight)
 
@@ -908,7 +920,7 @@ final class DefaultOmniBarViewMinimalChromeTests: XCTestCase {
     }
 
     func testWhenFloatingFieldMovesBetweenTopAndBottomThenContentRemainsInsideCurrentGlass() throws {
-        let barView = DefaultOmniBarView.create(isFloatingUIEnabled: true)
+        let barView = makeBarView(isFloatingUIEnabled: true)
         barView.frame = CGRect(x: 0, y: 0, width: 390, height: DefaultOmniBarView.expectedHeight)
         barView.layoutIfNeeded()
 
@@ -935,7 +947,7 @@ final class DefaultOmniBarViewMinimalChromeTests: XCTestCase {
     }
 
     func testWhenBottomFloatingFieldLeavesFireModeThenContentReturnsToGlass() throws {
-        let barView = DefaultOmniBarView.create(isFloatingUIEnabled: true)
+        let barView = makeBarView(isFloatingUIEnabled: true)
         barView.frame = CGRect(x: 0, y: 0, width: 390, height: DefaultOmniBarView.expectedHeight)
         barView.isUsingSmallTopSpacing = true
 
@@ -953,7 +965,7 @@ final class DefaultOmniBarViewMinimalChromeTests: XCTestCase {
     }
 
     func testWhenGlassAppearanceIsUnchangedThenMakingGlassPreservesGlassView() throws {
-        let barView = DefaultOmniBarView.create(isFloatingUIEnabled: true)
+        let barView = makeBarView(isFloatingUIEnabled: true)
         barView.frame = CGRect(x: 0, y: 0, width: 390, height: DefaultOmniBarView.expectedHeight)
         barView.layoutIfNeeded()
         let glassView = try XCTUnwrap(firstGlassView(in: barView.searchContainer))
@@ -964,7 +976,7 @@ final class DefaultOmniBarViewMinimalChromeTests: XCTestCase {
     }
 
     func testWhenMaterialAppearanceRefreshesThenGlassViewIsRebuilt() throws {
-        let barView = DefaultOmniBarView.create(isFloatingUIEnabled: true)
+        let barView = makeBarView(isFloatingUIEnabled: true)
         barView.frame = CGRect(x: 0, y: 0, width: 390, height: DefaultOmniBarView.expectedHeight)
         barView.isUsingSmallTopSpacing = true
         barView.layoutIfNeeded()
@@ -976,7 +988,7 @@ final class DefaultOmniBarViewMinimalChromeTests: XCTestCase {
     }
 
     func testWhenFireModeChangesThenGlassViewIsRebuilt() throws {
-        let barView = DefaultOmniBarView.create(isFloatingUIEnabled: true)
+        let barView = makeBarView(isFloatingUIEnabled: true)
         barView.frame = CGRect(x: 0, y: 0, width: 390, height: DefaultOmniBarView.expectedHeight)
         barView.layoutIfNeeded()
         let glassView = try XCTUnwrap(firstGlassView(in: barView.searchContainer))
@@ -987,7 +999,7 @@ final class DefaultOmniBarViewMinimalChromeTests: XCTestCase {
     }
 
     func testWhenBottomFloatingBarTemporarilyHasZeroHeightThenCornerRadiusRemainsRounded() {
-        let barView = DefaultOmniBarView.create(isFloatingUIEnabled: true)
+        let barView = makeBarView(isFloatingUIEnabled: true)
         barView.frame = CGRect(x: 0, y: 0, width: 390, height: 0)
         barView.isUsingSmallTopSpacing = true
 
@@ -997,21 +1009,21 @@ final class DefaultOmniBarViewMinimalChromeTests: XCTestCase {
     }
 
     func testWhenBottomFloatingFieldThenExpectedHeightIsTheFortyEightPointPill() {
-        let barView = DefaultOmniBarView.create(isFloatingUIEnabled: true)
+        let barView = makeBarView(isFloatingUIEnabled: true)
         barView.isUsingSmallTopSpacing = true
 
         XCTAssertEqual(barView.expectedHeight, 48)
     }
 
     func testWhenTopFloatingFieldThenExpectedHeightStaysAtTheStandardBarHeight() {
-        let barView = DefaultOmniBarView.create(isFloatingUIEnabled: true)
+        let barView = makeBarView(isFloatingUIEnabled: true)
         barView.isUsingSmallTopSpacing = false
 
         XCTAssertEqual(barView.expectedHeight, DefaultOmniBarView.expectedHeight)
     }
 
     func testWhenTopFloatingFieldThenInputIsFortyEightPointsHighWithTwoPointInternalSpacing() throws {
-        let barView = DefaultOmniBarView.create(isFloatingUIEnabled: true)
+        let barView = makeBarView(isFloatingUIEnabled: true)
         barView.frame = CGRect(x: 0, y: 0, width: 390, height: barView.expectedHeight)
         barView.isUsingSmallTopSpacing = false
 
@@ -1035,7 +1047,7 @@ final class DefaultOmniBarViewMinimalChromeTests: XCTestCase {
     }
 
     func testWhenTopFloatingLandscapeChromeThenInputHeightStaysUnchanged() {
-        let barView = DefaultOmniBarView.create(isFloatingUIEnabled: true)
+        let barView = makeBarView(isFloatingUIEnabled: true)
         barView.frame = CGRect(x: 0, y: 0, width: 844, height: barView.expectedHeight)
         barView.isUsingSmallTopSpacing = false
         barView.isExpandedPhoneLayout = true
@@ -1048,7 +1060,7 @@ final class DefaultOmniBarViewMinimalChromeTests: XCTestCase {
     }
 
     func testWhenTopFloatingLandscapeEditingThenCompactModeKeepsInputHeightUnchanged() {
-        let barView = DefaultOmniBarView.create(isFloatingUIEnabled: true)
+        let barView = makeBarView(isFloatingUIEnabled: true)
         barView.frame = CGRect(x: 0, y: 0, width: 844, height: barView.expectedHeight)
         barView.isUsingSmallTopSpacing = false
         barView.isExpandedPhoneLayout = true
@@ -1061,7 +1073,7 @@ final class DefaultOmniBarViewMinimalChromeTests: XCTestCase {
     }
 
     func testWhenBottomFloatingLandscapeEditingThenCompactModeKeepsInputHeightUnchanged() {
-        let barView = DefaultOmniBarView.create(isFloatingUIEnabled: true)
+        let barView = makeBarView(isFloatingUIEnabled: true)
         barView.frame = CGRect(x: 0, y: 0, width: 844, height: barView.expectedHeight)
         barView.isUsingSmallTopSpacing = true
         barView.isExpandedPhoneLayout = true
@@ -1074,7 +1086,7 @@ final class DefaultOmniBarViewMinimalChromeTests: XCTestCase {
     }
 
     func testWhenNonFloatingTopFieldThenInputHeightStaysUnchanged() {
-        let barView = DefaultOmniBarView.create(isFloatingUIEnabled: false)
+        let barView = makeBarView(isFloatingUIEnabled: false)
         barView.frame = CGRect(x: 0, y: 0, width: 390, height: barView.expectedHeight)
         barView.isUsingSmallTopSpacing = false
 
@@ -1085,7 +1097,7 @@ final class DefaultOmniBarViewMinimalChromeTests: XCTestCase {
     }
 
     func testWhenBottomFloatingLandscapeChromeThenExpectedHeightStaysAtTheStandardBarHeight() {
-        let barView = DefaultOmniBarView.create(isFloatingUIEnabled: true)
+        let barView = makeBarView(isFloatingUIEnabled: true)
         barView.isUsingSmallTopSpacing = true
         barView.setLayoutMode(.expandedPhone, animated: false)
 
@@ -1093,7 +1105,7 @@ final class DefaultOmniBarViewMinimalChromeTests: XCTestCase {
     }
 
     func testWhenBottomFloatingPadChromeThenExpectedHeightStaysAtTheStandardBarHeight() {
-        let barView = DefaultOmniBarView.create(isFloatingUIEnabled: true)
+        let barView = makeBarView(isFloatingUIEnabled: true)
         barView.isUsingSmallTopSpacing = true
         barView.setLayoutMode(.expandedPad, animated: false)
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/392891325557410/task/1218354969421551?focus=true
Tech Design URL:
CC:

### Description
This is a temporary fix in the hope that new simulators fix it the problem.  It will look opaque on the simulator but should look like glass on a device.

### Testing Steps
1. Enable floating UI
1. Launch the app and check the browser chrome responds to all button clicks - especially where menus should appear (Duck.ai and long press the customisable button)
2. Check with the bar in the other position
3. Check on device, should appear as liquid glass

### Impact
Low: Should only affect simulators

#### What could go wrong?
Buttons / menus could break -> gated to simulator only + UI test

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is gated to the iOS 26.5 Simulator; production devices still use glass, with regression coverage in UI and unit tests.
> 
> **Overview**
> **Floating UI on iOS 26.5 Simulator** no longer uses liquid glass on the address bar when that material breaks omnibar button menus (Duck.ai and Customize). `DefaultOmniBarView` detects simulator OS 26.0–26.5 and routes `makeGlass()` through the existing opaque path instead; devices keep glass. A test-only initializer flag `supportsButtonMenusInGlass` documents and unit-tests that fallback.
> 
> **Test coverage** adds an accessibility ID for the customizable omnibar button, a UI scenario that exercises AI chat tap/long-press menus (with/without page context) and the Customize long-press menu in both top and bottom bar positions, plus a unit test that opaque rendering applies when glass menus are unsupported.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 967751f6f4af2bf75a12e6d49c1fe94f93eb33a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->