### PR TITLE
Fix flaky test

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/DDGSync.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/DDGSync.swift
@@ -252,7 +252,7 @@ public class DDGSync: DDGSyncing {
             throw SyncError.accountNotFound
         }
 
-        let wasDeviceInfoMigrationRunning = deviceInfoMigrationTask != nil
+        let wasDeviceInfoMigrationRunning = deviceInfoUpdateState.isMigrationRunning
         do {
             let result = try await dependencies.account.fetchDevicesForAccount(account)
             fireUnifiedReadObservations(result.unifiedReadObservations, for: account)
@@ -267,9 +267,9 @@ public class DDGSync: DDGSyncing {
 
     public func updateDeviceName(_ name: String) async throws -> [RegisteredDevice] {
         let isUnifiedWriteEnabled = dependencies.syncFeatureFlags.canWriteUnifiedDeviceList()
-        isDeviceRenameInProgress = true
-        defer { isDeviceRenameInProgress = false }
-        await cancelDeviceInfoUpdatesAndWait()
+        deviceInfoUpdateState.setRenameInProgress(true)
+        defer { deviceInfoUpdateState.setRenameInProgress(false) }
+        await deviceInfoUpdateState.cancelAllAndWait()
 
         guard let account = try dependencies.secureStore.account() else {
             throw SyncError.accountNotFound
@@ -363,27 +363,6 @@ public class DDGSync: DDGSyncing {
             throw SyncError.accountNotFound
         }
         return deviceInfoMigrationCoordinator.hasCompletedMigration(for: account)
-    }
-
-    public func runDeviceInfoMigrationForDebug() async throws {
-        guard let account = try dependencies.secureStore.account() else {
-            throw SyncError.accountNotFound
-        }
-
-        // Let an automatic migration finish before starting the explicit debug run.
-        if let migrationTask = deviceInfoMigrationTask,
-           let migrationTaskID = deviceInfoMigrationTaskID {
-            await migrationTask.value
-            clearCompletedDeviceInfoMigrationTask(withID: migrationTaskID)
-        }
-
-        scheduleDeviceInfoMigration(for: account)
-        let migrationTask = deviceInfoMigrationTask
-        let migrationTaskID = deviceInfoMigrationTaskID
-        await migrationTask?.value
-        if let migrationTaskID {
-            clearCompletedDeviceInfoMigrationTask(withID: migrationTaskID)
-        }
     }
 
     public func resetDeviceInfoMigrationForDebug() {
@@ -542,13 +521,7 @@ public class DDGSync: DDGSyncing {
 
             var didRemoveAccount = false
             do {
-                deviceInfoMigrationTask?.cancel()
-                deviceInfoMigrationTask = nil
-                deviceInfoMigrationTaskID = nil
-                currentDeviceInfoRepairTask?.cancel()
-                currentDeviceInfoRepairTask = nil
-                currentDeviceInfoRepairTaskID = nil
-                hasAttemptedCurrentDeviceInfoRepair = false
+                deviceInfoUpdateState.cancelAll()
                 try dependencies.secureStore.removeAccount()
                 clearAccountInfoKeyCache(for: storedAccount)
                 deviceInfoMigrationCoordinator.reset()
@@ -732,19 +705,9 @@ public class DDGSync: DDGSyncing {
     }
 
     private func scheduleDeviceInfoMigration(for account: SyncAccount) {
-        guard deviceInfoMigrationTask == nil else {
-            return
-        }
         let deviceInfoMigrationCoordinator = deviceInfoMigrationCoordinator
-        let taskID = UUID()
-        deviceInfoMigrationTaskID = taskID
-        let task = Task {
+        deviceInfoUpdateState.scheduleMigration {
             await deviceInfoMigrationCoordinator.migrateCurrentDeviceIfNeeded(for: account)
-        }
-        deviceInfoMigrationTask = task
-        Task { [weak self] in
-            await task.value
-            self?.clearCompletedDeviceInfoMigrationTask(withID: taskID)
         }
     }
 
@@ -790,57 +753,14 @@ public class DDGSync: DDGSyncing {
         guard dependencies.syncFeatureFlags.canWriteUnifiedDeviceList(),
               let currentAccount = try? dependencies.secureStore.account(),
               currentAccount.userId == account.userId,
-              currentAccount.deviceId == account.deviceId,
-              deviceInfoMigrationTask == nil,
-              currentDeviceInfoRepairTask == nil,
-              !isDeviceRenameInProgress,
-              !hasAttemptedCurrentDeviceInfoRepair else {
+              currentAccount.deviceId == account.deviceId else {
             return
         }
-        Logger.sync.debug("Sync-UnifiedDevices: scheduling current device_info repair")
         let deviceInfoMigrationCoordinator = deviceInfoMigrationCoordinator
-        let taskID = UUID()
-        currentDeviceInfoRepairTaskID = taskID
-        // A failed best-effort repair retries on a later app launch, not on every device-list poll.
-        hasAttemptedCurrentDeviceInfoRepair = true
-        let task = Task {
+        deviceInfoUpdateState.scheduleRepair {
+            Logger.sync.debug("Sync-UnifiedDevices: scheduling current device_info repair")
             await deviceInfoMigrationCoordinator.repairCurrentDeviceInfo(for: currentAccount)
         }
-        currentDeviceInfoRepairTask = task
-        Task { [weak self] in
-            await task.value
-            self?.clearCompletedCurrentDeviceInfoRepairTask(withID: taskID)
-        }
-    }
-
-    private func clearCompletedDeviceInfoMigrationTask(withID taskID: UUID) {
-        guard deviceInfoMigrationTaskID == taskID else {
-            return
-        }
-        deviceInfoMigrationTask = nil
-        deviceInfoMigrationTaskID = nil
-    }
-
-    private func clearCompletedCurrentDeviceInfoRepairTask(withID taskID: UUID) {
-        guard currentDeviceInfoRepairTaskID == taskID else {
-            return
-        }
-        currentDeviceInfoRepairTask = nil
-        currentDeviceInfoRepairTaskID = nil
-    }
-
-    private func cancelDeviceInfoUpdatesAndWait() async {
-        let deviceInfoMigrationTask = deviceInfoMigrationTask
-        let currentDeviceInfoRepairTask = currentDeviceInfoRepairTask
-        deviceInfoMigrationTask?.cancel()
-        currentDeviceInfoRepairTask?.cancel()
-        await deviceInfoMigrationTask?.value
-        await currentDeviceInfoRepairTask?.value
-        self.deviceInfoMigrationTask = nil
-        deviceInfoMigrationTaskID = nil
-        self.currentDeviceInfoRepairTask = nil
-        currentDeviceInfoRepairTaskID = nil
-        hasAttemptedCurrentDeviceInfoRepair = false
     }
 
     private func persistRecoveredThirdPartyScopedPasswordIfAvailable(from accessCredentials: [AccessCredential]?, account: SyncAccount) {
@@ -904,13 +824,7 @@ public class DDGSync: DDGSyncing {
 
     private func removeAccount(reason: SyncError.AccountRemovedReason) throws {
         let account = try? dependencies.secureStore.account()
-        deviceInfoMigrationTask?.cancel()
-        deviceInfoMigrationTask = nil
-        deviceInfoMigrationTaskID = nil
-        currentDeviceInfoRepairTask?.cancel()
-        currentDeviceInfoRepairTask = nil
-        currentDeviceInfoRepairTaskID = nil
-        hasAttemptedCurrentDeviceInfoRepair = false
+        deviceInfoUpdateState.cancelAll()
         dependencies.scheduler.isEnabled = false
         startSyncCancellable?.cancel()
         syncQueueCancellable?.cancel()
@@ -976,10 +890,111 @@ public class DDGSync: DDGSyncing {
     private var syncQueueCancellable: AnyCancellable?
     private var syncDidFinishCancellable: AnyCancellable?
     private var syncQueueRequestErrorCancellable: AnyCancellable?
-    private var deviceInfoMigrationTask: Task<Void, Never>?
-    private var deviceInfoMigrationTaskID: UUID?
-    private var currentDeviceInfoRepairTask: Task<Void, Never>?
-    private var currentDeviceInfoRepairTaskID: UUID?
-    private var isDeviceRenameInProgress = false
-    private var hasAttemptedCurrentDeviceInfoRepair = false
+    private let deviceInfoUpdateState = DeviceInfoUpdateState()
+}
+
+private final class DeviceInfoUpdateState {
+
+    // Completion can overlap with rename or account removal, so task handles are read and replaced under one lock.
+    private struct TrackedTask {
+        let id: UUID
+        let task: Task<Void, Never>
+    }
+
+    private let lock = NSLock()
+    private var migrationTask: TrackedTask?
+    private var repairTask: TrackedTask?
+    private var isRenameInProgress = false
+    private var hasAttemptedRepair = false
+
+    var isMigrationRunning: Bool {
+        lock.withLock { migrationTask != nil }
+    }
+
+    func setRenameInProgress(_ isInProgress: Bool) {
+        lock.withLock {
+            isRenameInProgress = isInProgress
+        }
+    }
+
+    func scheduleMigration(_ operation: @escaping () async -> Void) {
+        lock.withLock {
+            guard migrationTask == nil else {
+                return
+            }
+
+            let taskID = UUID()
+            migrationTask = TrackedTask(id: taskID, task: Task { [weak self] in
+                await operation()
+                self?.clearMigrationTask(withID: taskID)
+            })
+        }
+    }
+
+    func scheduleRepair(_ operation: @escaping () async -> Void) {
+        lock.withLock {
+            guard migrationTask == nil,
+                  repairTask == nil,
+                  !isRenameInProgress,
+                  !hasAttemptedRepair else {
+                return
+            }
+
+            // A failed best-effort repair retries on a later app launch, not on every device-list poll.
+            hasAttemptedRepair = true
+            let taskID = UUID()
+            repairTask = TrackedTask(id: taskID, task: Task { [weak self] in
+                await operation()
+                self?.clearRepairTask(withID: taskID)
+            })
+        }
+    }
+
+    func cancelAll() {
+        let tasks = lock.withLock { () -> (migration: TrackedTask?, repair: TrackedTask?) in
+            let tasks = (migration: migrationTask, repair: repairTask)
+            migrationTask = nil
+            repairTask = nil
+            hasAttemptedRepair = false
+            return tasks
+        }
+        tasks.migration?.task.cancel()
+        tasks.repair?.task.cancel()
+    }
+
+    func cancelAllAndWait() async {
+        let tasks = lock.withLock { (migration: migrationTask, repair: repairTask) }
+        tasks.migration?.task.cancel()
+        tasks.repair?.task.cancel()
+        await tasks.migration?.task.value
+        await tasks.repair?.task.value
+
+        lock.withLock {
+            if migrationTask?.id == tasks.migration?.id {
+                migrationTask = nil
+            }
+            if repairTask?.id == tasks.repair?.id {
+                repairTask = nil
+            }
+            hasAttemptedRepair = false
+        }
+    }
+
+    private func clearMigrationTask(withID taskID: UUID) {
+        lock.withLock {
+            guard migrationTask?.id == taskID else {
+                return
+            }
+            migrationTask = nil
+        }
+    }
+
+    private func clearRepairTask(withID taskID: UUID) {
+        lock.withLock {
+            guard repairTask?.id == taskID else {
+                return
+            }
+            repairTask = nil
+        }
+    }
 }

--- a/SharedPackages/BrowserServicesKit/Sources/DDGSync/DDGSyncing.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/DDGSync/DDGSyncing.swift
@@ -292,7 +292,6 @@ public protocol DDGSyncingDebuggingSupport {
     /// Fetches devices through the production mapping path and includes the source used for each displayed device.
     func fetchDevicesForDebug() async throws -> [RegisteredDeviceDebugInfo]
     func isDeviceInfoMigrationCompleteForDebug() throws -> Bool
-    func runDeviceInfoMigrationForDebug() async throws
     func resetDeviceInfoMigrationForDebug()
 }
 
@@ -310,10 +309,6 @@ public extension DDGSyncingDebuggingSupport {
     }
 
     func isDeviceInfoMigrationCompleteForDebug() throws -> Bool {
-        throw SyncError.accountNotFound
-    }
-
-    func runDeviceInfoMigrationForDebug() async throws {
         throw SyncError.accountNotFound
     }
 

--- a/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/DDGSyncTests.swift
+++ b/SharedPackages/BrowserServicesKit/Tests/DDGSyncTests/DDGSyncTests.swift
@@ -665,19 +665,6 @@ final class DDGSyncTests: XCTestCase {
         XCTAssertEqual(migrationCall.account.deviceId, SyncAccount.mock.deviceId)
     }
 
-    func testWhenDebugMigrationIsResetThenItCanRunAgain() async throws {
-        let migrationCoordinator = DeviceInfoMigrationCoordinatingMock()
-        dependencies.createDeviceInfoMigrationCoordinatorStub = migrationCoordinator
-        let syncService = DDGSync(dataProvidersSource: dataProvidersSource, dependencies: dependencies)
-
-        try await syncService.runDeviceInfoMigrationForDebug()
-        syncService.resetDeviceInfoMigrationForDebug()
-        try await syncService.runDeviceInfoMigrationForDebug()
-
-        XCTAssertEqual(migrationCoordinator.calls.count, 2)
-        XCTAssertEqual(migrationCoordinator.resetCallCount, 1)
-    }
-
     func testWhenUnifiedReadObservationsAreReturnedThenTheyFireWithoutRequiringWriteFlag() async throws {
         dependencies.canReadUnifiedDeviceList = { true }
         dependencies.canWriteUnifiedDeviceList = { false }

--- a/iOS/DuckDuckGo/SyncDebugViewController.swift
+++ b/iOS/DuckDuckGo/SyncDebugViewController.swift
@@ -66,7 +66,6 @@ class SyncDebugViewController: UITableViewController {
     enum TestActionRows: Int, CaseIterable {
 
         case ensureAccountInfoKey
-        case runMigration
         case resetMigrationMarker
 
     }
@@ -190,8 +189,6 @@ class SyncDebugViewController: UITableViewController {
             switch TestActionRows(rawValue: indexPath.row) {
             case .ensureAccountInfoKey:
                 cell.textLabel?.text = "Ensure/repair account_info key"
-            case .runMigration:
-                cell.textLabel?.text = "Run device_info migration"
             case .resetMigrationMarker:
                 cell.textLabel?.text = "Reset migration marker"
             case .none:
@@ -311,8 +308,6 @@ class SyncDebugViewController: UITableViewController {
             switch TestActionRows(rawValue: indexPath.row) {
             case .ensureAccountInfoKey:
                 ensureAccountInfoKey()
-            case .runMigration:
-                runDeviceInfoMigration()
             case .resetMigrationMarker:
                 confirmResetMigrationMarker()
             case .none:
@@ -442,27 +437,10 @@ class SyncDebugViewController: UITableViewController {
         reloadUnifiedDevicesSection()
     }
 
-    private func runDeviceInfoMigration() {
-        Task { @MainActor [weak self] in
-            guard let self else { return }
-
-            do {
-                try await sync.runDeviceInfoMigrationForDebug()
-                refreshMigrationStatus()
-                let isComplete = try sync.isDeviceInfoMigrationCompleteForDebug()
-                let message = isComplete ? "Migration is complete." : "Migration did not complete. Check the Sync logs for details."
-                showAlert(title: "Device Info Migration", message: message)
-                refreshDevicesForDebug()
-            } catch {
-                showAlert(title: "Unable to Run Migration", message: String(reflecting: error))
-            }
-        }
-    }
-
     private func confirmResetMigrationMarker() {
         let alertController = UIAlertController(
             title: "Reset Migration Marker?",
-            message: "The next migration run will attempt to write device_info again.",
+            message: "Relaunch the app to attempt the device_info migration again.",
             preferredStyle: .alert)
         alertController.addAction(UIAlertAction(title: "Cancel", style: .cancel))
         alertController.addAction(UIAlertAction(title: "Reset", style: .destructive) { [weak self] _ in


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ External contributors: file an issue before opening a PR.
-->

Task/Issue URL:
Tech Design URL:
CC:

### Description
<!-- What changed and why, in plain English. No class names, method names, or implementation details — the diff shows those. Keep it brief. -->

### Testing Steps
<!-- One action per step. Note expected outcome inline where relevant, e.g. "3. Tap Save → settings screen dismisses". Assume the reviewer is unfamiliar with this part of the app. -->
1.
2.

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
2. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
3. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->

#### What could go wrong?
<!-- Before submitting: identify realistic failure scenarios and check a mitigation exists in this diff (test, flag, guard). Only keep this section if the risk is non-obvious to a reviewer. Otherwise delete it. One line per scenario: "X could happen → mitigated by Y." -->

### Quality Considerations
<!-- Edge cases, performance, privacy/security impact — omit if not applicable -->

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes concurrency around sync device_info migration, repair, and rename cancellation; behavior should match prior rules but races were the motivation for the lock-based refactor.
> 
> **Overview**
> Refactors **unified `device_info` migration and repair** task handling in `DDGSync` into a new **`DeviceInfoUpdateState`** helper that tracks migration/repair `Task`s, rename-in-progress, and one-shot repair attempts under an **`NSLock`**, replacing several ad-hoc properties and duplicate cancel/clear helpers. Account removal and device rename now call **`cancelAll()`** / **`cancelAllAndWait()`** on that coordinator; scheduling and eligibility checks (e.g. skip repair while migration runs or during rename) live in one place.
> 
> **Removes** the debug-only **`runDeviceInfoMigrationForDebug`** API and the iOS Sync debug **“Run device_info migration”** action; reset migration marker copy now tells users to **relaunch the app** to retry migration. Drops the associated unit test that depended on the removed API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b24704568e3f9d25d89dd082b8eea0103c568982. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->