### PR TITLE
PIR: Error handling for executeScript

### DIFF
--- a/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Model/Actions/ExecuteScript.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Model/Actions/ExecuteScript.swift
@@ -22,21 +22,25 @@ struct ExecuteScriptAction: Action {
     let id: String
     let actionType: ActionType
     let script: String
+    let failSilently: Bool
     let json: Data?
 
     enum CodingKeys: String, CodingKey {
         case id
         case actionType
         case script
+        case failSilently
     }
 
     init(id: String,
          actionType: ActionType,
          script: String,
+         failSilently: Bool = false,
          json: Data? = nil) {
         self.id = id
         self.actionType = actionType
         self.script = script
+        self.failSilently = failSilently
         self.json = json
     }
 
@@ -45,6 +49,7 @@ struct ExecuteScriptAction: Action {
         id = try container.decode(String.self, forKey: .id)
         actionType = try container.decode(ActionType.self, forKey: .actionType)
         script = try container.decode(String.self, forKey: .script)
+        failSilently = try container.decodeIfPresent(Bool.self, forKey: .failSilently) ?? false
         json = nil
     }
 
@@ -53,12 +58,14 @@ struct ExecuteScriptAction: Action {
         try container.encode(id, forKey: .id)
         try container.encode(actionType, forKey: .actionType)
         try container.encode(script, forKey: .script)
+        try container.encode(failSilently, forKey: .failSilently)
     }
 
     func with(json: Data?) -> ExecuteScriptAction {
         ExecuteScriptAction(id: id,
                             actionType: actionType,
                             script: script,
+                            failSilently: failSilently,
                             json: json)
     }
 }

--- a/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Operations/QueueManaging/JobQueueManager.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Operations/QueueManaging/JobQueueManager.swift
@@ -401,7 +401,8 @@ extension JobQueueManager: BrokerProfileJobStatusReportingDelegate {
                                                  version: version,
                                                  stepType: identifier?.stepType,
                                                  dataBrokerParent: dataBrokerParent,
-                                                 isFreeScan: isFreeScan))
+                                                 isFreeScan: isFreeScan,
+                                                 isSilentFailure: false))
         default:
             pixelHandler.fire(.otherError(error: error, dataBroker: brokerURL, version: version, isFreeScan: isFreeScan))
         }

