### PR TITLE
[macOS] Remove promoQueue feature flag

### DIFF
--- a/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
+++ b/SharedPackages/BrowserServicesKit/Sources/PrivacyConfig/Features/PrivacyFeature.swift
@@ -846,8 +846,6 @@ public enum DuckAiChatHistorySubfeature: String, PrivacySubfeature {
 public enum PromoQueueSubfeature: String, PrivacySubfeature {
     public var parent: PrivacyFeature { .promoQueue }
 
-    case featureEnabled
-
     /// Kill switch for the Bookmark Toolbar ("Show Bookmarks Bar?") promo.
     case bookmarkToolbarPromo
 

--- a/macOS/DuckDuckGo/Application/AppDelegate.swift
+++ b/macOS/DuckDuckGo/Application/AppDelegate.swift
@@ -1492,39 +1492,37 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         let urlEventHandlerResult = urlEventHandler.applicationDidFinishLaunching()
 
-        if featureFlagger.isFeatureOn(.promoQueue) {
-            let subscriptionPromoDelegate = FireWindowSubscriptionPromoDelegate()
-            self.subscriptionPromoDelegate = subscriptionPromoDelegate
-            let activeDomainPublisher = ActiveDomainPublisher(windowControllersManager: windowControllersManager)
-            let dependencies = PromoDependencies(
-                keyValueStore: keyValueStore,
-                isExternallyActivated: urlEventHandlerResult.willOpenWindows,
-                isNewUserProvider: { AppDelegate.isNewUser },
-                isOnboardingCompletedProvider: { [featureFlagger, onboardingContextualDialogsManager] in
-                    NonBlockingOnboarding(featureFlagger: featureFlagger).isNonBlocking
-                        ? onboardingContextualDialogsManager.state == .onboardingCompleted && !activeDomainPublisher.isActiveTabOnboarding
-                        : OnboardingActionsManager.isOnboardingFinished
-                },
-                activeRemoteMessageModel: activeRemoteMessageModel,
-                defaultBrowserAndDockPromptService: defaultBrowserAndDockPromptService,
-                sessionRestoreCoordinator: sessionRestorePromptCoordinator,
-                subscriptionPromoDelegate: subscriptionPromoDelegate,
-                featureFlagger: featureFlagger,
-                cookiePopupProtectionPreferences: cookiePopupProtectionPreferences,
-                windowControllersManager: windowControllersManager,
-                syncService: syncService,
-                syncBookmarksAdapter: syncDataProviders?.bookmarksAdapter,
-                pinningManager: pinningManager,
-                cookiePopupsBlockedPromoDelegate: cookiePopupsBlockedPromoDelegate,
-                duckPlayerOverlayObserver: duckPlayerOverlayObserver,
-                updateController: updateController,
-                updateNotificationBridge: updateNotificationPromoBridge,
-                brokenSitePromptPresentationCoordinator: brokenSitePromptPresentationCoordinator,
-                quitSurveyPromoObserver: quitSurveyPromoObserver
-            )
-            promoService = PromoServiceFactory.makePromoService(dependencies: dependencies)
-            NotificationCenter.default.post(name: .promoServiceAppLaunched, object: nil)
-        }
+        let subscriptionPromoDelegate = FireWindowSubscriptionPromoDelegate()
+        self.subscriptionPromoDelegate = subscriptionPromoDelegate
+        let activeDomainPublisher = ActiveDomainPublisher(windowControllersManager: windowControllersManager)
+        let dependencies = PromoDependencies(
+            keyValueStore: keyValueStore,
+            isExternallyActivated: urlEventHandlerResult.willOpenWindows,
+            isNewUserProvider: { AppDelegate.isNewUser },
+            isOnboardingCompletedProvider: { [featureFlagger, onboardingContextualDialogsManager] in
+                NonBlockingOnboarding(featureFlagger: featureFlagger).isNonBlocking
+                ? onboardingContextualDialogsManager.state == .onboardingCompleted && !activeDomainPublisher.isActiveTabOnboarding
+                : OnboardingActionsManager.isOnboardingFinished
+            },
+            activeRemoteMessageModel: activeRemoteMessageModel,
+            defaultBrowserAndDockPromptService: defaultBrowserAndDockPromptService,
+            sessionRestoreCoordinator: sessionRestorePromptCoordinator,
+            subscriptionPromoDelegate: subscriptionPromoDelegate,
+            featureFlagger: featureFlagger,
+            cookiePopupProtectionPreferences: cookiePopupProtectionPreferences,
+            windowControllersManager: windowControllersManager,
+            syncService: syncService,
+            syncBookmarksAdapter: syncDataProviders?.bookmarksAdapter,
+            pinningManager: pinningManager,
+            cookiePopupsBlockedPromoDelegate: cookiePopupsBlockedPromoDelegate,
+            duckPlayerOverlayObserver: duckPlayerOverlayObserver,
+            updateController: updateController,
+            updateNotificationBridge: updateNotificationPromoBridge,
+            brokenSitePromptPresentationCoordinator: brokenSitePromptPresentationCoordinator,
+            quitSurveyPromoObserver: quitSurveyPromoObserver
+        )
+        promoService = PromoServiceFactory.makePromoService(dependencies: dependencies)
+        NotificationCenter.default.post(name: .promoServiceAppLaunched, object: nil)
 
         setUpAutoClearHandler()
         bitwardenManager?.initCommunication()

--- a/macOS/DuckDuckGo/DefaultBrowserAndAddToDockPrompts/DefaultBrowserAndDockPromptCoordinator.swift
+++ b/macOS/DuckDuckGo/DefaultBrowserAndAddToDockPrompts/DefaultBrowserAndDockPromptCoordinator.swift
@@ -265,7 +265,7 @@ final class DefaultBrowserAndDockPromptCoordinator: DefaultBrowserAndDockPrompt 
 
     /// **MAIN DECISION POINT - Determines WHICH prompt to show and WHEN**
     ///
-    /// Called by `DefaultBrowserAndDockPromptPresenter.tryToShowPrompt()` every time a window becomes key.
+    /// Called by `DefaultBrowserAndDockPromptPresenter.tryToShowPrompt()` when the Promo Queue admits one of the `default-browser-and-dock-*` promos.
     /// Returns the type of prompt to display, or nil if no prompt should be shown.
     ///
     /// **Evaluation Order:**

--- a/macOS/DuckDuckGo/DefaultBrowserAndAddToDockPrompts/DefaultBrowserAndDockPromptCoordinator.swift
+++ b/macOS/DuckDuckGo/DefaultBrowserAndAddToDockPrompts/DefaultBrowserAndDockPromptCoordinator.swift
@@ -24,9 +24,9 @@
 //
 // **FLOW DIAGRAM:**
 //
-//   Window becomes key
+//   Promo Queue selects a default-browser-and-dock-* promo
 //         ↓
-//   MainViewController.showSetAsDefaultAndAddToDockIfNeeded()
+//   DefaultBrowserAndDockPromoDelegate.show(history:force:)
 //         ↓
 //   DefaultBrowserAndDockPromptPresenter.tryToShowPrompt()
 //         ↓

--- a/macOS/DuckDuckGo/DefaultBrowserAndAddToDockPrompts/DefaultBrowserAndDockPromptPresenting.swift
+++ b/macOS/DuckDuckGo/DefaultBrowserAndAddToDockPrompts/DefaultBrowserAndDockPromptPresenting.swift
@@ -57,19 +57,6 @@ protocol DefaultBrowserAndDockPromptPresenting {
                          onNoShow: (() -> Void)?)
 }
 
-extension DefaultBrowserAndDockPromptPresenting {
-    func tryToShowPrompt(popoverAnchorProvider: @escaping () -> NSView?,
-                         bannerViewHandler: @escaping (BannerMessageViewController) -> Void,
-                         inactiveUserModalWindowProvider: @escaping () -> NSWindow?) {
-        tryToShowPrompt(popoverAnchorProvider: popoverAnchorProvider,
-                        bannerViewHandler: bannerViewHandler,
-                        inactiveUserModalWindowProvider: inactiveUserModalWindowProvider,
-                        expectedType: nil,
-                        forceShow: false,
-                        onNoShow: nil)
-    }
-}
-
 enum DefaultBrowserAndDockPromptPresentationType: Equatable {
     case active(ActiveUserPrompt)
     case inactive
@@ -121,7 +108,8 @@ final class DefaultBrowserAndDockPromptPresenter: DefaultBrowserAndDockPromptPre
 
     /// **PROMPT ORCHESTRATOR**
     ///
-    /// Called from `MainViewController.showSetAsDefaultAndAddToDockIfNeeded()` when a window becomes key.
+    /// Called from `DefaultBrowserAndDockPromoDelegate.show(history:force:)` when the Promo Queue
+    /// selects one of the `default-browser-and-dock-*` promos.
     /// This is the main entry point for displaying any type of default browser/dock prompt.
     ///
     /// **Decision Flow:**

--- a/macOS/DuckDuckGo/HomePage/View/VPNSubscriptionPromo/SubscriptionPromoViewModel.swift
+++ b/macOS/DuckDuckGo/HomePage/View/VPNSubscriptionPromo/SubscriptionPromoViewModel.swift
@@ -186,7 +186,7 @@ final class SubscriptionPromoViewModel: ObservableObject {
     /// - en_US locale only
     /// - Non-subscriber only
     /// - Fire Tab visited >= 3 times
-    /// - Not dismissed or CTA actioned within the 28-day cooldown (fallback when PromoQueue is off; PromoService handles this via `resultWhenHidden` when on)
+    /// - Not dismissed or CTA actioned within the 28-day cooldown (enforced here for external promos; `PromoService` handles queue-driven promos via `resultWhenHidden`)
     /// - Not shown more than 4 times in any given 28-day rolling window
     private func evaluatePromoVisibility() {
         var shouldShow = false

--- a/macOS/DuckDuckGo/MainWindow/MainViewController.swift
+++ b/macOS/DuckDuckGo/MainWindow/MainViewController.swift
@@ -452,9 +452,6 @@ final class MainViewController: NSViewController {
         updateReloadMenuItem()
         updateStopMenuItem()
         browserTabViewController.windowDidBecomeKey()
-        if !featureFlagger.isFeatureOn(.promoQueue) {
-            showSetAsDefaultAndAddToDockIfNeeded()
-        }
         showWinBackOfferIfNeeded()
     }
 
@@ -968,34 +965,6 @@ final class MainViewController: NSViewController {
             .sink { [weak self] in
                 self?.hideBanner()
             }
-    }
-
-    /// **ENTRY POINT for Default Browser & Dock Prompts**
-    ///
-    /// This is called when a main window becomes key (see `windowDidBecomeKey()`).
-    /// It triggers the prompt system to evaluate if any prompt should be shown.
-    ///
-    /// **Flow:**
-    /// 1. Calls `DefaultBrowserAndDockPromptPresenter.tryToShowPrompt()`
-    /// 2. Presenter asks `DefaultBrowserAndDockPromptCoordinator.getPromptType()` to determine eligibility
-    /// 3. Coordinator checks: onboarding status, default browser/dock status, and timing rules
-    /// 4. If eligible, shows one of three prompt types:
-    ///    - **Popover**: Small popup anchored to address bar (first prompt, shown once)
-    ///    - **Banner**: Persistent bar at top of window (shown after popover, can repeat)
-    ///    - **Inactive User Modal**: Sheet for users who haven't used the app in 7+ days
-    ///
-    /// **See also:**
-    /// - `DefaultBrowserAndDockPromptPresenter.tryToShowPrompt()` - orchestrates prompt display
-    /// - `DefaultBrowserAndDockPromptCoordinator.getPromptType()` - determines which prompt to show
-    /// - `DefaultBrowserAndDockPromptTypeDecider` - implements timing logic
-    @objc private func showSetAsDefaultAndAddToDockIfNeeded() {
-        guard !isInPopUpWindow else { return }
-
-        defaultBrowserAndDockPromptPresenting.tryToShowPrompt(
-            popoverAnchorProvider: getSourceViewToShowSetAsDefaultAndAddToDockPopover,
-            bannerViewHandler: showMessageBanner,
-            inactiveUserModalWindowProvider: getSourceWindowToShowInactiveUserModal
-        )
     }
 
     func getSourceViewToShowSetAsDefaultAndAddToDockPopover() -> NSView? {

--- a/macOS/LocalPackages/FeatureFlags-macOS/Sources/FeatureFlags/FeatureFlag.swift
+++ b/macOS/LocalPackages/FeatureFlags-macOS/Sources/FeatureFlags/FeatureFlag.swift
@@ -413,10 +413,6 @@ public enum FeatureFlag: String, CaseIterable {
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1213734484627619
     case autoplayPolicy
 
-    /// Enables the promo service to coordinate promos/calls to action
-    /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1213431687119179?focus=true
-    case promoQueue
-
     /// Enables the Bookmark Toolbar ("Show Bookmarks Bar?") promo in the promo queue.
     /// https://app.asana.com/1/137249556945/project/1211834678943996/task/1218028792667616?focus=true
     case promoQueueBookmarkToolbarPromo
@@ -831,8 +827,6 @@ extension FeatureFlag: FeatureFlagDescribing {
             Config(defaultValue: .enabled, source: .remoteReleasable(AIChatSubfeature.chromeMenuButton), category: .duckAI)
         case .webViewLookUpAction:
             Config(defaultValue: .enabled, source: .remoteReleasable(MacOSBrowserConfigSubfeature.webViewLookUpAction))
-        case .promoQueue:
-            Config(defaultValue: .enabled, source: .remoteReleasable(PromoQueueSubfeature.featureEnabled))
         case .promoQueueBookmarkToolbarPromo:
             Config(defaultValue: .enabled, source: .remoteReleasable(PromoQueueSubfeature.bookmarkToolbarPromo))
         case .promoQueueSyncFaviconsPromo:

--- a/macOS/UITests/PromoQueueUITests.swift
+++ b/macOS/UITests/PromoQueueUITests.swift
@@ -23,7 +23,7 @@ final class PromoQueueUITests: UITestCase {
 
     override func setUpWithError() throws {
         try super.setUpWithError()
-        app = XCUIApplication.setUp(featureFlags: ["promoQueue": true])
+        app = XCUIApplication.setUp()
         app.enforceSingleWindow()
         app.resetPromoState()
         app.dismissExternalPromos()

--- a/macOS/UnitTests/HomePage/SubscriptionPromoViewModelTests.swift
+++ b/macOS/UnitTests/HomePage/SubscriptionPromoViewModelTests.swift
@@ -91,7 +91,7 @@ final class SubscriptionPromoViewModelTests: XCTestCase {
         XCTAssertFalse(sut.shouldShowPromo)
     }
 
-    // MARK: - Dismiss Cooldown (fallback when PromoQueue is off)
+    // MARK: - Dismiss Cooldown (enforced by the view model for external promos)
 
     func testWhenDismissedWithinCooldown_ThenDoesNotShowPromo() {
         persistor.fireTabVisitCount = 3


### PR DESCRIPTION
<!--
Note: This template is a reminder of our Engineering Expectations and Definition of Done. Remove sections that don't apply to your changes.

⚠️ External contributors: file an issue before opening a PR.
-->

Task/Issue URL: https://app.asana.com/1/137249556945/project/1211834678943996/task/1213431687119179?focus=true

### Description

Removes the `promoQueue` feature flag to make the Promo Queue permanent. Recently migrated promos still have individual feature flags in case of promo-specific concerns.

Also removes legacy (fallback) behavior for the SAD/ATT prompts that was only used if that feature flag was disabled.

### Testing Steps
<!-- One action per step. Note expected outcome inline where relevant, e.g. "3. Tap Save → settings screen dismisses". Assume the reviewer is unfamiliar with this part of the app. -->
1. Check that the app is not set as default or added to the dock.
2. Debug → SAD/ATT Prompts → Simulate Fresh App Install
3. Debug → New Tab Page → Reset Next Steps
4. Debug → Promo Queue → Reset All Promo State
5. Open a new tab page and confirm the Next Steps cards appear.
6. Debug → SAD/ATT Prompts → Advance by 14 days
7. Bring another app to the foreground.
8. Bring DuckDuckGo to the foreground and confirm **no** "Set as Default/Add to Dock" promo appears. (Can't coexist with Next Steps cards.)
9. Dismiss all of the visible Next Steps cards.
10. Bring another app to the foreground.
11. Bring DuckDuckGo to the foreground and confirm **no** "Set as Default/Add to Dock" promo appears. (Global cooldown is applied to app-initiated promos.)
12. Debug → Promo Queue → Advance Simulated Date by 1 Day
13. Bring another app to the foreground.
14. Bring DuckDuckGo to the foreground and confirm the "Set as Default/Add to Dock" popover appears.

<!-- 
### Testability Challenges
If you encountered issues writing tests due to any class in the codebase, please report it in the [Testability Challenges Document](https://app.asana.com/1/137249556945/project/1204186595873227/task/1211703869786699)

1. **Check the Document:** First, check the **Testability Challenges Table** to see if the class you encountered is listed.
15. **If the Class Exists:**
   - Update the **Encounter Count** by increasing it by 1.
16. **If the Class Does Not Exist:**
   - Add a new entry
-->

### Impact
<!-- 
What's the impact on users if something goes wrong?

High: Could affect user privacy, lose user data, break core functionality
Medium: Could disrupt specific features or user flows
Low: Minor visual changes, small bug fixes, improvement to existing features
None: Internal tooling, documentation
-->
Low: Removes already enabled feature flag and fallbacks.

Could disrupt promos if code was removed that is still needed by the promo queue. Mitigated by testing the promo queue behavior and SAD/ATT promos (only promos that still had a fallback for the queue being disabled).

---
###### Internal references:
[Definition of Done](https://app.asana.com/0/1202500774821704/1207634633537039/f) | [Engineering Expectations](https://app.asana.com/0/59792373528535/199064865822552) | [Tech Design Template](https://app.asana.com/0/59792373528535/184709971311943)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Promos and SAD/ATT timing now depend entirely on PromoService; regressions could change which prompts appear or when, though per-promo remote kill switches remain.
> 
> **Overview**
> Makes the **Promo Queue** always on by removing the master `promoQueue` feature flag and its privacy-config `featureEnabled` subfeature. **`PromoService` is now created on every launch** in `AppDelegate` (no gating), and UI tests no longer override `promoQueue: true`.
> 
> **Default browser / add-to-dock** prompts no longer run from `MainViewController.windowDidBecomeKey`; they are **only** shown when the promo queue admits a `default-browser-and-dock-*` promo via `DefaultBrowserAndDockPromoDelegate`. The convenience `tryToShowPrompt` overload without `expectedType` / `forceShow` / `onNoShow` was removed so callers must use the full API.
> 
> Per-promo kill switches (`promoQueueBookmarkToolbarPromo`, etc.) are unchanged. Comments in subscription promo code clarify cooldown handling for external vs queue-driven promos.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 376d2569c423949f5895da9bd055e9039f9b556a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->