### PR TITLE
iOS: Fire address-bar cancel pixel from the UTI dismiss path

### DIFF
--- a/iOS/DuckDuckGo/MainViewController.swift
+++ b/iOS/DuckDuckGo/MainViewController.swift
@@ -6172,6 +6172,13 @@ extension MainViewController: OmniBarDelegate {
                                  aiChat: .addressBarClearPressedOnAIChat)
     }
 
+    func onExperimentalAddressBarCancelPressed() {
+        fireControllerAwarePixel(ntp: .addressBarCancelPressedOnNTP,
+                                 serp: .addressBarCancelPressedOnSERP,
+                                 website: .addressBarCancelPressedOnWebsite,
+                                 aiChat: .addressBarCancelPressedOnAIChat)
+    }
+
     func escapeHatchForEditingState() -> EscapeHatchModel? {
         guard idleReturnEligibilityManager.isEligibleForNTPAfterIdle(),
               tabManager.currentTabsModel.currentTab?.link == nil,

--- a/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
+++ b/iOS/DuckDuckGo/UnifiedToggleInput/MainViewController+UnifiedToggleInput.swift
@@ -1007,6 +1007,7 @@ extension MainViewController {
         contentVC.onDismissRequested = { [weak self] in
             guard let self, let coordinator = self.unifiedToggleInputCoordinator else { return }
             if coordinator.isOmnibarSession {
+                self.onExperimentalAddressBarCancelPressed()
                 if let tab = self.tabManager.currentTabsModel.currentTab, tab.link == nil {
                     self.ntpAfterIdleInstrumentation.backButtonUsedFromNTP(afterIdle: tab.openedAfterIdle)
                 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1218389347478844

### Description

`m_addressbar_cancel_aichat` (and its ntp/serp/website siblings) dropped on iPhone in 7.236. Investigated: not an accidental deletion — the unified toggle input never fired this pixel, and 7.236 removed the last non-UTI iPhone paths that did (UTI rollout flags removed in #6419, the experimental editing state removed in #6444).

The gap is that the sibling legs of the same funnel *are* wired into UTI — `onExperimentalAddressBarTapped` for click, `onExperimentalAddressBarClearPressed` for clear — but cancel was not, so on iPhone we could measure address-bar clicks and clears but not cancels. This restores the missing leg, keeping the content-type split (ntp/serp/website/aichat) that `m_aichat_experimental_omnibar_back_button_pressed` doesn't provide (it splits by toggle mode).

### Testing Steps

1. On iPhone, open a new tab and tap the address bar → unified input opens.
2. Tap the back/dismiss arrow → `m_addressbar_cancel_ntp` fires.
3. Run a search, tap the address bar, dismiss → `m_addressbar_cancel_serp` fires.
4. Open a website, tap the address bar, dismiss → `m_addressbar_cancel_website` fires.
5. On a Duck.ai tab, expand the input and dismiss → no `m_addressbar_cancel_*` (not an omnibar session), `m_aichat_experimental_omnibar_back_button_pressed` still fires.
6. On iPad, dismiss the omnibar from a search → unchanged, still fires via `onCancelPressed()`.

### Impact

Low: adds a pixel fire to an existing dismiss path; no behaviour change.

#### What could go wrong?

`.ios.phone` volume for this pixel partially recovers, which could read as a new anomaly next cycle → flagged to the pixel owner in the task.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only addition on an existing dismiss path; no user-facing behavior change, though cancel pixel volume on `.ios.phone` may tick up versus recent releases.
> 
> **Overview**
> Restores **address-bar cancel analytics** on iPhone when users dismiss the unified toggle input (UTI) omnibar via the back arrow—matching how tap and clear pixels were already wired.
> 
> Adds `onExperimentalAddressBarCancelPressed()` in `MainViewController`, which fires the existing `m_addressbar_cancel_*` pixels with the same NTP/SERP/website/AI chat split as `onExperimentalAddressBarClearPressed()`. The UTI `onDismissRequested` handler calls it only when `coordinator.isOmnibarSession`, so Duck.ai expanded-input dismiss still does not emit these events (iPad continues to use `onCancelPressed()`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2049dc2904fa94da91d1f45f01a246ab0141f2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->