--- a/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Operations/SubJob/SubJobWebRunner/SubJobWebRunner.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Operations/SubJob/SubJobWebRunner/SubJobWebRunner.swift
@@ -106,7 +106,8 @@ public extension SubJobWebRunning {
 
     func evaluateActionAndHaltIfNeeded(_ action: Action) async -> Bool {
         if !stageCalculator.isRetrying {
-            retriesCountOnError = 1
+            // Scripts are not idempotent, so a failed one is never re-run. Authors handle their own retries.
+            retriesCountOnError = action is ExecuteScriptAction ? 0 : 1
         }
 
         return false
@@ -565,6 +566,27 @@ public extension SubJobWebRunning {
             if actionsHandler?.stepType == .optOut {
                 stageCalculator.fireOptOutConditionNotFound()
             }
+
+            await executeNextStep()
+            return
+        }
+
+        if let executeScriptAction = actionsHandler?.currentAction() as? ExecuteScriptAction,
+           executeScriptAction.failSilently,
+           case DataBrokerProtectionError.actionFailed(let actionID, let message) = error {
+            Logger.action.log(loggerContext(for: executeScriptAction),
+                              message: "Script action failed silently, continuing with regular action execution")
+
+            // Fired here rather than through the status reporting delegate, which would mark the job failed.
+            pixelHandler.fire(.actionFailedError(error: error,
+                                                 actionId: actionID,
+                                                 message: message,
+                                                 dataBroker: context.dataBroker.url,
+                                                 version: context.dataBroker.version,
+                                                 stepType: actionsHandler?.stepType,
+                                                 dataBrokerParent: context.dataBroker.parent,
+                                                 isFreeScan: stageCalculator.isFreeScan,
+                                                 isSilentFailure: true))
 
             await executeNextStep()
             return

--- a/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Pixels/DataBrokerProtectionSharedPixels.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Pixels/DataBrokerProtectionSharedPixels.swift
@@ -100,10 +100,11 @@ public enum DataBrokerProtectionSharedPixels {
         public static let removedAtParamKey = "removed_at"
         public static let isAuthenticated = "isAuthenticated"
         public static let isFreeScan = "free_scan"
+        public static let isSilentFailure = "isSilentFailure"
     }
 
     case httpError(error: Error, code: Int, dataBroker: String, version: String, isFreeScan: Bool?)
-    case actionFailedError(error: Error, actionId: String, message: String, dataBroker: String, version: String, stepType: StepType?, dataBrokerParent: String?, isFreeScan: Bool?)
+    case actionFailedError(error: Error, actionId: String, message: String, dataBroker: String, version: String, stepType: StepType?, dataBrokerParent: String?, isFreeScan: Bool?, isSilentFailure: Bool)
     case otherError(error: Error, dataBroker: String, version: String, isFreeScan: Bool?)
     case databaseError(error: Error, functionOccurredIn: String)
     case cocoaError(error: Error, functionOccurredIn: String)
@@ -356,13 +357,14 @@ extension DataBrokerProtectionSharedPixels: PixelKit.Event {
                           Consts.dataBrokerParamKey: dataBroker,
                           Consts.dataBrokerVersionKey: version]
             return addingFreeScanParamIfNeeded(to: params, isFreeScan: isFreeScan)
-        case .actionFailedError(_, let actionId, let message, let dataBroker, let version, let stepType, let dataBrokerParent, let isFreeScan):
+        case .actionFailedError(_, let actionId, let message, let dataBroker, let version, let stepType, let dataBrokerParent, let isFreeScan, let isSilentFailure):
             let params = ["actionID": actionId,
                           "message": message,
                           Consts.dataBrokerParamKey: dataBroker,
                           Consts.dataBrokerVersionKey: version,
                           Consts.stepTypeKey: stepType?.rawValue ?? "unknown",
-                          Consts.parentKey: dataBrokerParent ?? ""]
+                          Consts.parentKey: dataBrokerParent ?? "",
+                          Consts.isSilentFailure: isSilentFailure.description]
             return addingFreeScanParamIfNeeded(to: params, isFreeScan: isFreeScan)
         case .otherError(let error, let dataBroker, let version, let isFreeScan):
             let params = ["kind": (error as? DataBrokerProtectionError)?.name ?? "unknown",
@@ -771,7 +773,7 @@ public class DataBrokerProtectionSharedPixelsHandler: EventMapping<DataBrokerPro
             case .secureVaultDatabaseRecreated:
                 pixelKit.fire(event.prefixed(platform.pixelNamePrefix), frequency: .dailyAndCount, withAdditionalParameters: parameters)
             case .httpError(let error, _, _, _, _),
-                    .actionFailedError(let error, _, _, _, _, _, _, _),
+                    .actionFailedError(let error, _, _, _, _, _, _, _, _),
                     .otherError(let error, _, _, _):
                 pixelKit.fire(DebugEvent(event, error: error).prefixed(platform.pixelNamePrefix), frequency: .dailyAndCount)
             case .databaseError(let error, _),

--- a/SharedPackages/DataBrokerProtectionCore/Tests/DataBrokerProtectionCoreTests/ActionRequestEncodingTests.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Tests/DataBrokerProtectionCoreTests/ActionRequestEncodingTests.swift
@@ -48,6 +48,45 @@ final class ActionRequestEncodingTests: XCTestCase {
         XCTAssertEqual(rawActionPayload["someNewField"] as? String, "hello-world")
     }
 
+    func testWhenExecuteScriptActionOmitsFailSilently_thenItDefaultsToFalse() throws {
+        let stepJSON = """
+            {
+                "stepType": "scan",
+                "actions": [
+                    {
+                        "actionType": "executeScript",
+                        "id": "execute-script-1",
+                        "script": "document.body.dataset.result = 'ok';"
+                    }
+                ]
+            }
+            """
+        let step = try JSONDecoder().decode(Step.self, from: Data(stepJSON.utf8))
+        let action = try XCTUnwrap(step.actions.first as? ExecuteScriptAction)
+
+        XCTAssertFalse(action.failSilently)
+    }
+
+    func testWhenExecuteScriptActionSetsFailSilently_thenItIsDecoded() throws {
+        let stepJSON = """
+            {
+                "stepType": "scan",
+                "actions": [
+                    {
+                        "actionType": "executeScript",
+                        "id": "execute-script-1",
+                        "script": "document.body.dataset.result = 'ok';",
+                        "failSilently": true
+                    }
+                ]
+            }
+            """
+        let step = try JSONDecoder().decode(Step.self, from: Data(stepJSON.utf8))
+        let action = try XCTUnwrap(step.actions.first as? ExecuteScriptAction)
+
+        XCTAssertTrue(action.failSilently)
+    }
+
     func testWhenExecuteScriptActionDoesNotContainRawJSON_thenActionRequestEncodingFallsBackToTypedAction() throws {
         let action = ExecuteScriptAction(id: "execute-script-1",
                                          actionType: .executeScript,

--- a/SharedPackages/DataBrokerProtectionCore/Tests/DataBrokerProtectionCoreTests/BrokerProfileJobActionTests.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Tests/DataBrokerProtectionCoreTests/BrokerProfileJobActionTests.swift
@@ -459,6 +459,131 @@ final class BrokerProfileJobActionTests: XCTestCase {
         XCTAssertFalse(webViewHandler.wasSetCookiesCalled)
     }
 
+    // MARK: - ExecuteScriptAction Tests
+
+    func testWhenSilencedExecuteScriptActionFails_thenJobContinuesAndSilentFailurePixelIsFired() async {
+        let mockPixelHandler = MockDataBrokerProtectionPixelsHandler()
+        let executeScriptAction = ExecuteScriptAction(id: "1", actionType: .executeScript, script: "", failSilently: true)
+        let nextAction = ExpectationAction(id: "2", actionType: .expectation)
+        let step = Step(type: .optOut, actions: [executeScriptAction, nextAction])
+        let sut = BrokerProfileOptOutSubJobWebRunner(
+            privacyConfig: PrivacyConfigurationManagingMock(),
+            prefs: ContentScopeProperties.mock,
+            context: BrokerProfileQueryData.mock(with: [step]),
+            emailConfirmationDataService: emailConfirmationDataService,
+            captchaService: captchaService,
+            featureFlagger: MockDBPFeatureFlagger(),
+            applicationNameForUserAgentProvider: { nil },
+            operationAwaitTime: 0,
+            stageCalculator: MockStageDurationCalculator(),
+            pixelHandler: mockPixelHandler,
+            executionConfig: BrokerJobExecutionConfig(),
+            actionsHandlerMode: .optOut,
+            shouldRunNextStep: { true }
+        )
+        sut.webViewHandler = webViewHandler
+        sut.actionsHandler = ActionsHandler.forOptOut(step)
+        _ = sut.actionsHandler?.nextAction()
+
+        await sut.onError(error: DataBrokerProtectionError.actionFailed(actionID: "1", message: "Script failed"))
+
+        XCTAssertFalse(webViewHandler.wasFinishCalled)
+        XCTAssertTrue(webViewHandler.wasExecuteCalledForUserData)
+        guard case .actionFailedError(_, let actionId, let message, _, _, _, _, _, let isSilentFailure) = mockPixelHandler.lastFiredEvent else {
+            return XCTFail("Expected an actionFailedError pixel")
+        }
+        XCTAssertEqual(actionId, "1")
+        XCTAssertEqual(message, "Script failed")
+        XCTAssertTrue(isSilentFailure)
+    }
+
+    func testWhenExecuteScriptActionFailsWithoutFailSilently_thenJobFails() async {
+        let mockPixelHandler = MockDataBrokerProtectionPixelsHandler()
+        let executeScriptAction = ExecuteScriptAction(id: "1", actionType: .executeScript, script: "")
+        let step = Step(type: .optOut, actions: [executeScriptAction])
+        let sut = BrokerProfileOptOutSubJobWebRunner(
+            privacyConfig: PrivacyConfigurationManagingMock(),
+            prefs: ContentScopeProperties.mock,
+            context: BrokerProfileQueryData.mock(with: [step]),
+            emailConfirmationDataService: emailConfirmationDataService,
+            captchaService: captchaService,
+            featureFlagger: MockDBPFeatureFlagger(),
+            applicationNameForUserAgentProvider: { nil },
+            operationAwaitTime: 0,
+            stageCalculator: MockStageDurationCalculator(),
+            pixelHandler: mockPixelHandler,
+            executionConfig: BrokerJobExecutionConfig(),
+            actionsHandlerMode: .optOut,
+            shouldRunNextStep: { true }
+        )
+        sut.webViewHandler = webViewHandler
+        sut.actionsHandler = ActionsHandler.forOptOut(step)
+        _ = sut.actionsHandler?.nextAction()
+
+        await sut.onError(error: DataBrokerProtectionError.actionFailed(actionID: "1", message: "Script failed"))
+
+        XCTAssertTrue(webViewHandler.wasFinishCalled)
+        XCTAssertNil(mockPixelHandler.lastFiredEvent)
+    }
+
+    func testWhenSilencedExecuteScriptActionIsCancelled_thenJobFails() async {
+        let mockPixelHandler = MockDataBrokerProtectionPixelsHandler()
+        let executeScriptAction = ExecuteScriptAction(id: "1", actionType: .executeScript, script: "", failSilently: true)
+        let step = Step(type: .optOut, actions: [executeScriptAction])
+        let sut = BrokerProfileOptOutSubJobWebRunner(
+            privacyConfig: PrivacyConfigurationManagingMock(),
+            prefs: ContentScopeProperties.mock,
+            context: BrokerProfileQueryData.mock(with: [step]),
+            emailConfirmationDataService: emailConfirmationDataService,
+            captchaService: captchaService,
+            featureFlagger: MockDBPFeatureFlagger(),
+            applicationNameForUserAgentProvider: { nil },
+            operationAwaitTime: 0,
+            stageCalculator: MockStageDurationCalculator(),
+            pixelHandler: mockPixelHandler,
+            executionConfig: BrokerJobExecutionConfig(),
+            actionsHandlerMode: .optOut,
+            shouldRunNextStep: { true }
+        )
+        sut.webViewHandler = webViewHandler
+        sut.actionsHandler = ActionsHandler.forOptOut(step)
+        _ = sut.actionsHandler?.nextAction()
+
+        await sut.onError(error: DataBrokerProtectionError.cancelled)
+
+        XCTAssertTrue(webViewHandler.wasFinishCalled)
+        XCTAssertNil(mockPixelHandler.lastFiredEvent)
+    }
+
+    func testWhenActionIsEvaluated_thenOnlyNonExecuteScriptActionsArmARetry() async {
+        let executeScriptAction = ExecuteScriptAction(id: "1", actionType: .executeScript, script: "")
+        let expectationAction = ExpectationAction(id: "2", actionType: .expectation)
+        let step = Step(type: .optOut, actions: [executeScriptAction, expectationAction])
+        let sut = BrokerProfileOptOutSubJobWebRunner(
+            privacyConfig: PrivacyConfigurationManagingMock(),
+            prefs: ContentScopeProperties.mock,
+            context: BrokerProfileQueryData.mock(with: [step]),
+            emailConfirmationDataService: emailConfirmationDataService,
+            captchaService: captchaService,
+            featureFlagger: MockDBPFeatureFlagger(),
+            applicationNameForUserAgentProvider: { nil },
+            operationAwaitTime: 0,
+            stageCalculator: MockStageDurationCalculator(),
+            pixelHandler: pixelHandler,
+            executionConfig: BrokerJobExecutionConfig(),
+            actionsHandlerMode: .optOut,
+            shouldRunNextStep: { true }
+        )
+        sut.webViewHandler = webViewHandler
+        sut.actionsHandler = ActionsHandler.forOptOut(step)
+
+        _ = await sut.evaluateActionAndHaltIfNeeded(executeScriptAction)
+        XCTAssertEqual(sut.retriesCountOnError, 0)
+
+        _ = await sut.evaluateActionAndHaltIfNeeded(expectationAction)
+        XCTAssertEqual(sut.retriesCountOnError, 1)
+    }
+
     // MARK: - ConditionAction Tests
 
     func testWhenConditionActionSucceedsInOptOutStep_thenFireOptOutConditionFoundIsCalled() async {

--- a/SharedPackages/DataBrokerProtectionCore/Tests/DataBrokerProtectionCoreTests/JobQueueManagerTests.swift
+++ b/SharedPackages/DataBrokerProtectionCore/Tests/DataBrokerProtectionCoreTests/JobQueueManagerTests.swift
@@ -736,7 +736,7 @@ final class JobQueueManagerTests: XCTestCase {
             return XCTFail("Expected pixel to be fired")
         }
 
-        if case let .actionFailedError(_, actionId, message, dataBroker, version, stepType, parent, _) = lastEvent {
+        if case let .actionFailedError(_, actionId, message, dataBroker, version, stepType, parent, _, _) = lastEvent {
             XCTAssertEqual(actionId, "action-id")
             XCTAssertEqual(message, "something happened")
             XCTAssertEqual(dataBroker, "broker.com")
@@ -775,7 +775,7 @@ final class JobQueueManagerTests: XCTestCase {
             return XCTFail("Expected pixel to be fired")
         }
 
-        if case let .actionFailedError(_, _, _, _, _, stepType, parent, _) = lastEvent {
+        if case let .actionFailedError(_, _, _, _, _, stepType, parent, _, _) = lastEvent {
             XCTAssertNil(stepType)
             XCTAssertNil(parent)
         } else {

--- a/iOS/PixelDefinitions/pixels/definitions/data_broker_protection.json5
+++ b/iOS/PixelDefinitions/pixels/definitions/data_broker_protection.json5
@@ -1070,7 +1070,7 @@
         ]
     },
     "m_ios_dbp_data_broker_action-failed_error": {
-        "description": "Fired when a scan or opt-out action fails while processing a data broker.",
+        "description": "Fired when a scan or opt-out action fails while processing a data broker, including executeScript failures silenced by failSilently. A silenced failure does not stop the job, so this pixel does not necessarily indicate a failed scan or opt-out; filter on the isSilentFailure parameter to separate the two.",
         "owners": ["quanganhdo"],
         "triggers": ["other"],
         "suffixes": ["daily_count"],
@@ -1096,6 +1096,11 @@
                 "description": "Identifies the failing step type (scan or optOut)",
                 "type": "string",
                 "enum": ["scan", "optOut", "unknown"]
+            },
+            {
+                "key": "isSilentFailure",
+                "description": "True when the failure was silenced by failSilently on an executeScript action and the job continued to the next action",
+                "type": "boolean"
             },
             "dbpParentBroker",
             "dbpIsFreeScan"

--- a/iOS/PixelDefinitions/pixels/params_dictionary.json5
+++ b/iOS/PixelDefinitions/pixels/params_dictionary.json5
@@ -285,6 +285,7 @@
             "getCaptchaInfo",
             "solveCaptcha",
             "condition",
+            "executeScript",
             "unknown"
         ]
     },

--- a/macOS/PixelDefinitions/pixels/definitions/data_broker_protection.json5
+++ b/macOS/PixelDefinitions/pixels/definitions/data_broker_protection.json5
@@ -957,7 +957,7 @@
         ]
     },
     "m_mac_dbp_data_broker_action-failed_error": {
-        "description": "Fired when a scan or opt-out action fails while processing a data broker.",
+        "description": "Fired when a scan or opt-out action fails while processing a data broker, including executeScript failures silenced by failSilently. A silenced failure does not stop the job, so this pixel does not necessarily indicate a failed scan or opt-out; filter on the isSilentFailure parameter to separate the two.",
         "owners": ["quanganhdo"],
         "triggers": ["other"],
         "suffixes": ["daily_count"],
@@ -983,6 +983,11 @@
                 "description": "Identifies the failing step type (scan or optOut)",
                 "type": "string",
                 "enum": ["scan", "optOut", "unknown"]
+            },
+            {
+                "key": "isSilentFailure",
+                "description": "True when the failure was silenced by failSilently on an executeScript action and the job continued to the next action",
+                "type": "boolean"
             },
             "dbpParentBroker",
             "dbpIsFreeScan",

--- a/macOS/PixelDefinitions/pixels/params_dictionary.json5
+++ b/macOS/PixelDefinitions/pixels/params_dictionary.json5
@@ -338,6 +338,7 @@
             "getCaptchaInfo",
             "solveCaptcha",
             "condition",
+            "executeScript",
             "unknown"
         ]
     },


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ External contributors: file an issue before opening a PR.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1217806727201843?focus=true
Tech Design URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1217897464444079?focus=true
CC:

### Description
<!-- What changed and why, in plain English. No class names, method names, or implementation details — the diff shows those. Keep it brief. -->

Adds timeout and error handling for `executeScript`

### Testing Steps
<!-- One action per step. Note expected outcome inline where relevant, e.g. "3. Tap Save → settings screen dismisses". Assume the reviewer is unfamiliar with this part of the app. -->
1. CI passes
2. Verify against the test JSON in debugging tool

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact

Minor

#### What could go wrong?
<!-- Before submitting: identify realistic failure scenarios and check a mitigation exists in this diff (test, flag, guard). Only keep this section if the risk is non-obvious to a reviewer. Otherwise delete it. One line per scenario: "X could happen → mitigated by Y." -->

### Quality Considerations
<!-- Edge cases, performance, privacy/security impact — omit if not applicable -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes broker job failure semantics for executeScript when failSilently is enabled; incorrect broker JSON could mask real opt-out/scan failures, though defaults preserve prior behavior and tests cover the new paths.
> 
> **Overview**
> Adds optional **`failSilently`** on broker **`executeScript`** actions so script failures can advance the job instead of failing the scan/opt-out.
> 
> When `failSilently` is true and the failure is an `actionFailed` error, **`SubJobWebRunner`** skips retries (scripts are treated as non-idempotent), continues to the next action, and emits **`actionFailedError`** with **`isSilentFailure: true`** so telemetry still records the failure without going through the status delegate path that would mark the job failed. Hard failures and cancellations behave as before.
> 
> **`actionFailedError`** pixels on iOS/macOS gain an **`isSilentFailure`** parameter (and **`executeScript`** is added to action-type enums where needed). **`JobQueueManager`** continues to report non-silent action failures with **`isSilentFailure: false`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85011f2f8f8bfb23bc844ede168f26dd891aefea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->