### PR TITLE
macOS: Add Open AI Settings to Duck.ai menus

### DIFF
--- a/macOS/DuckDuckGo/Menus/AIChatMenu.swift
+++ b/macOS/DuckDuckGo/Menus/AIChatMenu.swift
@@ -40,6 +40,7 @@ final class AIChatMenu: NSMenu {
         var openNewVoiceChat: @MainActor () -> Void
         var openNewImageChat: @MainActor () -> Void
         var openChat: @MainActor (AIChatSuggestion) -> Void
+        var openAISettings: @MainActor () -> Void
         var deleteAllChats: () async -> Void
     }
 
@@ -111,6 +112,15 @@ final class AIChatMenu: NSMenu {
         return item
     }()
 
+    private lazy var openAISettingsItem: NSMenuItem = {
+        let item = NSMenuItem(title: UserText.aiChatChromeOpenAISettings, action: #selector(openAISettingsTapped), keyEquivalent: "")
+        item.target = self
+        item.withImage(
+            TabBarViewController.contextMenuIcon(DesignSystemImages.Glyphs.Size24.settingsAiChat),
+            visibleOnMacOS27: origin == .moreOptionsMenu)
+        return item
+    }()
+
     // MARK: - Dynamic chat items
 
     private var chatItems: [NSMenuItem] = []
@@ -175,6 +185,8 @@ final class AIChatMenu: NSMenu {
         // Dynamic chat items are inserted after recentChatsLabel by insertChatItems(_:)
         addItem(.separator())
         addItem(deleteAllChatsItem)
+        addItem(.separator())
+        addItem(openAISettingsItem)
     }
 
     // MARK: - NSMenu update
@@ -299,6 +311,10 @@ final class AIChatMenu: NSMenu {
         PixelKit.fire(pixel, frequency: .dailyAndStandard)
     }
 
+    @objc private func openAISettingsTapped() {
+        actions.openAISettings()
+    }
+
     @objc private func deleteAllChatsTapped() {
         var dialog = AIChatDeleteChatsDialog()
         let actions = self.actions
@@ -391,6 +407,9 @@ extension AIChatMenu.Actions {
             openChat: { suggestion in
                 aiChatConversationSourceHandler.setData(conversationSources.recentChat)
                 tabOpener.openAIChatTab(with: .existingChat(chatId: suggestion.chatId), behavior: .currentTab)
+            },
+            openAISettings: {
+                windowControllersManager.showTab(with: .settings(pane: .aiChat))
             },
             deleteAllChats: {
                 if case .failure(let error) = await historyCleaner.cleanAIChatHistory() {

--- a/macOS/UnitTests/AIChat/AIChatMenuTests.swift
+++ b/macOS/UnitTests/AIChat/AIChatMenuTests.swift
@@ -32,6 +32,7 @@ final class AIChatMenuTests: XCTestCase {
     private var openNewVoiceChatCalled = false
     private var openNewImageChatCalled = false
     private var openedChat: AIChatSuggestion?
+    private var openAISettingsCalled = false
     private var deleteAllChatsCalled = false
 
     override func setUp() {
@@ -42,6 +43,7 @@ final class AIChatMenuTests: XCTestCase {
             openNewVoiceChat: { [weak self] in self?.openNewVoiceChatCalled = true },
             openNewImageChat: { [weak self] in self?.openNewImageChatCalled = true },
             openChat: { [weak self] suggestion in self?.openedChat = suggestion },
+            openAISettings: { [weak self] in self?.openAISettingsCalled = true },
             deleteAllChats: { [weak self] in self?.deleteAllChatsCalled = true }
         )
     }
@@ -68,6 +70,7 @@ final class AIChatMenuTests: XCTestCase {
         XCTAssertTrue(titles.contains(UserText.aiChatMenuNewImageChat))
         XCTAssertTrue(titles.contains(UserText.aiChatMenuRecentChats))
         XCTAssertTrue(titles.contains(UserText.aiChatMenuDeleteAllChats))
+        XCTAssertEqual(titles.last, UserText.aiChatChromeOpenAISettings)
     }
 
     func testNewChatItemHasOptionCommandNShortcut() {
@@ -268,6 +271,29 @@ final class AIChatMenuTests: XCTestCase {
         let item = menu.items.first { $0.title == UserText.aiChatMenuNewImageChat }!
         menu.performActionForItem(at: menu.index(of: item))
         XCTAssertTrue(openNewImageChatCalled)
+    }
+
+    func testOpenAISettingsTappedCallsAction() {
+        let menu = AIChatMenu(suggestionsReader: suggestionsReader, actions: actions)
+        let item = menu.items.first { $0.title == UserText.aiChatChromeOpenAISettings }!
+        menu.performActionForItem(at: menu.index(of: item))
+        XCTAssertTrue(openAISettingsCalled)
+    }
+
+    func testDefaultOpenAISettingsActionOpensAIChatPreferences() {
+        let windowControllersManager = WindowControllersManagerMock()
+        let defaultActions = AIChatMenu.Actions.makeDefault(
+            conversationSources: .mainMenu,
+            remoteSettings: AIChatRemoteSettings(),
+            tabOpener: MockAIChatTabOpener(),
+            historyCleaner: StubAIChatHistoryCleaner(result: .success(())),
+            windowControllersManager: windowControllersManager,
+            aiChatSyncCleaner: { nil }
+        )
+
+        defaultActions.openAISettings()
+
+        XCTAssertEqual(windowControllersManager.showTabCalls, [.settings(pane: .aiChat)])
     }
 
     func testChatItemTappedCallsOpenChatWithCorrectSuggestion() async {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204006570077678/task/1215438194342413?focus=true
Tech Design URL:
CC:

### Description
Adds Open AI Settings as the final action in the Duck.ai application and More Options submenus. Reuses the existing label, AI settings icon, and settings navigation.

### Testing Steps
1. On macOS, enable the Duck.ai application menu and More Options shortcuts in AI Settings.
2. Open each Duck.ai submenu — Open AI Settings appears last with the AI settings icon.
3. Select it — AI Settings opens.

### Impact
Low. Adds a menu item backed by existing navigation.

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only menu entry wired to existing settings navigation; no auth, data, or chat-history logic changes.
> 
> **Overview**
> Adds **Open AI Settings** as the last item in the Duck.ai **application menu** and **More Options** submenu (after Delete All Chats), using existing copy (`UserText.aiChatChromeOpenAISettings`) and the AI settings glyph.
> 
> `AIChatMenu.Actions` gains `openAISettings`; the default implementation opens **Settings → AI Chat** via `windowControllersManager.showTab(with: .settings(pane: .aiChat))`. Unit tests cover menu placement, the injected action, and the default navigation behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f8afdd3c328242ddf29343daa3513895336c7b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->