### PR TITLE
iOS: Fix Duck.ai end-to-end setup for the new-tab menu

### DIFF
--- a/.maestro/release_tests/ai-chat.yaml
+++ b/.maestro/release_tests/ai-chat.yaml
@@ -16,11 +16,17 @@ tags:
         isRunningUITests: true
         ff.browsingMenuSheetEnabledByDefault: "true"
 
-# NTP: tap Duck.ai button — opens chat tab
+# NTP: open a chat through the Duck.ai menu when available
 - assertVisible:
     id: "Browser.OmniBar.Button.AIChat"
 - tapOn:
     id: "Browser.OmniBar.Button.AIChat"
+
+- runFlow:
+    when:
+        visible: "New Chat"
+    commands:
+        - tapOn: "New Chat"
 
 - runFlow:
     when:

--- a/.maestro/shared/open_chat_tab.yaml
+++ b/.maestro/shared/open_chat_tab.yaml
@@ -19,6 +19,12 @@ appId: com.duckduckgo.mobile.ios
     id: "Browser.OmniBar.Button.AIChat"
 
 - runFlow:
+    when:
+        visible: "New Chat"
+    commands:
+        - tapOn: "New Chat"
+
+- runFlow:
     file: dismiss_chat_open_modals.yaml
 
 - assertVisible: "Close tab"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414709148257752/task/1218391534056649

### Description
#6770 made the new-tab address-bar Duck.ai button present a menu instead of opening chat directly, so the Duck.ai e2e setup no longer reached the chat tab. Select **New Chat** when that menu appears, then continue through the existing consent handling and chat assertions. Configurations that still open chat directly skip the selection and take the same path.

Root cause of [the failed release job](https://github.com/duckduckgo/apple-browsers/actions/runs/34561492297/job/103148539694): the menu is gated on `DuckAIAddressBarMenuFactory.isChatHistoryAvailable` — non-iPad and both `aiChatNativeChatHistory` and `aiChatAddressBarRecentChats`. Both flags are `defaultValue: .enabled` and neither is present in the bundled `ios-config.json`, so both are on in the production leg. That is why the same 8 flows failed in **both** the production and internal legs (7 on `"Close tab" is visible`, `ai-chat` on `"Free Plan" is visible`).

The two touched setup paths — `shared/open_chat_tab.yaml` (7 flows) and `release_tests/ai-chat.yaml` (its own inline preamble) — account for exactly those 8 failures.

### Testing Steps
No manual steps: this is test automation, verified by running the tests themselves (see below).

### Impact
None: test automation only; no shipped app behaviour changes.

### Quality Considerations
**Local Maestro run — all 8 previously failing flows green.** Run against the CI-built `duckduckgo-ios-app` artifact from the failed run (this PR changes YAML only, so that binary is the right target), on iPhone 18 Pro Max / iOS 27.0, maestro 1.40.3, using the CI invocation `maestro test -e ONBOARDING_COMPLETED=true <flow>`:

| Flow | Result |
|---|---|
| `test_chat_tab_new_button` | pass |
| `test_uti_multiline_duck_ai_tab` | pass |
| `test_chat_tab_new_chat` | pass |
| `test_chat_tab_toolbar_buttons` | pass |
| `test_chat_tab_model_picker` | pass |
| `test_chat_tab_send_prompt` | pass |
| `test_ai_chat_tab_header` | pass |
| `ai-chat` | pass |

Each log shows exactly one `Tap on "New Chat"` and zero assertion failures, so the conditional genuinely fired rather than being silently skipped — the guard is doing the work, not hiding it. A separate probe flow also confirmed Maestro's accessibility bridge can see this `UIMenu`'s items (it cannot for some other in-app menus, so this was worth proving rather than assuming).

The conditional follows the existing convention in `shared/dismiss_chat_open_modals.yaml`. Skipping a missing menu cannot mask a broken chat entry, because the downstream `Close tab` / `Free Plan` assertions remain mandatory.

**Full release suite on the failing CI configuration — green.** [Run 34594221693](https://github.com/duckduckgo/apple-browsers/actions/runs/34594221693), dispatched on this branch with `user_modes=production` / `test_tags=release`: **56/56 flows passed on attempt 1**, including all eight that previously failed.

The setup-matrix log confirms it resolved to the configuration that failed in [run 34561492297](https://github.com/duckduckgo/apple-browsers/actions/runs/34561492297/job/103148539694): `iPhone-16`, `exclude-tags: ipad`, `user-mode: production`, plus the workflow's `--device-os iOS-18-2` and `-e ONBOARDING_COMPLETED=true` with no `INTERNAL_USER_MODE` override.

| Previously failing flow | CI result |
|---|---|
| `test_chat_tab_new_button` | Passed (1m 6s) |
| `test_uti_multiline_duck_ai_tab` | Passed (1m 7s) |
| `test_chat_tab_new_chat` | Passed (1m 8s) |
| `test_chat_tab_toolbar_buttons` | Passed (56s) |
| `test_chat_tab_model_picker` | Passed (1m 1s) |
| `test_chat_tab_send_prompt` | Passed (1m 20s) |
| `test_ai_chat_tab_header` | Passed (1m 10s) |
| `ai-chat` | Passed (3m 29s) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
