### PR TITLE
Add macOS debug deployment toggle script

### DIFF
--- a/scripts/toggle-macos-debug-deployment.sh
+++ b/scripts/toggle-macos-debug-deployment.sh
@@ -1,0 +1,86 @@
+#!/bin/sh
+
+set -eu
+
+usage() {
+    echo "Usage: $0 [on|off|toggle]" >&2
+}
+
+if [ "$#" -gt 1 ]; then
+    usage
+    exit 1
+fi
+
+action="${1:-toggle}"
+case "$action" in
+    on|off|toggle) ;;
+    *)
+        usage
+        exit 1
+        ;;
+esac
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null)" || {
+    echo "error: Run this script from an apple-browsers Git checkout." >&2
+    exit 1
+}
+
+override_file="$repo_root/macOS/LocalOverrides.xcconfig"
+override_line='DEPLOYMENT_LOCATION[config=Debug] = YES'
+current_value=""
+
+if [ -f "$override_file" ]; then
+    current_value="$(awk '
+        /^[[:space:]]*DEPLOYMENT_LOCATION\[config=Debug\][[:space:]]*=/ {
+            value = $0
+            sub(/^[[:space:]]*DEPLOYMENT_LOCATION\[config=Debug\][[:space:]]*=[[:space:]]*/, "", value)
+        }
+        END { print value }
+    ' "$override_file")"
+fi
+
+if [ "$action" = "toggle" ]; then
+    if [ "$current_value" = "YES" ]; then
+        action="off"
+    else
+        action="on"
+    fi
+fi
+
+temporary_file="$(mktemp "${TMPDIR:-/tmp}/duckduckgo-local-overrides.XXXXXX")"
+trap 'rm -f "$temporary_file"' EXIT HUP INT TERM
+
+if [ -f "$override_file" ]; then
+    awk -v action="$action" -v override="$override_line" '
+        BEGIN { found = 0 }
+        /^[[:space:]]*DEPLOYMENT_LOCATION\[config=Debug\][[:space:]]*=/ {
+            if (action == "on" && !found) {
+                print override
+                found = 1
+            }
+            next
+        }
+        { print }
+        END {
+            if (action == "on" && !found) {
+                print override
+            }
+        }
+    ' "$override_file" > "$temporary_file"
+elif [ "$action" = "on" ]; then
+    printf '%s\n' "$override_line" > "$temporary_file"
+fi
+
+if [ "$action" = "off" ] && ! grep -q '[^[:space:]]' "$temporary_file"; then
+    rm -f "$override_file"
+    echo "Disabled macOS debug deployment."
+    exit 0
+fi
+
+if [ -f "$override_file" ] && cmp -s "$temporary_file" "$override_file"; then
+    echo "macOS debug deployment is already $action."
+    exit 0
+fi
+
+cp "$temporary_file" "$override_file"
+echo "Turned macOS debug deployment $action: $override_file"


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ External contributors: file an issue before opening a PR.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1215419848050295/task/1218368799524904?focus=true
Tech Design URL:
CC:

### Description

Back in April (https://github.com/duckduckgo/apple-browsers/pull/4510) we changed the debug build behavior to not automatically be deployed to `/Applications/DEBUG`.

This script makes it easier to toggle the behavior, as in case of PIR, we need the debug build to be in `/Applications` so the background agent can work

### Testing Steps
<!-- One action per step. Note expected outcome inline where relevant, e.g. "3. Tap Save → settings screen dismisses". Assume the reviewer is unfamiliar with this part of the app. -->
1. Run the script, confirm it does what it says
2.

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact

Low, internal tooling

#### What could go wrong?
<!-- Before submitting: identify realistic failure scenarios and check a mitigation exists in this diff (test, flag, guard). Only keep this section if the risk is non-obvious to a reviewer. Otherwise delete it. One line per scenario: "X could happen → mitigated by Y." -->

### Quality Considerations
<!-- Edge cases, performance, privacy/security impact — omit if not applicable -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Developer-only shell script that edits a local, gitignored xcconfig; no app runtime or release build impact.
> 
> **Overview**
> Adds **`scripts/toggle-macos-debug-deployment.sh`**, a small `sh` helper for developers to turn macOS **Debug** install-to-`/Applications` behavior on, off, or toggle (default).
> 
> The script must run inside an **apple-browsers** checkout, reads/writes **`macOS/LocalOverrides.xcconfig`** (gitignored local override), and sets or removes **`DEPLOYMENT_LOCATION[config=Debug] = YES`**. Turning **off** drops the override file when it would be empty; **on** creates or updates the line while preserving other override content. Idempotent when the desired state is already set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fabd916b13729aadc96d1b839c8d2a30d5c072a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->