### PR TITLE
Update address bar shield position and size for consistency between animation and static icons

### DIFF
--- a/iOS/DuckDuckGo/DefaultOmniBarSearchView.swift
+++ b/iOS/DuckDuckGo/DefaultOmniBarSearchView.swift
@@ -152,7 +152,9 @@ final class DefaultOmniBarSearchView: UIView {
             leadingConstraint,
             mainStackView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -Metrics.horizontalInset),
 
-            notificationContainer.leadingAnchor.constraint(equalTo: leftIconContainerPlaceholder.leadingAnchor, constant: 4),
+            // Paired with `staticIconLeadingPadding` to centre the notification's shield on the
+            // privacy icon it hands over to.
+            notificationContainer.leadingAnchor.constraint(equalTo: leftIconContainerPlaceholder.leadingAnchor, constant: 1),
             notificationContainer.trailingAnchor.constraint(equalTo: textField.trailingAnchor),
             notificationContainer.centerYAnchor.constraint(equalTo: textField.centerYAnchor),
             notificationContainer.heightAnchor.constraint(equalTo: textField.heightAnchor, constant: 4),

--- a/iOS/DuckDuckGo/OmniBarNotification.swift
+++ b/iOS/DuckDuckGo/OmniBarNotification.swift
@@ -69,7 +69,7 @@ struct OmniBarNotification: View {
                 .resizable()
                 .aspectRatio(contentMode: .fit)
                 .frame(width: Constants.Size.staticIcon.width, height: Constants.Size.staticIcon.height)
-                .padding(.leading, 9)
+                .padding(.leading, Constants.Spacing.staticIconLeadingPadding)
                 .padding(.top, 7)
                 .padding(.bottom, 7)
                 .padding(.trailing, 9)
@@ -78,7 +78,7 @@ struct OmniBarNotification: View {
                 .resizable()
                 .aspectRatio(contentMode: .fit)
                 .frame(width: Constants.Size.staticIcon.width, height: Constants.Size.staticIcon.height)
-                .padding(.leading, 9)
+                .padding(.leading, Constants.Spacing.staticIconLeadingPadding)
                 .padding(.top, 7)
                 .padding(.bottom, 7)
                 .padding(.trailing, 9)
@@ -148,13 +148,14 @@ private enum Constants {
     enum Spacing {
         static let textClippingShapeOffset: CGFloat = -7
         static let textTrailingPadding: CGFloat = 12
+        static let staticIconLeadingPadding: CGFloat = 9
     }
     
     enum Size {
         static let animatedIcon = CGSize(width: 36, height: 36)
         static let cancel = CGSize(width: 13, height: 13)
         static let rowHeight: CGFloat = 76
-        static let staticIcon = CGSize(width: 21, height: 21)
+        static let staticIcon = CGSize(width: 24, height: 24)
     }
 
     enum Radius {

--- a/iOS/DuckDuckGo/OmniBarViewController.swift
+++ b/iOS/DuckDuckGo/OmniBarViewController.swift
@@ -527,6 +527,7 @@ class OmniBarViewController: UIViewController, OmniBar {
 
                             // Update to final icon state after animation completes
                             self.barView.privacyInfoContainer.privacyIcon.updateIcon(privacyIcon)
+                            self.barView.privacyInfoContainer.privacyIcon.resetToRestingFrame()
 
                             // Animation complete, process next in queue
                             self.completeCurrentAnimation()

--- a/iOS/DuckDuckGo/PrivacyIconView.swift
+++ b/iOS/DuckDuckGo/PrivacyIconView.swift
@@ -30,10 +30,11 @@ private extension PrivacyIconView {
     /// Scale factor for dynamic Dax Easter Egg logos to match PDF default logo visual size (24/47 ≈ 0.51)
     static let daxLogoScaleFactor: CGFloat = 0.51
 
-    /// The legacy art uses a 32pt canvas; the rebranded art uses a 24pt canvas.
-    /// We need to render them to different sizes to ensure the rebranded icon isn't enlarged too much.
+    /// The rebranded art draws the shield at 20 units inside its own canvas, so rendering an animation
+    /// at its canvas size lands the shield on the 20pt ink of a 24pt DesignResourcesKit icon. The legacy
+    /// art is drawn to different proportions and keeps its tuned sizes until it is removed.
+    static let legacyShieldSize: CGFloat = 47
     static let legacyShieldDotSize: CGFloat = 44
-    static let rebrandedShieldDotSize: CGFloat = 26
 }
 
 enum PrivacyIcon {
@@ -61,6 +62,8 @@ class PrivacyIconView: UIView {
     private(set) var shieldDotAnimationView: LottieAnimationView!
     private var transitionPlaceholderView: UIView!
 
+    private var shieldWidthConstraint: NSLayoutConstraint!
+    private var shieldHeightConstraint: NSLayoutConstraint!
     private var shieldDotWidthConstraint: NSLayoutConstraint!
     private var shieldDotHeightConstraint: NSLayoutConstraint!
 
@@ -114,9 +117,11 @@ class PrivacyIconView: UIView {
         ])
 
         // Protections Enabled Animation
+        shieldWidthConstraint = shieldAnimationView.widthAnchor.constraint(equalToConstant: Self.legacyShieldSize)
+        shieldHeightConstraint = shieldAnimationView.heightAnchor.constraint(equalToConstant: Self.legacyShieldSize)
         NSLayoutConstraint.activate([
-            shieldAnimationView.widthAnchor.constraint(equalToConstant: 47),
-            shieldAnimationView.heightAnchor.constraint(equalToConstant: 47),
+            shieldWidthConstraint,
+            shieldHeightConstraint,
             shieldAnimationView.centerXAnchor.constraint(equalTo: centerXAnchor),
             shieldAnimationView.centerYAnchor.constraint(equalTo: centerYAnchor)
         ])
@@ -166,10 +171,6 @@ class PrivacyIconView: UIView {
 
         let isRebranded = AppRebrand.isAppRebranded()
 
-        let shieldDotSize = isRebranded ? Self.rebrandedShieldDotSize : Self.legacyShieldDotSize
-        shieldDotWidthConstraint.constant = shieldDotSize
-        shieldDotHeightConstraint.constant = shieldDotSize
-
         let shieldAnimationName = isRebranded ? "shield.new" : "shield.new-legacy"
         let shieldDotAnimationName: String
         if useDarkStyle {
@@ -183,6 +184,14 @@ class PrivacyIconView: UIView {
 
         let shieldWithDotAnimation = LottieAnimation.named(shieldDotAnimationName, animationCache: cache)
         shieldDotAnimationView.animation = shieldWithDotAnimation
+
+        let shieldSize = isRebranded ? shieldAnimation?.size : nil
+        shieldWidthConstraint.constant = shieldSize?.width ?? Self.legacyShieldSize
+        shieldHeightConstraint.constant = shieldSize?.height ?? Self.legacyShieldSize
+
+        let shieldDotSize = isRebranded ? shieldWithDotAnimation?.size : nil
+        shieldDotWidthConstraint.constant = shieldDotSize?.width ?? Self.legacyShieldDotSize
+        shieldDotHeightConstraint.constant = shieldDotSize?.height ?? Self.legacyShieldDotSize
     }
     
     func updateIcon(_ newIcon: PrivacyIcon) {
@@ -301,19 +310,27 @@ class PrivacyIconView: UIView {
             staticImageView.isHidden = true
             shieldAnimationView.isHidden = false
             shieldDotAnimationView.isHidden = true
-
-            // Set animated view to frame 1
-            if let animation = shieldAnimationView.animation {
-                let totalFrames = animation.endFrame - animation.startFrame
-                shieldAnimationView.currentProgress = totalFrames > 0 ? 1.0 / totalFrames : 0.0
-            }
+            setRestingFrame(for: icon)
         case .shieldWithDot:
             staticImageView.isHidden = true
             shieldAnimationView.isHidden = true
             shieldDotAnimationView.isHidden = false
+            setRestingFrame(for: icon)
+        }
+    }
 
-            // Set to final frame (100%) to show completed shield with checkmark
-            shieldDotAnimationView.currentProgress = 1.0
+    func resetToRestingFrame() {
+        setRestingFrame(for: icon)
+    }
+
+    private func setRestingFrame(for icon: PrivacyIcon) {
+        switch icon {
+        case .shield:
+            shieldAnimationView.currentProgress = 0
+        case .shieldWithDot:
+            shieldDotAnimationView.currentProgress = 1
+        case .daxLogo, .alert:
+            break
         }
     }
     
@@ -409,7 +426,7 @@ class PrivacyIconView: UIView {
 
             /// If the trait collection changes then it means this view is already visible and animations have
             /// probably completed.
-            shieldDotAnimationView.currentProgress = 1.0
+            resetToRestingFrame()
         }
     }
 }

--- a/iOS/DuckDuckGo/PrivacyIconView.swift
+++ b/iOS/DuckDuckGo/PrivacyIconView.swift
@@ -30,9 +30,8 @@ private extension PrivacyIconView {
     /// Scale factor for dynamic Dax Easter Egg logos to match PDF default logo visual size (24/47 ≈ 0.51)
     static let daxLogoScaleFactor: CGFloat = 0.51
 
-    /// The rebranded art draws the shield at 20 units inside its own canvas, so rendering an animation
-    /// at its canvas size lands the shield on the 20pt ink of a 24pt DesignResourcesKit icon. The legacy
-    /// art is drawn to different proportions and keeps its tuned sizes until it is removed.
+    /// The rebranded art draws the shield at 20 units inside its own canvas.
+    /// Using this size results in the shield matching the 24pt DesignResourcesKit icon.
     static let legacyShieldSize: CGFloat = 47
     static let legacyShieldDotSize: CGFloat = 44
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414709148257752/task/1218156612396044?focus=true
Tech Design URL:
CC:

### Description

This PR updates the size and positioning of the address bar shield for consistency between the animating state and static state. They should now be the same size:

https://github.com/user-attachments/assets/381c8281-ba0f-4259-977f-e2957e262f7b


### Testing Steps

1. Build and run on iOS
2. Visit a website. Observe the shield animation and ensure the shield remains the same size and position throughout.

### Impact

Low: Minor visual changes, small bug fixes, improvement to existing features

Visual change, but very prominent, so needs to be correct.

#### What could go wrong?

Size or positioning of shield may be incorrect.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only layout and Lottie resting-frame behavior in the omnibar; incorrect sizing would be visible but has no security or data impact.
> 
> **Overview**
> Aligns the address bar **shield** so animated Lottie states and static/notification icons share the same visual size and position during handoffs (e.g. trackers-blocked notification → privacy icon).
> 
> **Privacy icon:** Rebrand builds size shield Lottie views from the animation asset dimensions (legacy still uses fixed 47/44pt). Resting frames are centralized via `setRestingFrame` / `resetToRestingFrame` (shield at progress 0, shield-with-dot at 1), including after tracker animation completes and on appearance changes.
> 
> **Omni bar notification:** Static shield artwork is **24×24** (was 21×21); leading padding is a named constant paired with a tighter notification container leading inset (4 → 1) so the notification shield centers on the privacy icon slot.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf91b9191916aa37c5a070d92ca57f0870c53ed3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->