### PR TITLE
iOS: Keep glass OmniBar button menus open across unrelated trait changes

### DIFF
--- a/iOS/DuckDuckGo/DefaultOmniBarView.swift
+++ b/iOS/DuckDuckGo/DefaultOmniBarView.swift
@@ -787,16 +787,6 @@ final class DefaultOmniBarView: UIView, OmniBarView, ExpandableOmniBarView {
         return view
     }
 
-    private static var defaultSupportsButtonMenusInGlass: Bool {
-#if targetEnvironment(simulator)
-        let version = ProcessInfo.processInfo.operatingSystemVersion
-        return version.majorVersion != 26 || version.minorVersion > 5
-#else
-        return true
-#endif
-    }
-
-    private let supportsButtonMenusInGlass: Bool
     private var glassEffectConstraints: [NSLayoutConstraint] = []
     private var floatingHostToContainerConstraints: [NSLayoutConstraint] = []
     private var floatingHostToGlassContentConstraints: [NSLayoutConstraint] = []
@@ -832,14 +822,8 @@ final class DefaultOmniBarView: UIView, OmniBarView, ExpandableOmniBarView {
         Self.init(isFloatingUIEnabled: false)
     }
 
-    convenience init(isFloatingUIEnabled: Bool) {
-        self.init(isFloatingUIEnabled: isFloatingUIEnabled,
-                  supportsButtonMenusInGlass: Self.defaultSupportsButtonMenusInGlass)
-    }
-
-    init(isFloatingUIEnabled: Bool, supportsButtonMenusInGlass: Bool) {
+    init(isFloatingUIEnabled: Bool) {
         self.isFloatingUIEnabled = isFloatingUIEnabled
-        self.supportsButtonMenusInGlass = supportsButtonMenusInGlass
         self.searchAreaView = DefaultOmniBarSearchView(centersContentVertically: isFloatingUIEnabled)
         if isFloatingUIEnabled {
             self.searchAreaContainerView = SearchAreaContainerView()
@@ -870,11 +854,6 @@ final class DefaultOmniBarView: UIView, OmniBarView, ExpandableOmniBarView {
 
     func makeGlass() {
         guard isFloatingUIEnabled else {
-            makeOpaque()
-            return
-        }
-        // iOS 26.5 Simulator glass breaks button menus.
-        if !supportsButtonMenusInGlass {
             makeOpaque()
             return
         }

--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -7961,7 +7961,12 @@ extension MainViewController {
         if !themeColorManager.updateThemeColor() {
             updateStatusBarBackgroundColor()
         }
-        refreshSettledFloatingGlassAppearance()
+        // Rebuilding the glass detaches its controls and can dismiss an opening button menu.
+        // Unrelated trait changes must preserve that hierarchy.
+        if traitCollection.userInterfaceStyle != previousTraitCollection?.userInterfaceStyle
+            || traitCollection.accessibilityContrast != previousTraitCollection?.accessibilityContrast {
+            refreshSettledFloatingGlassAppearance()
+        }
         updateFindInPage()
 
         revealChromeIfPinned()

--- a/iOS/DuckDuckGoTests/FloatingUITests.swift
+++ b/iOS/DuckDuckGoTests/FloatingUITests.swift
@@ -692,7 +692,7 @@ final class FloatingUILayoutPolicyTests: XCTestCase {
 final class DefaultOmniBarViewMinimalChromeTests: XCTestCase {
 
     private func makeBarView(isFloatingUIEnabled: Bool) -> DefaultOmniBarView {
-        DefaultOmniBarView(isFloatingUIEnabled: isFloatingUIEnabled, supportsButtonMenusInGlass: true)
+        DefaultOmniBarView.create(isFloatingUIEnabled: isFloatingUIEnabled)
     }
 
     private func firstGlassView(in view: UIView) -> UIVisualEffectView? {
@@ -712,14 +712,6 @@ final class DefaultOmniBarViewMinimalChromeTests: XCTestCase {
             return host
         }
         return view.subviews.lazy.compactMap(floatingContentHost(in:)).first
-    }
-
-    func testWhenButtonMenusDoNotSupportGlassThenFloatingFieldIsOpaque() throws {
-        let barView = DefaultOmniBarView(isFloatingUIEnabled: true, supportsButtonMenusInGlass: false)
-        let searchContainer = try XCTUnwrap(barView.searchContainer)
-
-        XCTAssertNil(firstGlassView(in: searchContainer))
-        XCTAssertFalse(searchContainer.backgroundColor == .clear)
     }
 
     func testWhenFloatingMinimalChromeBarEnabledThenLeadingAndTrailingGlassGroupsAreAddedAndRemoved() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414709148257752/task/1218359865688082?focus=true
Tech Design URL:
CC:

### Description
With Floating UI enabled, tapping a glass omnibar button with an attached menu (for example the Duck.ai button) could dismiss the menu immediately as it opened (reproducible on iOS 26.5 simulator). `MainViewController.traitCollectionDidChange` rebuilt the floating glass background on every trait change callback. Rebuilding removes and recreates the glass view and temporarily detaches its controls, which cancels the button menu UIKit is presenting.

Remove the earlier simulator-only workaround, which forced the floating field opaque on the iOS 26.5 simulator.

### Testing Steps
1. Enable Floating UI in internal settings and restart the app.
2. On the new tab page, tap the Duck.ai button in the omnibar, verify its menu opens and stays open.
3. Repeat on a loaded web page, and with the bottom address bar position.
4. Switch the device between light and dark mode while the app is visible, verify the glass omnibar updates its appearance correctly.
5. Toggle Increase Contrast in Accessibility settings, verify the glass omnibar updates.

### Impact and Risks
Low. The change narrows when the glass background is rebuilt to the two trait dimensions that affect its colors.

#### What could go wrong?
--

### Quality Considerations
N/A

### Notes to Reviewer
--

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrows glass refresh to appearance-related traits; localized to floating UI chrome with no auth or data changes.
> 
> **Overview**
> Fixes floating OmniBar button menus (e.g. Duck.ai) closing immediately on open by **not** rebuilding floating glass on every `traitCollectionDidChange`. `MainViewController` now calls `refreshSettledFloatingGlassAppearance()` only when **user interface style** or **accessibility contrast** changes, so unrelated trait updates no longer tear down and recreate the glass hierarchy while UIKit is presenting a menu.
> 
> Removes the iOS 26.5 simulator workaround in `DefaultOmniBarView` (`supportsButtonMenusInGlass` / forced opaque field) and drops the matching unit test; tests construct the bar via `DefaultOmniBarView.create` again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f97d2571e78953e0ae9918df414740e0dd27acf2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->