### PR TITLE
Duck.ai: let an unreadable native-storage entries blob self-heal

### DIFF
--- a/SharedPackages/AIChat/Sources/AIChat/Shared/NativeStorage/DuckAiNativeDiskStorageHandler.swift
+++ b/SharedPackages/AIChat/Sources/AIChat/Shared/NativeStorage/DuckAiNativeDiskStorageHandler.swift
@@ -208,7 +208,7 @@ public final class DuckAiNativeDiskStorageHandler: DuckAiNativeStorageHandling, 
         guard let data = try settingsStore.value(for: \.settings) else {
             return [:]
         }
-        guard let dict = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+        guard let dict = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
             return [:]
         }
         return dict

--- a/SharedPackages/AIChat/Tests/AIChatTests/NativeStorage/DuckAiNativeDiskStorageHandlerTests.swift
+++ b/SharedPackages/AIChat/Tests/AIChatTests/NativeStorage/DuckAiNativeDiskStorageHandlerTests.swift
@@ -244,6 +244,21 @@ final class DuckAiNativeDiskStorageHandlerTests: XCTestCase {
         XCTAssertEqual(recorded.map { Set($0) }, Set(["a", "b"]))
     }
 
+    func testWhenSettingsBlobIsUnreadableThenDeleteChatStillRecordsId() throws {
+        settingsStore.underlyingDict[DuckAiNativeStorageKeyNames.settings.rawValue] = Data("}{ not json".utf8)
+
+        try handler.deleteChat(chatId: "chat-1")
+
+        let recorded = try handler.getEntry(key: DuckAiNativeStorageReservedEntryKeys.locallyDeletedChatIds.rawValue) as? [String]
+        XCTAssertEqual(recorded, ["chat-1"])
+    }
+
+    func testWhenSettingsBlobIsUnreadableThenGetEntryReturnsNil() throws {
+        settingsStore.underlyingDict[DuckAiNativeStorageKeyNames.settings.rawValue] = Data("}{ not json".utf8)
+
+        XCTAssertNil(try handler.getEntry(key: "theme"))
+    }
+
     func testWhenConcurrentDeleteChatsThenNoIdsAreLost() throws {
         let iterations = 100
         let queue1 = DispatchQueue(label: "test.delchat1", qos: .userInitiated)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1218325507257077?focus=true
Tech Design URL:
CC:

### Description
When a Duck.ai chat is deleted, the chat is removed and then the deletion is recorded so sync knows not to pull it back. If the stored settings blob could not be parsed as JSON, every entry read and write on that device threw, so chats were removed but their deletions were never recorded. The blob now falls back to empty and repairs itself, matching the behaviour already used for migration status.

### Testing Steps
1. With Sync on and a few Duck.ai chats in history, delete one from the recent chats list → it disappears.
2. Force quit, relaunch, open Duck.ai → the deleted chat does not come back.
3. Burn a chat with the Fire Button, then force quit and relaunch → the burned chat does not come back.
4. `cd SharedPackages/AIChat && swift test --filter DuckAiNativeDiskStorageHandlerTests` → 28 tests pass, including the two added here.

### Impact
Medium

#### What could go wrong?
A blob that is unreadable for a recoverable reason is now silently replaced rather than surfacing an error → the same fallback already applies to the type-mismatch branch beside it and to migration status, and the entries it holds are web-app state that the page rewrites.

### Quality Considerations
On 2026-09-08 a single phone reported 408 `m_duck-ai_native-storage_chat-delete_error` events plus 9 `m_duck-ai_native-storage_settings-put_error`, all NSCocoaErrorDomain 3840, inside a two-second window (09:54:47–09:54:48) and never again. That is one pixel per chat from a single bulk delete, not repeated retries, and the version and region in the alert are incidental — the pixel is per-occurrence, so one device can move it 1000%. One of the added tests reproduces that error signature exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UtZJsvGj3Ew6AcVjDXAPec

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Corrupt settings are silently discarded rather than surfacing errors, which could drop locally cached web-app state until the page repopulates it; the tradeoff is intentional and scoped to recoverable JSON parse failures.
> 
> **Overview**
> **Fixes Duck.ai chat deletes failing to persist when on-disk settings JSON is corrupt.**
> 
> `loadSettingsBlob()` now treats JSON parse failures like a missing blob and returns an empty dictionary (`try?` instead of `try`), so entry reads/writes—including recording `locallyDeletedChatIds` after `deleteChat`—can proceed and rewrite valid JSON. This matches the existing self-heal behavior used for migration status.
> 
> Adds tests that seed invalid settings data and assert chat delete still records the ID and `getEntry` returns `nil` instead of throwing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d0998062b0d803106f95ab123eb36cf8f787f5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->